### PR TITLE
feat(runtime): add centralized runtime registration system

### DIFF
--- a/.claude/skills/add-runtime
+++ b/.claude/skills/add-runtime
@@ -1,0 +1,1 @@
+../../skills/add-runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,41 @@ type InstanceData struct {
 }
 ```
 
+### Runtime System
+
+The runtime system provides a pluggable architecture for managing workspaces on different container/VM platforms (Podman, MicroVM, Kubernetes, etc.).
+
+**Key Components:**
+- **Runtime Interface** (`pkg/runtime/runtime.go`): Contract all runtimes must implement
+- **Registry** (`pkg/runtime/registry.go`): Manages runtime registration and discovery
+- **Runtime Implementations** (`pkg/runtime/<runtime-name>/`): Platform-specific packages (e.g., `fake`)
+- **Centralized Registration** (`pkg/runtimesetup/register.go`): Automatically registers all available runtimes
+
+**Adding a New Runtime:**
+
+Use the `/add-runtime` skill which provides step-by-step instructions for creating a new runtime implementation. The `fake` runtime in `pkg/runtime/fake/` serves as a reference implementation.
+
+**Runtime Registration in Commands:**
+
+Commands use `runtimesetup.RegisterAll()` to automatically register all available runtimes:
+
+```go
+import "github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
+
+// In command preRun
+manager, err := instances.NewManager(storageDir)
+if err != nil {
+    return err
+}
+
+// Register all available runtimes
+if err := runtimesetup.RegisterAll(manager); err != nil {
+    return err
+}
+```
+
+This automatically registers all runtimes from `pkg/runtimesetup/register.go` that report as available (e.g., only registers Podman if `podman` CLI is installed).
+
 ### Skills System
 Skills are reusable capabilities that can be discovered and executed by AI agents:
 - **Location**: `skills/<skill-name>/SKILL.md`

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
-	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -74,10 +74,9 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 		return outputErrorIfJSON(cmd, i.output, fmt.Errorf("failed to create manager: %w", err))
 	}
 
-	// Register fake runtime (for testing)
-	// TODO: In production, register only the runtimes that are available/configured
-	if err := manager.RegisterRuntime(fake.New()); err != nil {
-		return outputErrorIfJSON(cmd, i.output, fmt.Errorf("failed to register fake runtime: %w", err))
+	// Register all available runtimes
+	if err := runtimesetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, i.output, fmt.Errorf("failed to register runtimes: %w", err))
 	}
 
 	i.manager = manager

--- a/pkg/cmd/workspace_remove.go
+++ b/pkg/cmd/workspace_remove.go
@@ -26,7 +26,7 @@ import (
 
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
-	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -71,10 +71,9 @@ func (w *workspaceRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
 		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to create manager: %w", err))
 	}
 
-	// Register fake runtime (for testing)
-	// TODO: In production, register only the runtimes that are available/configured
-	if err := manager.RegisterRuntime(fake.New()); err != nil {
-		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register fake runtime: %w", err))
+	// Register all available runtimes
+	if err := runtimesetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register runtimes: %w", err))
 	}
 
 	w.manager = manager

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -26,7 +26,7 @@ import (
 
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
-	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -71,10 +71,9 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to create manager: %w", err))
 	}
 
-	// Register fake runtime (for testing)
-	// TODO: In production, register only the runtimes that are available/configured
-	if err := manager.RegisterRuntime(fake.New()); err != nil {
-		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register fake runtime: %w", err))
+	// Register all available runtimes
+	if err := runtimesetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register runtimes: %w", err))
 	}
 
 	w.manager = manager

--- a/pkg/cmd/workspace_stop.go
+++ b/pkg/cmd/workspace_stop.go
@@ -26,7 +26,7 @@ import (
 
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
-	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -71,10 +71,9 @@ func (w *workspaceStopCmd) preRun(cmd *cobra.Command, args []string) error {
 		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to create manager: %w", err))
 	}
 
-	// Register fake runtime (for testing)
-	// TODO: In production, register only the runtimes that are available/configured
-	if err := manager.RegisterRuntime(fake.New()); err != nil {
-		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register fake runtime: %w", err))
+	// Register all available runtimes
+	if err := runtimesetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register runtimes: %w", err))
 	}
 
 	w.manager = manager

--- a/pkg/runtimesetup/register.go
+++ b/pkg/runtimesetup/register.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package runtimesetup provides centralized registration of all available runtime implementations.
+package runtimesetup
+
+import (
+	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+)
+
+// Registrar is an interface for types that can register runtimes.
+// This is implemented by instances.Manager.
+type Registrar interface {
+	RegisterRuntime(rt runtime.Runtime) error
+}
+
+// Available is an optional interface that runtimes can implement
+// to report whether they are available in the current environment.
+//
+// This allows runtimes to check for:
+//   - Operating system compatibility
+//   - Required CLI tools or binaries
+//   - Configuration prerequisites
+//   - License or permission requirements
+//
+// Example implementation:
+//
+//	type myRuntime struct {}
+//
+//	func (r *myRuntime) Available() bool {
+//	    // Check if required CLI tool exists
+//	    _, err := exec.LookPath("my-tool")
+//	    return err == nil
+//	}
+type Available interface {
+	// Available returns true if the runtime is available in the current environment.
+	Available() bool
+}
+
+// runtimeFactory is a function that creates a new runtime instance.
+type runtimeFactory func() runtime.Runtime
+
+// availableRuntimes is the list of all runtimes that can be registered.
+// Add new runtimes here to make them available for automatic registration.
+var availableRuntimes = []runtimeFactory{
+	fake.New,
+}
+
+// RegisterAll registers all available runtimes to the given registrar.
+// It skips runtimes that implement the Available interface and report false.
+// Returns an error if any runtime fails to register.
+func RegisterAll(registrar Registrar) error {
+	return registerAllWithAvailable(registrar, availableRuntimes)
+}
+
+// registerAllWithAvailable registers the given runtimes to the registrar.
+// It skips runtimes that implement the Available interface and report false.
+// Returns an error if any runtime fails to register.
+// This function is internal and used for testing with custom runtime lists.
+func registerAllWithAvailable(registrar Registrar, factories []runtimeFactory) error {
+	for _, factory := range factories {
+		rt := factory()
+
+		// Skip runtimes that are not available in this environment
+		if avail, ok := rt.(Available); ok && !avail.Available() {
+			continue
+		}
+
+		if err := registrar.RegisterRuntime(rt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/runtimesetup/register_test.go
+++ b/pkg/runtimesetup/register_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimesetup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+)
+
+// fakeRegistrar is a test implementation of Registrar
+type fakeRegistrar struct {
+	registered []runtime.Runtime
+	failNext   bool
+}
+
+func (f *fakeRegistrar) RegisterRuntime(rt runtime.Runtime) error {
+	if f.failNext {
+		f.failNext = false
+		return runtime.ErrRuntimeNotFound // reusing an error for testing
+	}
+	f.registered = append(f.registered, rt)
+	return nil
+}
+
+// testRuntime is a simple test runtime implementation
+type testRuntime struct {
+	runtimeType string
+	available   bool
+}
+
+func (t *testRuntime) Type() string { return t.runtimeType }
+
+func (t *testRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+	return runtime.RuntimeInfo{}, fmt.Errorf("not implemented")
+}
+
+func (t *testRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	return runtime.RuntimeInfo{}, fmt.Errorf("not implemented")
+}
+
+func (t *testRuntime) Stop(ctx context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (t *testRuntime) Remove(ctx context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (t *testRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	return runtime.RuntimeInfo{}, fmt.Errorf("not implemented")
+}
+
+func (t *testRuntime) Available() bool {
+	return t.available
+}
+
+func TestRegisterAll(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registers all runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		registrar := &fakeRegistrar{}
+
+		// Create test runtimes
+		testFactories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "test1", available: true} },
+			func() runtime.Runtime { return &testRuntime{runtimeType: "test2", available: true} },
+		}
+
+		err := registerAllWithAvailable(registrar, testFactories)
+		if err != nil {
+			t.Fatalf("registerAllWithAvailable() failed: %v", err)
+		}
+
+		// We should have registered 2 test runtimes
+		if len(registrar.registered) != 2 {
+			t.Errorf("Expected 2 runtimes to be registered, got %d", len(registrar.registered))
+		}
+
+		// Check that both types are present
+		types := make(map[string]bool)
+		for _, rt := range registrar.registered {
+			types[rt.Type()] = true
+		}
+
+		if !types["test1"] {
+			t.Error("Expected 'test1' runtime to be registered")
+		}
+		if !types["test2"] {
+			t.Error("Expected 'test2' runtime to be registered")
+		}
+	})
+
+	t.Run("skips unavailable runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		registrar := &fakeRegistrar{}
+
+		// Create test runtimes with one unavailable
+		testFactories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "test1", available: true} },
+			func() runtime.Runtime { return &testRuntime{runtimeType: "test2", available: false} },
+			func() runtime.Runtime { return &testRuntime{runtimeType: "test3", available: true} },
+		}
+
+		err := registerAllWithAvailable(registrar, testFactories)
+		if err != nil {
+			t.Fatalf("registerAllWithAvailable() failed: %v", err)
+		}
+
+		// We should have registered only 2 runtimes (test2 is unavailable)
+		if len(registrar.registered) != 2 {
+			t.Errorf("Expected 2 runtimes to be registered, got %d", len(registrar.registered))
+		}
+
+		// Check that only available runtimes are present
+		types := make(map[string]bool)
+		for _, rt := range registrar.registered {
+			types[rt.Type()] = true
+		}
+
+		if !types["test1"] {
+			t.Error("Expected 'test1' runtime to be registered")
+		}
+		if types["test2"] {
+			t.Error("Did not expect 'test2' runtime to be registered (unavailable)")
+		}
+		if !types["test3"] {
+			t.Error("Expected 'test3' runtime to be registered")
+		}
+	})
+
+	t.Run("returns error on registration failure", func(t *testing.T) {
+		t.Parallel()
+
+		registrar := &fakeRegistrar{failNext: true}
+
+		testFactories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "test1", available: true} },
+		}
+
+		err := registerAllWithAvailable(registrar, testFactories)
+		if err == nil {
+			t.Fatal("Expected error when registration fails, got nil")
+		}
+	})
+}

--- a/skills/add-command-simple/SKILL.md
+++ b/skills/add-command-simple/SKILL.md
@@ -29,6 +29,7 @@ import (
 
     "github.com/spf13/cobra"
     "github.com/kortex-hub/kortex-cli/pkg/instances"
+    // "github.com/kortex-hub/kortex-cli/pkg/runtimesetup"  // Uncomment if registering runtimes
     // Add other imports as needed
 )
 
@@ -90,6 +91,14 @@ func (c *<command>Cmd) preRun(cmd *cobra.Command, args []string) error {
         return fmt.Errorf("failed to create manager: %w", err)
     }
     c.manager = manager
+
+    // Register runtimes if your command interacts with workspaces
+    // (e.g., Start, Stop, Remove, Create operations)
+    // Commands that only list or query workspaces don't need this
+    //
+    // if err := runtimesetup.RegisterAll(manager); err != nil {
+    //     return fmt.Errorf("failed to register runtimes: %w", err)
+    // }
 
     return nil
 }
@@ -285,6 +294,7 @@ If the command warrants user-facing documentation, update relevant docs.
 - **Example Validation**: Always add a Test<Command>Cmd_Examples test
 - **Parallel Tests**: All test functions should call `t.Parallel()` as the first line
 - **Cross-Platform Paths**: Use `filepath.Join()` and `t.TempDir()` for all path operations
+- **Runtime Registration**: Commands that perform runtime operations (Create, Start, Stop, Remove) need to call `runtimesetup.RegisterAll(manager)` in preRun. Commands that only query or list workspaces don't need this.
 
 ## Common Flag Patterns
 

--- a/skills/add-command-with-json/SKILL.md
+++ b/skills/add-command-with-json/SKILL.md
@@ -31,6 +31,7 @@ import (
 
     "github.com/spf13/cobra"
     "github.com/kortex-hub/kortex-cli/pkg/instances"
+    // "github.com/kortex-hub/kortex-cli/pkg/runtimesetup"  // Uncomment if registering runtimes
     // Add other imports as needed
 )
 
@@ -94,6 +95,14 @@ func (c *<command>Cmd) preRun(cmd *cobra.Command, args []string) error {
         return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to create manager: %w", err))
     }
     c.manager = manager
+
+    // Register runtimes if your command interacts with workspaces
+    // (e.g., Start, Stop, Remove, Create operations)
+    // Commands that only list or query workspaces don't need this
+    //
+    // if err := runtimesetup.RegisterAll(manager); err != nil {
+    //     return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to register runtimes: %w", err))
+    // }
 
     return nil
 }
@@ -287,6 +296,7 @@ If the command warrants user-facing documentation, update relevant docs.
 - **Examples**: Include 3-5 clear examples showing common use cases
 - **Testing**: Create both unit tests (preRun) and E2E tests (full execution)
 - **Example Validation**: Always add a Test<Command>Cmd_Examples test
+- **Runtime Registration**: Commands that perform runtime operations (Create, Start, Stop, Remove) need to call `runtimesetup.RegisterAll(manager)` in preRun. Commands that only query or list workspaces don't need this.
 
 ## References
 

--- a/skills/add-runtime/SKILL.md
+++ b/skills/add-runtime/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: add-runtime
+description: Add a new runtime implementation to the kortex-cli runtime system
+argument-hint: <runtime-name>
+---
+
+# Add Runtime Skill
+
+This skill guides you through adding a new runtime implementation to the kortex-cli runtime system.
+
+## What are Runtimes?
+
+Runtimes provide the execution environment for workspaces on different container/VM platforms:
+- **Podman**: Container-based workspaces
+- **MicroVM**: Lightweight VM-based workspaces
+- **Kubernetes**: Kubernetes pod-based workspaces
+- **fake**: Test runtime for development
+
+## Steps to Add a New Runtime
+
+### 1. Create Runtime Package
+
+Create a new directory: `pkg/runtime/<runtime-name>/`
+
+Example: `pkg/runtime/podman/`
+
+### 2. Implement the Runtime Interface
+
+Create `pkg/runtime/<runtime-name>/<runtime-name>.go` with:
+
+```go
+package <runtime-name>
+
+import (
+    "context"
+    "github.com/kortex-hub/kortex-cli/pkg/runtime"
+)
+
+type <runtime-name>Runtime struct {
+    storageDir string
+}
+
+// Ensure implementation of runtime.Runtime at compile time
+var _ runtime.Runtime = (*<runtime-name>Runtime)(nil)
+
+// Ensure implementation of runtime.StorageAware at compile time (optional)
+var _ runtime.StorageAware = (*<runtime-name>Runtime)(nil)
+
+// New creates a new runtime instance
+func New() runtime.Runtime {
+    return &<runtime-name>Runtime{}
+}
+
+// Type returns the runtime type identifier
+func (r *<runtime-name>Runtime) Type() string {
+    return "<runtime-name>"
+}
+
+// Initialize implements runtime.StorageAware (optional)
+func (r *<runtime-name>Runtime) Initialize(storageDir string) error {
+    r.storageDir = storageDir
+    // Optional: create subdirectories, load state, etc.
+    return nil
+}
+
+// Available implements runtimesetup.Available (optional)
+func (r *<runtime-name>Runtime) Available() bool {
+    // Check if the runtime is available on this system
+    // Example: check if CLI tool is installed
+    _, err := exec.LookPath("<runtime-cli-tool>")
+    return err == nil
+}
+
+// Create creates a new runtime instance
+func (r *<runtime-name>Runtime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+    // Implementation: create workspace on the platform
+    // Use params.Name, params.SourcePath, params.ConfigPath
+    return runtime.RuntimeInfo{}, nil
+}
+
+// Start starts a runtime instance
+func (r *<runtime-name>Runtime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+    // Implementation: start the workspace
+    return runtime.RuntimeInfo{}, nil
+}
+
+// Stop stops a runtime instance
+func (r *<runtime-name>Runtime) Stop(ctx context.Context, id string) error {
+    // Implementation: stop the workspace
+    return nil
+}
+
+// Remove removes a runtime instance
+func (r *<runtime-name>Runtime) Remove(ctx context.Context, id string) error {
+    // Implementation: remove the workspace
+    return nil
+}
+
+// Info retrieves information about a runtime instance
+func (r *<runtime-name>Runtime) Info(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+    // Implementation: get workspace info
+    return runtime.RuntimeInfo{}, nil
+}
+```
+
+### 3. Register the Runtime
+
+Edit `pkg/runtimesetup/register.go`:
+
+1. Add import:
+```go
+import (
+    "github.com/kortex-hub/kortex-cli/pkg/runtime"
+    "github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+    "github.com/kortex-hub/kortex-cli/pkg/runtime/<runtime-name>"  // Add this
+)
+```
+
+2. Add to `availableRuntimes` slice:
+```go
+var availableRuntimes = []runtimeFactory{
+    fake.New,
+    <runtime-name>.New,  // Add this
+}
+```
+
+### 4. Add Tests
+
+Create `pkg/runtime/<runtime-name>/<runtime-name>_test.go`:
+
+```go
+package <runtime-name>
+
+import (
+    "context"
+    "testing"
+)
+
+func TestNew(t *testing.T) {
+    t.Parallel()
+
+    rt := New()
+    if rt == nil {
+        t.Fatal("New() returned nil")
+    }
+
+    if rt.Type() != "<runtime-name>" {
+        t.Errorf("Expected type '<runtime-name>', got %s", rt.Type())
+    }
+}
+
+func TestCreate(t *testing.T) {
+    t.Parallel()
+
+    // Add tests for Create method
+}
+
+// Add tests for other methods...
+```
+
+### 5. Update Copyright Headers
+
+Run the copyright headers skill:
+```bash
+/copyright-headers
+```
+
+### 6. Test the Runtime
+
+```bash
+# Run tests
+make test
+
+# Build
+make build
+
+# Test with CLI (if runtime is available on your system)
+./kortex-cli init --runtime <runtime-name>
+```
+
+## Required Interfaces
+
+### Runtime Interface (required)
+
+All runtimes MUST implement:
+
+```go
+type Runtime interface {
+    Type() string
+    Create(ctx context.Context, params CreateParams) (RuntimeInfo, error)
+    Start(ctx context.Context, id string) (RuntimeInfo, error)
+    Stop(ctx context.Context, id string) error
+    Remove(ctx context.Context, id string) error
+    Info(ctx context.Context, id string) (RuntimeInfo, error)
+}
+```
+
+### StorageAware Interface (optional)
+
+Implement if the runtime needs persistent storage:
+
+```go
+type StorageAware interface {
+    Initialize(storageDir string) error
+}
+```
+
+When implemented, the registry will:
+1. Create a directory at `REGISTRY_STORAGE/<runtime-type>`
+2. Call `Initialize()` with the path
+3. The runtime can use this directory to persist data
+
+### Available Interface (optional)
+
+Implement to control runtime availability:
+
+```go
+type Available interface {
+    Available() bool
+}
+```
+
+Use this to:
+- Check if required CLI tools are installed
+- Check OS compatibility
+- Check configuration prerequisites
+- Check license/permission requirements
+
+## Reference Implementation
+
+See `pkg/runtime/fake/` for a complete reference implementation that demonstrates:
+- All required Runtime interface methods
+- StorageAware implementation for persistence
+- Proper error handling and state management
+- Comprehensive tests
+
+## Common Patterns
+
+### Error Handling
+
+Use the predefined errors from `pkg/runtime`:
+
+```go
+import "github.com/kortex-hub/kortex-cli/pkg/runtime"
+
+// Instance not found
+return runtime.RuntimeInfo{}, fmt.Errorf("%w: %s", runtime.ErrInstanceNotFound, id)
+
+// Invalid parameters
+return runtime.RuntimeInfo{}, fmt.Errorf("%w: name is required", runtime.ErrInvalidParams)
+```
+
+### Persistence
+
+If using StorageAware:
+
+```go
+func (r *myRuntime) Initialize(storageDir string) error {
+    r.storageDir = storageDir
+    r.storageFile = filepath.Join(storageDir, "instances.json")
+
+    // Load existing state
+    return r.loadFromDisk()
+}
+
+func (r *myRuntime) Create(...) {
+    // ... create instance
+
+    // Save to disk
+    if err := r.saveToDisk(); err != nil {
+        return runtime.RuntimeInfo{}, fmt.Errorf("failed to persist instance: %w", err)
+    }
+}
+```
+
+## Usage Example
+
+After implementing a Podman runtime:
+
+```bash
+# Initialize workspace with Podman runtime
+./kortex-cli init --runtime podman
+
+# Start workspace
+./kortex-cli workspace start <workspace-id>
+
+# Stop workspace
+./kortex-cli workspace stop <workspace-id>
+
+# Remove workspace
+./kortex-cli workspace remove <workspace-id>
+```
+
+## Notes
+
+- Runtime names should be lowercase (e.g., `podman`, `microvm`, `k8s`)
+- Use the `fake` runtime as a reference implementation
+- All runtimes are registered automatically via `runtimesetup.RegisterAll()`
+- Commands don't need to be modified when adding new runtimes
+- Only available runtimes (those with `Available() == true`) will be registered


### PR DESCRIPTION
Created pkg/runtimesetup package to abstract runtime registration from individual commands. Commands now call RegisterAll() instead of manually registering each runtime, making it easier to add new runtime implementations without modifying existing commands.

Added /add-runtime skill with step-by-step documentation for creating new runtime implementations. Updated command creation skills to include guidance on when runtime registration is needed.

Fixes #76 