### PR TITLE
fix: make skill discoverable for several agents

### DIFF
--- a/.claude/skills/copyright-headers
+++ b/.claude/skills/copyright-headers
@@ -1,0 +1,1 @@
+../../skills/copyright-headers

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,19 @@
+# Agent Skills
+
+This directory contains reusable skills that can be discovered and executed by any AI agent.
+
+## Structure
+
+Each skill is contained in its own subdirectory with a `SKILL.md` file that defines:
+- The skill name and description
+- Input parameters and argument hints
+- Detailed instructions for execution
+- Usage examples
+
+## Available Skills
+
+- **copyright-headers**: Add or update Apache License 2.0 copyright headers to source files
+
+## Usage
+
+Agents can discover skills by scanning this directory for `SKILL.md` files. Each skill's metadata and instructions are contained in its respective file.

--- a/skills/copyright-headers/SKILL.md
+++ b/skills/copyright-headers/SKILL.md
@@ -2,7 +2,6 @@
 name: copyright-headers
 description: Add or update Apache License 2.0 copyright headers to Go source files, configuration files (YAML, TOML), shell scripts, and Makefiles
 argument-hint: "[files to examine]"
-allowed-tools: yes
 ---
 
 # Copyright Headers


### PR DESCRIPTION
- move skills to the `skills` directory, to make them discoverable in a generic way
- make a symlink to skills, to make them discoverable by Claude Code (which cannot find it in the generic place)
- remove `allowed-tools` tag which was not appropriate

Tested with Cursor and Claude code