### PR TITLE
feat: list with JSON output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/kortex-hub/kortex-cli
 
 go 1.25.7
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260309100818-e0ea254e6f13
+	github.com/spf13/cobra v1.10.2
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260309100818-e0ea254e6f13 h1:JkzrfheDTegKzYzjOfo6K5oEgMmT1+1+oqxTfRghJCw=
+github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260309100818-e0ea254e6f13/go.mod h1:jWKudiw26CIjuOsROQ80FOuuk2m2/5BVkuATpmD5xQQ=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -19,8 +19,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
+	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
 	"github.com/spf13/cobra"
 )
@@ -69,7 +71,12 @@ func (w *workspaceListCmd) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list instances: %w", err)
 	}
 
-	// Display the instances
+	// Handle JSON output format
+	if w.output == "json" {
+		return w.outputJSON(cmd, instancesList)
+	}
+
+	// Display the instances in text format
 	if len(instancesList) == 0 {
 		cmd.Println("No workspaces registered")
 		return nil
@@ -82,6 +89,38 @@ func (w *workspaceListCmd) run(cmd *cobra.Command, args []string) error {
 		cmd.Println()
 	}
 
+	return nil
+}
+
+// outputJSON converts instances to Workspace format and outputs as JSON
+func (w *workspaceListCmd) outputJSON(cmd *cobra.Command, instancesList []instances.Instance) error {
+	// Convert instances to API Workspace format
+	workspaces := make([]api.Workspace, 0, len(instancesList))
+	for _, instance := range instancesList {
+		workspace := api.Workspace{
+			Id:   instance.GetID(),
+			Name: instance.GetName(),
+			Paths: api.WorkspacePaths{
+				Configuration: instance.GetConfigDir(),
+				Source:        instance.GetSourceDir(),
+			},
+		}
+		workspaces = append(workspaces, workspace)
+	}
+
+	// Create WorkspacesList wrapper
+	workspacesList := api.WorkspacesList{
+		Items: workspaces,
+	}
+
+	// Marshal to JSON with indentation
+	jsonData, err := json.MarshalIndent(workspacesList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal workspaces to JSON: %w", err)
+	}
+
+	// Output the JSON to stdout
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
 	return nil
 }
 

--- a/pkg/cmd/workspace_list_test.go
+++ b/pkg/cmd/workspace_list_test.go
@@ -20,10 +20,12 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
 )
 
@@ -309,4 +311,103 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 			t.Errorf("Expected output to contain ID %s, got: %s", addedInstance.GetID(), result)
 		}
 	})
+
+	t.Run("outputs JSON with empty list", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "list", "--storage", storageDir, "-o", "json"})
+
+		var output bytes.Buffer
+		rootCmd.SetOut(&output)
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Parse JSON output
+		var workspacesList api.WorkspacesList
+		err = json.Unmarshal(output.Bytes(), &workspacesList)
+		if err != nil {
+			t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, output.String())
+		}
+
+		// Verify empty items array
+		if workspacesList.Items == nil {
+			t.Error("Expected Items to be non-nil")
+		}
+		if len(workspacesList.Items) != 0 {
+			t.Errorf("Expected 0 items, got %d", len(workspacesList.Items))
+		}
+	})
+
+	t.Run("outputs JSON with single workspace", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		// Create a workspace
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kortex"),
+			Name:      "test-workspace",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		addedInstance, err := manager.Add(instance)
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		// List workspaces with JSON output
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "list", "--storage", storageDir, "-o", "json"})
+
+		var output bytes.Buffer
+		rootCmd.SetOut(&output)
+
+		err = rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Parse JSON output
+		var workspacesList api.WorkspacesList
+		err = json.Unmarshal(output.Bytes(), &workspacesList)
+		if err != nil {
+			t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, output.String())
+		}
+
+		// Verify structure
+		if len(workspacesList.Items) != 1 {
+			t.Fatalf("Expected 1 item, got %d", len(workspacesList.Items))
+		}
+
+		workspace := workspacesList.Items[0]
+
+		// Verify all fields
+		if workspace.Id != addedInstance.GetID() {
+			t.Errorf("Expected ID %s, got %s", addedInstance.GetID(), workspace.Id)
+		}
+		if workspace.Name != addedInstance.GetName() {
+			t.Errorf("Expected Name %s, got %s", addedInstance.GetName(), workspace.Name)
+		}
+		if workspace.Paths.Source != addedInstance.GetSourceDir() {
+			t.Errorf("Expected Source %s, got %s", addedInstance.GetSourceDir(), workspace.Paths.Source)
+		}
+		if workspace.Paths.Configuration != addedInstance.GetConfigDir() {
+			t.Errorf("Expected Configuration %s, got %s", addedInstance.GetConfigDir(), workspace.Paths.Configuration)
+		}
+	})
+
 }


### PR DESCRIPTION
adds JSON output to the `list` command, using the `WorkspacesList` interface defined in https://github.com/kortex-hub/kortex-cli-api v0.1.3