### PR TITLE
feat(cmd): add --runtime flag to init  command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Exit code: `0` (success, but no workspaces registered)
 **Step 2: Register a new workspace**
 
 ```bash
-$ kortex-cli init /path/to/project -o json
+$ kortex-cli init /path/to/project --runtime fake -o json
 ```
 
 ```json
@@ -73,7 +73,7 @@ Exit code: `0` (success)
 **Step 3: Register with verbose output to get full details**
 
 ```bash
-$ kortex-cli init /path/to/another-project -o json -v
+$ kortex-cli init /path/to/another-project --runtime fake -o json -v
 ```
 
 ```json
@@ -164,7 +164,7 @@ All errors are returned in JSON format when using `--output json`, with the erro
 **Error: Non-existent directory**
 
 ```bash
-$ kortex-cli init /tmp/no-exist -o json
+$ kortex-cli init /tmp/no-exist --runtime fake -o json
 ```
 
 ```json
@@ -204,7 +204,7 @@ Exit code: `1` (error)
 #!/bin/bash
 
 # Register a workspace
-output=$(kortex-cli init /path/to/project -o json)
+output=$(kortex-cli init /path/to/project --runtime fake -o json)
 exit_code=$?
 
 if [ $exit_code -eq 0 ]; then
@@ -215,6 +215,82 @@ else
     echo "Error: $error_msg"
     exit 1
 fi
+```
+
+## Environment Variables
+
+kortex-cli supports environment variables for configuring default behavior.
+
+### `KORTEX_CLI_DEFAULT_RUNTIME`
+
+Sets the default runtime to use when registering a workspace with the `init` command.
+
+**Usage:**
+
+```bash
+export KORTEX_CLI_DEFAULT_RUNTIME=fake
+kortex-cli init /path/to/project
+```
+
+**Priority:**
+
+The runtime is determined in the following order (highest to lowest priority):
+
+1. `--runtime` flag (if specified)
+2. `KORTEX_CLI_DEFAULT_RUNTIME` environment variable (if set)
+3. Error if neither is set (runtime is required)
+
+**Example:**
+
+```bash
+# Set the default runtime for the current shell session
+export KORTEX_CLI_DEFAULT_RUNTIME=fake
+
+# Register a workspace using the environment variable
+kortex-cli init /path/to/project
+
+# Override the environment variable with the flag
+kortex-cli init /path/to/another-project --runtime podman
+```
+
+**Notes:**
+
+- The runtime parameter is mandatory when registering workspaces
+- If neither the flag nor the environment variable is set, the `init` command will fail with an error
+- Supported runtime types depend on the available runtime implementations
+- Setting this environment variable is useful for automation scripts or when you consistently use the same runtime
+
+### `KORTEX_CLI_STORAGE`
+
+Sets the default storage directory where kortex-cli stores its data files.
+
+**Usage:**
+
+```bash
+export KORTEX_CLI_STORAGE=/custom/path/to/storage
+kortex-cli init /path/to/project --runtime fake
+```
+
+**Priority:**
+
+The storage directory is determined in the following order (highest to lowest priority):
+
+1. `--storage` flag (if specified)
+2. `KORTEX_CLI_STORAGE` environment variable (if set)
+3. Default: `$HOME/.kortex-cli`
+
+**Example:**
+
+```bash
+# Set a custom storage directory
+export KORTEX_CLI_STORAGE=/var/lib/kortex
+
+# All commands will use this storage directory
+kortex-cli init /path/to/project --runtime fake
+kortex-cli list
+
+# Override the environment variable with the flag
+kortex-cli list --storage /tmp/kortex-storage
 ```
 
 ## Commands
@@ -235,6 +311,7 @@ kortex-cli init [sources-directory] [flags]
 
 #### Flags
 
+- `--runtime, -r <type>` - Runtime to use for the workspace (required if `KORTEX_CLI_DEFAULT_RUNTIME` is not set)
 - `--workspace-configuration <path>` - Directory for workspace configuration files (default: `<sources-directory>/.kortex`)
 - `--name, -n <name>` - Human-readable name for the workspace (default: generated from sources directory)
 - `--verbose, -v` - Show detailed output including all workspace information
@@ -245,28 +322,28 @@ kortex-cli init [sources-directory] [flags]
 
 **Register the current directory:**
 ```bash
-kortex-cli init
+kortex-cli init --runtime fake
 ```
 Output: `a1b2c3d4e5f6...` (workspace ID)
 
 **Register a specific directory:**
 ```bash
-kortex-cli init /path/to/myproject
+kortex-cli init /path/to/myproject --runtime fake
 ```
 
 **Register with a custom name:**
 ```bash
-kortex-cli init /path/to/myproject --name "my-awesome-project"
+kortex-cli init /path/to/myproject --runtime fake --name "my-awesome-project"
 ```
 
 **Register with custom configuration location:**
 ```bash
-kortex-cli init /path/to/myproject --workspace-configuration /path/to/config
+kortex-cli init /path/to/myproject --runtime fake --workspace-configuration /path/to/config
 ```
 
 **View detailed output:**
 ```bash
-kortex-cli init --verbose
+kortex-cli init --runtime fake --verbose
 ```
 Output:
 ```text
@@ -279,7 +356,7 @@ Registered workspace:
 
 **JSON output (default - ID only):**
 ```bash
-kortex-cli init /path/to/myproject --output json
+kortex-cli init /path/to/myproject --runtime fake --output json
 ```
 Output:
 ```json
@@ -290,7 +367,7 @@ Output:
 
 **JSON output with verbose flag (full workspace details):**
 ```bash
-kortex-cli init /path/to/myproject --output json --verbose
+kortex-cli init /path/to/myproject --runtime fake --output json --verbose
 ```
 Output:
 ```json
@@ -306,7 +383,7 @@ Output:
 
 **JSON output with short flags:**
 ```bash
-kortex-cli init -o json -v
+kortex-cli init -r fake -o json -v
 ```
 
 #### Workspace Naming
@@ -317,20 +394,21 @@ kortex-cli init -o json -v
 **Examples:**
 ```bash
 # First workspace in /home/user/project
-kortex-cli init /home/user/project
+kortex-cli init /home/user/project --runtime fake
 # Name: "project"
 
 # Second workspace with the same directory name
-kortex-cli init /home/user/another-location/project --name "project"
+kortex-cli init /home/user/another-location/project --runtime fake --name "project"
 # Name: "project-2"
 
 # Third workspace with the same name
-kortex-cli init /tmp/project --name "project"
+kortex-cli init /tmp/project --runtime fake --name "project"
 # Name: "project-3"
 ```
 
 #### Notes
 
+- **Runtime is required**: You must specify a runtime using either the `--runtime` flag or the `KORTEX_CLI_DEFAULT_RUNTIME` environment variable
 - All directory paths are converted to absolute paths for consistency
 - The workspace ID is a unique identifier generated automatically
 - Workspaces can be listed using the `workspace list` command

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -34,6 +34,7 @@ type initCmd struct {
 	sourcesDir         string
 	workspaceConfigDir string
 	name               string
+	runtime            string
 	absSourcesDir      string
 	absConfigDir       string
 	manager            instances.Manager
@@ -80,6 +81,17 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 	}
 
 	i.manager = manager
+
+	// Determine runtime: flag takes precedence over environment variable
+	if i.runtime == "" {
+		// Check environment variable
+		if envRuntime := os.Getenv("KORTEX_CLI_DEFAULT_RUNTIME"); envRuntime != "" {
+			i.runtime = envRuntime
+		} else {
+			// Neither flag nor environment variable is set
+			return outputErrorIfJSON(cmd, i.output, fmt.Errorf("runtime is required: use --runtime flag or set KORTEX_CLI_DEFAULT_RUNTIME environment variable"))
+		}
+	}
 
 	// Get sources directory (default to current directory)
 	i.sourcesDir = "."
@@ -133,7 +145,7 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the instance to the manager with runtime
-	addedInstance, err := i.manager.Add(cmd.Context(), instance, "fake")
+	addedInstance, err := i.manager.Add(cmd.Context(), instance, i.runtime)
 	if err != nil {
 		return outputErrorIfJSON(cmd, i.output, err)
 	}
@@ -191,16 +203,16 @@ func NewInitCmd() *cobra.Command {
 The sources directory defaults to the current directory (.) if not specified.
 The workspace configuration directory defaults to .kortex/ inside the sources directory if not specified.`,
 		Example: `# Register current directory as workspace
-kortex-cli init
+kortex-cli init --runtime fake
 
 # Register specific directory as workspace
-kortex-cli init /path/to/project
+kortex-cli init --runtime fake /path/to/project
 
 # Register with custom workspace name
-kortex-cli init --name my-project
+kortex-cli init --runtime fake --name my-project
 
 # Show detailed output
-kortex-cli init --verbose`,
+kortex-cli init --runtime fake --verbose`,
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -211,6 +223,9 @@ kortex-cli init --verbose`,
 
 	// Add name flag
 	cmd.Flags().StringVarP(&c.name, "name", "n", "", "Name for the workspace (default: generated from sources directory)")
+
+	// Add runtime flag
+	cmd.Flags().StringVarP(&c.runtime, "runtime", "r", "", "Runtime to use for the workspace (required if KORTEX_CLI_DEFAULT_RUNTIME is not set)")
 
 	// Add verbose flag
 	cmd.Flags().BoolVarP(&c.verbose, "verbose", "v", false, "Show detailed output")

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -38,7 +38,9 @@ func TestInitCmd_PreRun(t *testing.T) {
 
 		tempDir := t.TempDir()
 
-		c := &initCmd{}
+		c := &initCmd{
+			runtime: "fake",
+		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
 		cmd.Flags().String("storage", tempDir, "test storage flag")
@@ -80,7 +82,9 @@ func TestInitCmd_PreRun(t *testing.T) {
 		tempDir := t.TempDir()
 		sourcesDir := t.TempDir()
 
-		c := &initCmd{}
+		c := &initCmd{
+			runtime: "fake",
+		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
 		cmd.Flags().String("storage", tempDir, "test storage flag")
@@ -123,6 +127,7 @@ func TestInitCmd_PreRun(t *testing.T) {
 		configDir := t.TempDir()
 
 		c := &initCmd{
+			runtime:            "fake",
 			workspaceConfigDir: configDir,
 		}
 		cmd := &cobra.Command{}
@@ -163,6 +168,7 @@ func TestInitCmd_PreRun(t *testing.T) {
 		configDir := t.TempDir()
 
 		c := &initCmd{
+			runtime:            "fake",
 			workspaceConfigDir: configDir,
 		}
 		cmd := &cobra.Command{}
@@ -230,7 +236,9 @@ func TestInitCmd_PreRun(t *testing.T) {
 			t.Fatalf("Failed to create relative directory: %v", err)
 		}
 
-		c := &initCmd{}
+		c := &initCmd{
+			runtime: "fake",
+		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
 		cmd.Flags().String("storage", storageDir, "test storage flag")
@@ -267,7 +275,9 @@ func TestInitCmd_PreRun(t *testing.T) {
 		tempDir := t.TempDir()
 		nonExistentDir := filepath.Join(tempDir, "does-not-exist")
 
-		c := &initCmd{}
+		c := &initCmd{
+			runtime: "fake",
+		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
 		cmd.Flags().String("storage", tempDir, "test storage flag")
@@ -295,7 +305,9 @@ func TestInitCmd_PreRun(t *testing.T) {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 
-		c := &initCmd{}
+		c := &initCmd{
+			runtime: "fake",
+		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
 		cmd.Flags().String("storage", tempDir, "test storage flag")
@@ -318,7 +330,8 @@ func TestInitCmd_PreRun(t *testing.T) {
 		tempDir := t.TempDir()
 
 		c := &initCmd{
-			output: "", // Default empty output
+			runtime: "fake",
+			output:  "", // Default empty output
 		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
@@ -342,7 +355,8 @@ func TestInitCmd_PreRun(t *testing.T) {
 		tempDir := t.TempDir()
 
 		c := &initCmd{
-			output: "json",
+			runtime: "fake",
+			output:  "json",
 		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
@@ -366,7 +380,8 @@ func TestInitCmd_PreRun(t *testing.T) {
 		tempDir := t.TempDir()
 
 		c := &initCmd{
-			output: "xml",
+			runtime: "fake",
+			output:  "xml",
 		}
 		cmd := &cobra.Command{}
 		cmd.Flags().String("workspace-configuration", "", "test flag")
@@ -399,7 +414,8 @@ func TestInitCmd_PreRun(t *testing.T) {
 		invalidStorage := filepath.Join(notADir, "subdir")
 
 		c := &initCmd{
-			output: "json",
+			runtime: "fake",
+			output:  "json",
 		}
 		cmd := &cobra.Command{}
 		buf := new(bytes.Buffer)
@@ -424,6 +440,86 @@ func TestInitCmd_PreRun(t *testing.T) {
 			t.Errorf("Expected error to contain 'failed to create manager', got: %s", errorResponse.Error)
 		}
 	})
+
+	t.Run("fails when runtime flag is not provided and environment variable is not set", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		c := &initCmd{
+			runtime: "", // No runtime specified
+		}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workspace-configuration", "", "test flag")
+		cmd.Flags().String("storage", tempDir, "test storage flag")
+
+		args := []string{}
+
+		err := c.preRun(cmd, args)
+		if err == nil {
+			t.Fatal("Expected preRun() to fail when runtime is not specified")
+		}
+
+		if !strings.Contains(err.Error(), "runtime is required") {
+			t.Errorf("Expected error to contain 'runtime is required', got: %v", err)
+		}
+	})
+
+	t.Run("uses environment variable when runtime flag is not provided", func(t *testing.T) {
+		// Note: Cannot use t.Parallel() when using t.Setenv()
+
+		t.Run("with valid runtime from env", func(t *testing.T) {
+			t.Setenv("KORTEX_CLI_DEFAULT_RUNTIME", "fake")
+
+			tempDir := t.TempDir()
+
+			c := &initCmd{
+				runtime: "", // No runtime flag specified
+			}
+			cmd := &cobra.Command{}
+			cmd.Flags().String("workspace-configuration", "", "test flag")
+			cmd.Flags().String("storage", tempDir, "test storage flag")
+
+			args := []string{}
+
+			err := c.preRun(cmd, args)
+			if err != nil {
+				t.Fatalf("preRun() failed: %v", err)
+			}
+
+			if c.runtime != "fake" {
+				t.Errorf("Expected runtime to be 'fake' from environment variable, got: %s", c.runtime)
+			}
+		})
+	})
+
+	t.Run("runtime flag takes precedence over environment variable", func(t *testing.T) {
+		// Note: Cannot use t.Parallel() when using t.Setenv()
+
+		t.Run("flag overrides env", func(t *testing.T) {
+			t.Setenv("KORTEX_CLI_DEFAULT_RUNTIME", "env-runtime")
+
+			tempDir := t.TempDir()
+
+			c := &initCmd{
+				runtime: "flag-runtime",
+			}
+			cmd := &cobra.Command{}
+			cmd.Flags().String("workspace-configuration", "", "test flag")
+			cmd.Flags().String("storage", tempDir, "test storage flag")
+
+			args := []string{}
+
+			err := c.preRun(cmd, args)
+			if err != nil {
+				t.Fatalf("preRun() failed: %v", err)
+			}
+
+			if c.runtime != "flag-runtime" {
+				t.Errorf("Expected runtime to be 'flag-runtime', got: %s", c.runtime)
+			}
+		})
+	})
 }
 
 func TestInitCmd_E2E(t *testing.T) {
@@ -437,7 +533,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake"})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -507,7 +603,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -570,7 +666,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--workspace-configuration", configDir})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", "--workspace-configuration", configDir})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -635,7 +731,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--workspace-configuration", configDir})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--workspace-configuration", configDir})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -700,7 +796,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd1 := NewRootCmd()
 		buf1 := new(bytes.Buffer)
 		rootCmd1.SetOut(buf1)
-		rootCmd1.SetArgs([]string{"--storage", storageDir, "init", sourcesDir1})
+		rootCmd1.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir1})
 
 		err := rootCmd1.Execute()
 		if err != nil {
@@ -711,7 +807,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd2 := NewRootCmd()
 		buf2 := new(bytes.Buffer)
 		rootCmd2.SetOut(buf2)
-		rootCmd2.SetArgs([]string{"--storage", storageDir, "init", sourcesDir2})
+		rootCmd2.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir2})
 
 		err = rootCmd2.Execute()
 		if err != nil {
@@ -791,7 +887,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--verbose"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--verbose"})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -856,7 +952,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -896,7 +992,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--name", customName})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--name", customName})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -950,7 +1046,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd1 := NewRootCmd()
 		buf1 := new(bytes.Buffer)
 		rootCmd1.SetOut(buf1)
-		rootCmd1.SetArgs([]string{"--storage", storageDir, "init", sourcesDir1})
+		rootCmd1.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir1})
 
 		err := rootCmd1.Execute()
 		if err != nil {
@@ -961,7 +1057,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd2 := NewRootCmd()
 		buf2 := new(bytes.Buffer)
 		rootCmd2.SetOut(buf2)
-		rootCmd2.SetArgs([]string{"--storage", storageDir, "init", sourcesDir2, "--name", "project"})
+		rootCmd2.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir2, "--name", "project"})
 
 		err = rootCmd2.Execute()
 		if err != nil {
@@ -972,7 +1068,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd3 := NewRootCmd()
 		buf3 := new(bytes.Buffer)
 		rootCmd3.SetOut(buf3)
-		rootCmd3.SetArgs([]string{"--storage", storageDir, "init", sourcesDir3, "--name", "project"})
+		rootCmd3.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir3, "--name", "project"})
 
 		err = rootCmd3.Execute()
 		if err != nil {
@@ -1022,7 +1118,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--name", customName, "--verbose"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--name", customName, "--verbose"})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -1050,7 +1146,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
 		rootCmd.SetErr(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", nonExistentDir})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", nonExistentDir})
 
 		err := rootCmd.Execute()
 		if err == nil {
@@ -1092,7 +1188,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
 		rootCmd.SetErr(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", regularFile})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", regularFile})
 
 		err := rootCmd.Execute()
 		if err == nil {
@@ -1128,7 +1224,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--output", "json"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--output", "json"})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -1185,7 +1281,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--output", "json", "--verbose"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--output", "json", "--verbose"})
 
 		err := rootCmd.Execute()
 		if err != nil {
@@ -1250,7 +1346,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", nonExistentDir, "--output", "json"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", nonExistentDir, "--output", "json"})
 
 		err := rootCmd.Execute()
 		if err == nil {
@@ -1293,7 +1389,7 @@ func TestInitCmd_E2E(t *testing.T) {
 		rootCmd := NewRootCmd()
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
-		rootCmd.SetArgs([]string{"--storage", storageDir, "init", sourcesDir, "--name", customName, "--output", "json", "--verbose"})
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--name", customName, "--output", "json", "--verbose"})
 
 		err := rootCmd.Execute()
 		if err != nil {


### PR DESCRIPTION
Add mandatory --runtime flag to the init command for selecting the runtime implementation when registering workspaces. The runtime can be specified via:
- --runtime/-r flag (highest priority)
- KORTEX_CLI_DEFAULT_RUNTIME environment variable
- Error if neither is set (runtime is required)

Updated README.md with comprehensive Environment Variables section documenting KORTEX_CLI_DEFAULT_RUNTIME and KORTEX_CLI_STORAGE, including usage examples and priority order.

Resolves #51