### PR TITLE
doc: add README with project introduction and glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# kortex-cli
+
+## Introduction
+
+kortex-cli is a command-line interface for launching and managing AI agents with custom configurations. It provides a unified way to start different agents with specific settings including skills, MCP (Model Context Protocol) server connections, and LLM integrations.
+
+### Supported Agents
+
+- **Claude Code** - Anthropic's official CLI for Claude
+- **Goose** - AI agent for development tasks
+- **Cursor** - AI-powered code editor agent
+
+### Key Features
+
+- Configure agents with custom skills and capabilities
+- Connect to MCP servers for extended functionality
+- Integrate with various LLM providers
+- Consistent interface across different agent types
+
+## Glossary
+
+### Agent
+An AI assistant that can perform tasks autonomously. In kortex-cli, agents are the different AI tools (Claude Code, Goose, Cursor) that can be launched and configured.
+
+### LLM (Large Language Model)
+The underlying AI model that powers the agents. Examples include Claude (by Anthropic), GPT (by OpenAI), and other language models.
+
+### MCP (Model Context Protocol)
+A standardized protocol for connecting AI agents to external data sources and tools. MCP servers provide agents with additional capabilities like database access, API integrations, or file system operations.
+
+### Skills
+Pre-configured capabilities or specialized functions that can be enabled for an agent. Skills extend what an agent can do, such as code review, testing, or specific domain knowledge.


### PR DESCRIPTION
Created README.md for kortex-cli with:
- Project title and introduction explaining the CLI's purpose
- List of supported agents (Claude Code, Goose, Cursor)
- Key features including skills, MCP servers, and LLM integrations
- Glossary defining important terms (Agent, LLM, MCP, Skills)

(100% generated using Claude Code inside container)