### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      # check at 3am UTC
+      time: "03:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot for go modules