### PR TITLE
feat(workspace): add project detection for workspace grouping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -858,6 +858,67 @@ if err != nil {
 }
 ```
 
+### Project Detection and Grouping
+
+Each workspace has a `project` field that enables grouping workspaces belonging to the same project across branches, forks, or subdirectories.
+
+**Project Identifier Detection:**
+
+The manager automatically detects the project identifier when adding instances:
+
+1. **Git repository with remote**: Uses repository remote URL (without `.git`) plus relative path
+   - Checks `upstream` remote first (useful for forks)
+   - Falls back to `origin` remote if `upstream` doesn't exist
+   - Example: `https://github.com/kortex-hub/kortex-cli/` (at root) or `https://github.com/kortex-hub/kortex-cli/pkg/git` (in subdirectory)
+
+2. **Git repository without remote**: Uses repository root directory plus relative path
+   - Example: `/home/user/local-repo` (at root) or `/home/user/local-repo/pkg/utils` (in subdirectory)
+
+3. **Non-git directory**: Uses the source directory path
+   - Example: `/tmp/workspace`
+
+**Custom Project Override:**
+
+Users can override auto-detection with the `--project` flag:
+
+```go
+// Add instance with custom project
+addedInstance, err := manager.Add(ctx, instances.AddOptions{
+    Instance:        instance,
+    RuntimeType:     "fake",
+    WorkspaceConfig: workspaceConfig,
+    Project:         "custom-project-id", // Optional: overrides auto-detection
+})
+```
+
+**Implementation Details:**
+
+- **Package**: `pkg/git` provides git repository detection with testable abstractions
+- **Detector Interface**: `git.Detector` with `DetectRepository(ctx, dir)` method
+- **Executor Pattern**: `git.Executor` abstracts git command execution for testing
+- **Manager Integration**: `manager.detectProject()` is called during `Add()` if no custom project is provided
+
+**Testing:**
+
+```go
+// Use fake git detector in tests
+gitDetector := newFakeGitDetectorWithRepo(
+    "/repo/root",
+    "https://github.com/user/repo",
+    "pkg/subdir", // relative path
+)
+
+manager, _ := newManagerWithFactory(
+    storageDir,
+    fakeInstanceFactory,
+    newFakeGenerator(),
+    newTestRegistry(tmpDir),
+    gitDetector,
+)
+```
+
+See `pkg/instances/manager_project_test.go` for comprehensive test examples.
+
 ### Cross-Platform Path Handling
 
 ⚠️ **CRITICAL**: All path operations and tests MUST be cross-platform compatible (Linux, macOS, Windows).

--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ kortex-cli init [sources-directory] [flags]
 - `--runtime, -r <type>` - Runtime to use for the workspace (required if `KORTEX_CLI_DEFAULT_RUNTIME` is not set)
 - `--workspace-configuration <path>` - Directory for workspace configuration files (default: `<sources-directory>/.kortex`)
 - `--name, -n <name>` - Human-readable name for the workspace (default: generated from sources directory)
+- `--project, -p <identifier>` - Custom project identifier to override auto-detection (default: auto-detected from git repository or source directory)
 - `--verbose, -v` - Show detailed output including all workspace information
 - `--output, -o <format>` - Output format (supported: `json`)
 - `--storage <path>` - Storage directory for kortex-cli data (default: `$HOME/.kortex-cli`)
@@ -651,6 +652,11 @@ kortex-cli init /path/to/myproject --runtime fake
 **Register with a custom name:**
 ```bash
 kortex-cli init /path/to/myproject --runtime fake --name "my-awesome-project"
+```
+
+**Register with a custom project identifier:**
+```bash
+kortex-cli init /path/to/myproject --runtime fake --project "my project"
 ```
 
 **Register with custom configuration location:**
@@ -723,9 +729,81 @@ kortex-cli init /tmp/project --runtime fake --name "project"
 # Name: "project-3"
 ```
 
+#### Project Detection
+
+When registering a workspace, kortex-cli automatically detects and stores a project identifier. This allows grouping workspaces that belong to the same project, even across different branches, forks, or subdirectories.
+
+**The project is determined using the following rules:**
+
+**1. Git repository with remote URL**
+
+The project is the repository remote URL (without `.git` suffix) plus the workspace's relative path within the repository:
+
+- **At repository root**: `https://github.com/user/repo/`
+- **In subdirectory**: `https://github.com/user/repo/sub/path`
+
+**Remote priority:**
+1. `upstream` remote is checked first (useful for forks)
+2. `origin` remote is used if `upstream` doesn't exist
+3. If neither exists, falls back to local repository path (see below)
+
+**Example - Fork with upstream:**
+```bash
+# Repository setup:
+# upstream: https://github.com/kortex-hub/kortex-cli.git
+# origin:   https://github.com/myuser/kortex-cli.git (fork)
+
+# Workspace at repository root
+kortex-cli init /home/user/kortex-cli --runtime fake
+# Project: https://github.com/kortex-hub/kortex-cli/
+
+# Workspace in subdirectory
+kortex-cli init /home/user/kortex-cli/pkg/git --runtime fake
+# Project: https://github.com/kortex-hub/kortex-cli/pkg/git
+```
+
+This ensures all forks and branches of the same upstream repository are grouped together.
+
+**2. Git repository without remote**
+
+The project is the repository root directory path plus the workspace's relative path:
+
+- **At repository root**: `/home/user/my-local-repo`
+- **In subdirectory**: `/home/user/my-local-repo/sub/path`
+
+**Example - Local repository:**
+```bash
+# Workspace at repository root
+kortex-cli init /home/user/local-repo --runtime fake
+# Project: /home/user/local-repo
+
+# Workspace in subdirectory
+kortex-cli init /home/user/local-repo/pkg/utils --runtime fake
+# Project: /home/user/local-repo/pkg/utils
+```
+
+**3. Non-git directory**
+
+The project is the workspace source directory path:
+
+**Example - Regular directory:**
+```bash
+kortex-cli init /tmp/workspace --runtime fake
+# Project: /tmp/workspace
+```
+
+**Benefits:**
+
+- **Cross-branch grouping**: Workspaces in different git worktrees or branches of the same repository share the same project
+- **Fork grouping**: Forks reference the upstream repository, grouping all contributors working on the same project
+- **Subdirectory support**: Monorepo subdirectories are tracked with their full path for precise identification
+- **Custom override**: Use `--project` flag to manually group workspaces under a custom identifier (e.g., "client-project")
+- **Future filtering**: The project field enables filtering and grouping commands (e.g., list all workspaces for a specific project)
+
 #### Notes
 
 - **Runtime is required**: You must specify a runtime using either the `--runtime` flag or the `KORTEX_CLI_DEFAULT_RUNTIME` environment variable
+- **Project auto-detection**: The project identifier is automatically detected from git repository information or source directory path. Use `--project` flag to override with a custom identifier
 - All directory paths are converted to absolute paths for consistency
 - The workspace ID is a unique identifier generated automatically
 - Workspaces can be listed using the `workspace list` command

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -38,6 +38,7 @@ type initCmd struct {
 	workspaceConfigDir string
 	name               string
 	runtime            string
+	project            string
 	absSourcesDir      string
 	absConfigDir       string
 	manager            instances.Manager
@@ -167,6 +168,7 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		Instance:        instance,
 		RuntimeType:     i.runtime,
 		WorkspaceConfig: i.workspaceConfig,
+		Project:         i.project,
 	})
 	if err != nil {
 		return outputErrorIfJSON(cmd, i.output, err)
@@ -233,6 +235,9 @@ kortex-cli init --runtime fake /path/to/project
 # Register with custom workspace name
 kortex-cli init --runtime fake --name my-project
 
+# Register with custom project identifier
+kortex-cli init --runtime fake --project my-custom-project
+
 # Show detailed output
 kortex-cli init --runtime fake --verbose`,
 		Args:    cobra.MaximumNArgs(1),
@@ -249,6 +254,9 @@ kortex-cli init --runtime fake --verbose`,
 	// Add runtime flag
 	cmd.Flags().StringVarP(&c.runtime, "runtime", "r", "", "Runtime to use for the workspace (required if KORTEX_CLI_DEFAULT_RUNTIME is not set)")
 	cmd.RegisterFlagCompletionFunc("runtime", completeRuntimeFlag)
+
+	// Add project flag
+	cmd.Flags().StringVarP(&c.project, "project", "p", "", "Custom project identifier (default: auto-detected from git repository or source directory)")
 
 	// Add verbose flag
 	cmd.Flags().BoolVarP(&c.verbose, "verbose", "v", false, "Show detailed output")

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -1519,6 +1519,44 @@ func TestInitCmd_E2E(t *testing.T) {
 			t.Errorf("Expected name %s in JSON output, got %s", customName, workspace.Name)
 		}
 	})
+
+	t.Run("registers workspace with custom project identifier", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+		customProject := "my-custom-project-id"
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir, "--project", customProject})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify instance was created with custom project
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		instancesList, err := manager.List()
+		if err != nil {
+			t.Fatalf("Failed to list instances: %v", err)
+		}
+
+		if len(instancesList) != 1 {
+			t.Fatalf("Expected 1 instance, got %d", len(instancesList))
+		}
+
+		inst := instancesList[0]
+
+		// Verify project is the custom value
+		if inst.GetProject() != customProject {
+			t.Errorf("Expected project %s, got %s", customProject, inst.GetProject())
+		}
+	})
 }
 
 func TestInitCmd_Examples(t *testing.T) {
@@ -1539,7 +1577,7 @@ func TestInitCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 4
+	expectedCount := 5
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/git/exec.go
+++ b/pkg/git/exec.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Executor provides an interface for executing git commands
+type Executor interface {
+	// Output executes a git command in the specified directory and returns its standard output
+	Output(ctx context.Context, dir string, args ...string) ([]byte, error)
+}
+
+// executor is the internal implementation of Executor
+type executor struct{}
+
+// Compile-time check to ensure executor implements Executor interface
+var _ Executor = (*executor)(nil)
+
+// NewExecutor creates a new git command executor
+func NewExecutor() Executor {
+	return &executor{}
+}
+
+// Output executes a git command in the specified directory and returns its standard output
+func (e *executor) Output(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	return cmd.Output()
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// ErrNotGitRepository is returned when a directory is not inside a git repository
+	ErrNotGitRepository = errors.New("not a git repository")
+)
+
+// exitCoder is an interface for errors that have an exit code
+type exitCoder interface {
+	ExitCode() int
+}
+
+// RepositoryInfo contains information about a git repository
+type RepositoryInfo struct {
+	// RootDir is the absolute path to the repository root
+	RootDir string
+	// RemoteURL is the URL of the origin remote (empty if no remote)
+	RemoteURL string
+	// RelativePath is the relative path from repository root to the queried directory
+	RelativePath string
+}
+
+// Detector provides methods for detecting and analyzing git repositories
+type Detector interface {
+	// DetectRepository checks if the given directory is inside a git repository
+	// and returns information about the repository if found.
+	// Returns ErrNotGitRepository if not inside a git repository.
+	DetectRepository(ctx context.Context, dir string) (*RepositoryInfo, error)
+}
+
+// detector is the internal implementation of Detector
+type detector struct {
+	executor Executor
+}
+
+// Compile-time check to ensure detector implements Detector interface
+var _ Detector = (*detector)(nil)
+
+// NewDetector creates a new git repository detector
+func NewDetector() Detector {
+	return &detector{
+		executor: NewExecutor(),
+	}
+}
+
+// newDetectorWithExecutor creates a new detector with a custom executor (for testing)
+func newDetectorWithExecutor(executor Executor) Detector {
+	return &detector{
+		executor: executor,
+	}
+}
+
+// DetectRepository checks if the given directory is inside a git repository
+func (d *detector) DetectRepository(ctx context.Context, dir string) (*RepositoryInfo, error) {
+	// Convert to absolute path
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if inside a git repository by running git rev-parse --show-toplevel
+	output, err := d.executor.Output(ctx, absDir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		// Exit status 128 means not a git repository
+		if exitErr, ok := err.(exitCoder); ok && exitErr.ExitCode() == 128 {
+			return nil, ErrNotGitRepository
+		}
+		return nil, err
+	}
+
+	rootDir := strings.TrimSpace(string(output))
+	if rootDir == "" {
+		return nil, ErrNotGitRepository
+	}
+
+	// Calculate relative path from repository root to the queried directory
+	relativePath, err := filepath.Rel(rootDir, absDir)
+	if err != nil {
+		return nil, err
+	}
+	// If at repository root, relative path will be "."
+	if relativePath == "." {
+		relativePath = ""
+	}
+
+	// Get the remote URL (try upstream first, then origin)
+	remoteURL := ""
+	output, err = d.executor.Output(ctx, rootDir, "remote", "get-url", "upstream")
+	if err == nil {
+		remoteURL = strings.TrimSpace(string(output))
+		// Remove .git suffix if present
+		remoteURL = strings.TrimSuffix(remoteURL, ".git")
+	} else {
+		// upstream not found, try origin
+		output, err = d.executor.Output(ctx, rootDir, "remote", "get-url", "origin")
+		if err == nil {
+			remoteURL = strings.TrimSpace(string(output))
+			// Remove .git suffix if present
+			remoteURL = strings.TrimSuffix(remoteURL, ".git")
+		}
+		// Ignore errors - remote might not exist
+	}
+
+	return &RepositoryInfo{
+		RootDir:      rootDir,
+		RemoteURL:    remoteURL,
+		RelativePath: relativePath,
+	}, nil
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// fakeExecutor is a test implementation of Executor
+type fakeExecutor struct {
+	revParseOutput []byte
+	revParseError  error
+	upstreamOutput []byte
+	upstreamError  error
+	originOutput   []byte
+	originError    error
+}
+
+func (f *fakeExecutor) Output(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("no args provided")
+	}
+
+	switch args[0] {
+	case "rev-parse":
+		if f.revParseError != nil {
+			return nil, f.revParseError
+		}
+		return f.revParseOutput, nil
+	case "remote":
+		if len(args) < 3 {
+			return nil, errors.New("remote command requires subcommand and name")
+		}
+		// args[1] is "get-url", args[2] is remote name
+		remoteName := args[2]
+		switch remoteName {
+		case "upstream":
+			if f.upstreamError != nil {
+				return nil, f.upstreamError
+			}
+			return f.upstreamOutput, nil
+		case "origin":
+			if f.originError != nil {
+				return nil, f.originError
+			}
+			return f.originOutput, nil
+		default:
+			return nil, errors.New("unknown remote: " + remoteName)
+		}
+	default:
+		return nil, errors.New("unknown command: " + args[0])
+	}
+}
+
+func TestDetector_DetectRepository(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detects git repository with origin remote", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := t.TempDir()
+
+		fake := &fakeExecutor{
+			revParseOutput: []byte(testDir + "\n"),
+			upstreamError:  &exec.ExitError{}, // upstream doesn't exist
+			originOutput:   []byte("https://github.com/user/repo.git\n"),
+		}
+
+		detector := newDetectorWithExecutor(fake)
+		info, err := detector.DetectRepository(context.Background(), testDir)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if info.RootDir != testDir {
+			t.Errorf("Expected root dir %s, got %s", testDir, info.RootDir)
+		}
+
+		if info.RemoteURL != "https://github.com/user/repo" {
+			t.Errorf("Expected remote URL https://github.com/user/repo (without .git), got %s", info.RemoteURL)
+		}
+
+		if info.RelativePath != "" {
+			t.Errorf("Expected empty relative path at root, got %s", info.RelativePath)
+		}
+	})
+
+	t.Run("detects git repository with upstream remote", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := t.TempDir()
+
+		fake := &fakeExecutor{
+			revParseOutput: []byte(testDir + "\n"),
+			upstreamOutput: []byte("https://github.com/upstream/repo.git\n"),
+			originOutput:   []byte("https://github.com/user/fork.git\n"),
+		}
+
+		detector := newDetectorWithExecutor(fake)
+		info, err := detector.DetectRepository(context.Background(), testDir)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if info.RootDir != testDir {
+			t.Errorf("Expected root dir %s, got %s", testDir, info.RootDir)
+		}
+
+		if info.RemoteURL != "https://github.com/upstream/repo" {
+			t.Errorf("Expected upstream remote URL https://github.com/upstream/repo (without .git), got %s", info.RemoteURL)
+		}
+
+		if info.RelativePath != "" {
+			t.Errorf("Expected empty relative path at root, got %s", info.RelativePath)
+		}
+	})
+
+	t.Run("detects git repository with remote in subdirectory", func(t *testing.T) {
+		t.Parallel()
+
+		repoRoot := t.TempDir()
+		subDir := filepath.Join(repoRoot, "sub", "path")
+
+		fake := &fakeExecutor{
+			revParseOutput: []byte(repoRoot + "\n"),
+			upstreamError:  &exec.ExitError{}, // upstream doesn't exist
+			originOutput:   []byte("https://github.com/user/repo.git\n"),
+		}
+
+		detector := newDetectorWithExecutor(fake)
+		info, err := detector.DetectRepository(context.Background(), subDir)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if info.RootDir != repoRoot {
+			t.Errorf("Expected root dir %s, got %s", repoRoot, info.RootDir)
+		}
+
+		if info.RemoteURL != "https://github.com/user/repo" {
+			t.Errorf("Expected remote URL https://github.com/user/repo (without .git), got %s", info.RemoteURL)
+		}
+
+		expectedRelPath := filepath.Join("sub", "path")
+		if info.RelativePath != expectedRelPath {
+			t.Errorf("Expected relative path %s, got %s", expectedRelPath, info.RelativePath)
+		}
+	})
+
+	t.Run("detects git repository without any remote", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := t.TempDir()
+
+		fake := &fakeExecutor{
+			revParseOutput: []byte(testDir + "\n"),
+			upstreamError:  &exec.ExitError{},
+			originError:    &exec.ExitError{},
+		}
+
+		detector := newDetectorWithExecutor(fake)
+		info, err := detector.DetectRepository(context.Background(), testDir)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if info.RootDir != testDir {
+			t.Errorf("Expected root dir %s, got %s", testDir, info.RootDir)
+		}
+
+		if info.RemoteURL != "" {
+			t.Errorf("Expected empty remote URL, got %s", info.RemoteURL)
+		}
+
+		if info.RelativePath != "" {
+			t.Errorf("Expected empty relative path, got %s", info.RelativePath)
+		}
+	})
+
+	t.Run("returns error when not a git repository", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := t.TempDir()
+
+		fake := &fakeExecutor{
+			revParseError: &exitError128{},
+		}
+
+		detector := newDetectorWithExecutor(fake)
+		_, err := detector.DetectRepository(context.Background(), testDir)
+
+		if !errors.Is(err, ErrNotGitRepository) {
+			t.Errorf("Expected ErrNotGitRepository, got %v", err)
+		}
+	})
+
+	t.Run("returns error on git command failure", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := t.TempDir()
+
+		fake := &fakeExecutor{
+			revParseError: errors.New("git command failed"),
+		}
+
+		detector := newDetectorWithExecutor(fake)
+		_, err := detector.DetectRepository(context.Background(), testDir)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+
+		if errors.Is(err, ErrNotGitRepository) {
+			t.Error("Should not be ErrNotGitRepository")
+		}
+	})
+}
+
+// exitError128 is a test helper that simulates git exit code 128
+type exitError128 struct{}
+
+func (e *exitError128) ExitCode() int {
+	return 128
+}
+
+func (e *exitError128) Error() string {
+	return "exit status 128"
+}

--- a/pkg/instances/instance.go
+++ b/pkg/instances/instance.go
@@ -60,6 +60,15 @@ type InstanceData struct {
 	Paths InstancePaths `json:"paths"`
 	// Runtime contains runtime-specific information
 	Runtime RuntimeData `json:"runtime"`
+	// Project is the project identifier for grouping instances.
+	// Format depends on workspace type:
+	// - Git repository with remote: normalized remote repository identifier (remote URL with .git suffix
+	//   and credentials stripped, e.g., "https://github.com/user/repo")
+	// - Git repository without remote: repository root directory as absolute path (e.g., "/home/user/my-local-repo")
+	// - Non-git directory: workspace source directory as absolute path (e.g., "/home/user/my-workspace")
+	// When the workspace is in a subdirectory of the repository, a relative-path suffix is appended
+	// (e.g., "https://github.com/user/repo/pkg/subdir" or "/home/user/my-local-repo/pkg/subdir")
+	Project string `json:"project"`
 }
 
 // Instance represents a workspace instance with source and configuration directories.
@@ -82,6 +91,8 @@ type Instance interface {
 	GetRuntimeType() string
 	// GetRuntimeData returns the complete runtime data for this instance
 	GetRuntimeData() RuntimeData
+	// GetProject returns the project identifier for this instance
+	GetProject() string
 	// Dump returns the serializable data of the instance
 	Dump() InstanceData
 }
@@ -100,6 +111,8 @@ type instance struct {
 	ConfigDir string
 	// Runtime contains runtime-specific information
 	Runtime RuntimeData
+	// Project is the project identifier for grouping instances
+	Project string
 }
 
 // Compile-time check to ensure instance implements Instance interface
@@ -153,6 +166,11 @@ func (i *instance) GetRuntimeData() RuntimeData {
 	}
 }
 
+// GetProject returns the project identifier for this instance
+func (i *instance) GetProject() string {
+	return i.Project
+}
+
 // Dump returns the serializable data of the instance
 func (i *instance) Dump() InstanceData {
 	return InstanceData{
@@ -163,6 +181,7 @@ func (i *instance) Dump() InstanceData {
 			Configuration: i.ConfigDir,
 		},
 		Runtime: i.Runtime,
+		Project: i.Project,
 	}
 }
 
@@ -228,6 +247,7 @@ func NewInstanceFromData(data InstanceData) (Instance, error) {
 		SourceDir: data.Paths.Source,
 		ConfigDir: data.Paths.Configuration,
 		Runtime:   data.Runtime,
+		Project:   data.Project,
 	}, nil
 }
 

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	workspace "github.com/kortex-hub/kortex-cli-api/workspace-configuration/go"
 	"github.com/kortex-hub/kortex-cli/pkg/generator"
+	"github.com/kortex-hub/kortex-cli/pkg/git"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 )
 
@@ -46,6 +48,8 @@ type AddOptions struct {
 	RuntimeType string
 	// WorkspaceConfig is the loaded workspace configuration (optional, can be nil)
 	WorkspaceConfig *workspace.WorkspaceConfiguration
+	// Project is an optional custom project identifier to override auto-detection
+	Project string
 }
 
 // Manager handles instance storage and operations
@@ -76,6 +80,7 @@ type manager struct {
 	factory         InstanceFactory
 	generator       generator.Generator
 	runtimeRegistry runtime.Registry
+	gitDetector     git.Detector
 }
 
 // Compile-time check to ensure manager implements Manager interface
@@ -88,12 +93,12 @@ func NewManager(storageDir string) (Manager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime registry: %w", err)
 	}
-	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg)
+	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, git.NewDetector())
 }
 
-// newManagerWithFactory creates a new instance manager with a custom instance factory, generator, and registry.
-// This is unexported and primarily useful for testing with fake instances, generators, and runtimes.
-func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry) (Manager, error) {
+// newManagerWithFactory creates a new instance manager with a custom instance factory, generator, registry, and git detector.
+// This is unexported and primarily useful for testing with fake instances, generators, runtimes, and git detector.
+func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, detector git.Detector) (Manager, error) {
 	if storageDir == "" {
 		return nil, errors.New("storage directory cannot be empty")
 	}
@@ -105,6 +110,9 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 	}
 	if reg == nil {
 		return nil, errors.New("registry cannot be nil")
+	}
+	if detector == nil {
+		return nil, errors.New("git detector cannot be nil")
 	}
 
 	// Ensure storage directory exists
@@ -118,6 +126,7 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 		factory:         factory,
 		generator:       gen,
 		runtimeRegistry: reg,
+		gitDetector:     detector,
 	}, nil
 }
 
@@ -171,6 +180,12 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		name = m.ensureUniqueName(name, instances)
 	}
 
+	// Use custom project identifier if provided, otherwise auto-detect
+	project := opts.Project
+	if project == "" {
+		project = m.detectProject(ctx, inst.GetSourceDir())
+	}
+
 	// Get the runtime
 	rt, err := m.runtimeRegistry.Get(opts.RuntimeType)
 	if err != nil {
@@ -187,7 +202,7 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)
 	}
 
-	// Create a new instance with the unique ID, name, and runtime info
+	// Create a new instance with the unique ID, name, runtime info, and project
 	instanceWithID := &instance{
 		ID:        uniqueID,
 		Name:      name,
@@ -199,6 +214,7 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 			State:      runtimeInfo.State,
 			Info:       runtimeInfo.Info,
 		},
+		Project: project,
 	}
 
 	instances = append(instances, instanceWithID)
@@ -483,6 +499,47 @@ func (m *manager) ensureUniqueName(name string, instances []Instance) string {
 		}
 		counter++
 	}
+}
+
+// detectProject detects the project identifier for a source directory
+// Returns:
+//   - Git repository with remote: the repository remote URL with workspace path appended
+//     (e.g., "https://github.com/user/repo/" for root, "https://github.com/user/repo/sub/path" for subdirectory)
+//   - Git repository without remote: the repository root directory with workspace path appended
+//   - Non-git directory: the source directory
+func (m *manager) detectProject(ctx context.Context, sourceDir string) string {
+	// Try to detect git repository
+	repoInfo, err := m.gitDetector.DetectRepository(ctx, sourceDir)
+	if err != nil {
+		// Not a git repository, use source directory
+		return sourceDir
+	}
+
+	// Git repository found
+	if repoInfo.RemoteURL != "" {
+		// Has remote URL, construct project identifier with relative path
+		// Ensure URL ends with slash before appending path
+		baseURL := repoInfo.RemoteURL
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+
+		if repoInfo.RelativePath != "" {
+			// Append relative path to base URL
+			// Convert to forward slashes for URL compatibility (Windows uses backslashes)
+			urlPath := filepath.ToSlash(repoInfo.RelativePath)
+			return baseURL + urlPath
+		}
+		// At repository root, return base URL with trailing slash
+		return baseURL
+	}
+
+	// No remote URL, use repository root directory with relative path
+	// Use filepath.Join for local paths (OS-specific separators)
+	if repoInfo.RelativePath != "" {
+		return filepath.Join(repoInfo.RootDir, repoInfo.RelativePath)
+	}
+	return repoInfo.RootDir
 }
 
 // loadInstances reads instances from the storage file

--- a/pkg/instances/manager_project_test.go
+++ b/pkg/instances/manager_project_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instances
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kortex-hub/kortex-cli/pkg/git"
+)
+
+func TestManager_detectProject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns source directory for non-git directory", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		sourceDir := filepath.Join(tmpDir, "workspace")
+
+		// Create fake git detector that returns ErrNotGitRepository
+		gitDetector := newFakeGitDetector()
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), sourceDir)
+
+		if result != sourceDir {
+			t.Errorf("detectProject() = %v, want %v", result, sourceDir)
+		}
+	})
+
+	t.Run("returns remote URL with trailing slash for git repository at root", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		repoRoot := filepath.Join(tmpDir, "repo")
+
+		// Create fake git detector that returns repository info
+		gitDetector := newFakeGitDetectorWithRepo(
+			repoRoot,
+			"https://github.com/user/repo",
+			"", // at root, relative path is empty
+		)
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), repoRoot)
+
+		expected := "https://github.com/user/repo/"
+		if result != expected {
+			t.Errorf("detectProject() = %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("returns remote URL with subdirectory path for git repository in subdirectory", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		repoRoot := filepath.Join(tmpDir, "repo")
+		subDir := filepath.Join(repoRoot, "pkg", "git")
+
+		// Create fake git detector that returns repository info with relative path
+		gitDetector := newFakeGitDetectorWithRepo(
+			repoRoot,
+			"https://github.com/user/repo",
+			filepath.Join("pkg", "git"),
+		)
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), subDir)
+
+		expected := "https://github.com/user/repo/pkg/git"
+		if result != expected {
+			t.Errorf("detectProject() = %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("returns local repository root for git repository without remote", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		repoRoot := filepath.Join(tmpDir, "local-repo")
+
+		// Create fake git detector that returns repository info without remote URL
+		gitDetector := newFakeGitDetectorWithRepo(
+			repoRoot,
+			"", // no remote URL
+			"", // at root
+		)
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), repoRoot)
+
+		if result != repoRoot {
+			t.Errorf("detectProject() = %v, want %v", result, repoRoot)
+		}
+	})
+
+	t.Run("returns local repository root with relative path for git repository without remote in subdirectory", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		repoRoot := filepath.Join(tmpDir, "local-repo")
+		subDir := filepath.Join(repoRoot, "pkg", "utils")
+
+		// Create fake git detector that returns repository info without remote URL
+		gitDetector := newFakeGitDetectorWithRepo(
+			repoRoot,
+			"", // no remote URL
+			filepath.Join("pkg", "utils"),
+		)
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), subDir)
+
+		expected := filepath.Join(repoRoot, "pkg", "utils")
+		if result != expected {
+			t.Errorf("detectProject() = %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("handles remote URL that already has trailing slash", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		repoRoot := filepath.Join(tmpDir, "repo")
+
+		// Create fake git detector with URL that already has trailing slash
+		gitDetector := newFakeGitDetectorWithRepo(
+			repoRoot,
+			"https://github.com/user/repo/",
+			"",
+		)
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), repoRoot)
+
+		expected := "https://github.com/user/repo/"
+		if result != expected {
+			t.Errorf("detectProject() = %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("preserves URL scheme and slashes when appending relative path", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		repoRoot := filepath.Join(tmpDir, "repo")
+
+		// Create fake git detector with HTTPS URL
+		gitDetector := newFakeGitDetectorWithRepo(
+			repoRoot,
+			"https://github.com/upstream/repo",
+			filepath.Join("pkg", "cmd"),
+		)
+
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), gitDetector)
+		mgr := m.(*manager)
+
+		result := mgr.detectProject(context.Background(), repoRoot)
+
+		// Should preserve https:// in the URL
+		expected := "https://github.com/upstream/repo/pkg/cmd"
+		if result != expected {
+			t.Errorf("detectProject() = %v, want %v", result, expected)
+		}
+	})
+}
+
+// newFakeGitDetectorWithRepo creates a fake git detector that returns repository info
+func newFakeGitDetectorWithRepo(rootDir, remoteURL, relativePath string) *fakeGitDetector {
+	return &fakeGitDetector{
+		repoInfo: &git.RepositoryInfo{
+			RootDir:      rootDir,
+			RemoteURL:    remoteURL,
+			RelativePath: relativePath,
+		},
+	}
+}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/kortex-hub/kortex-cli/pkg/git"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
 )
@@ -36,6 +37,7 @@ type fakeInstance struct {
 	configDir  string
 	accessible bool
 	runtime    RuntimeData
+	project    string
 }
 
 // Compile-time check to ensure fakeInstance implements Instance interface
@@ -69,6 +71,10 @@ func (f *fakeInstance) GetRuntimeData() RuntimeData {
 	return f.runtime
 }
 
+func (f *fakeInstance) GetProject() string {
+	return f.project
+}
+
 func (f *fakeInstance) Dump() InstanceData {
 	return InstanceData{
 		ID:   f.id,
@@ -78,6 +84,7 @@ func (f *fakeInstance) Dump() InstanceData {
 			Configuration: f.configDir,
 		},
 		Runtime: f.runtime,
+		Project: f.project,
 	}
 }
 
@@ -89,6 +96,7 @@ type newFakeInstanceParams struct {
 	ConfigDir  string
 	Accessible bool
 	Runtime    RuntimeData
+	Project    string
 }
 
 // newFakeInstance creates a new fake instance for testing
@@ -100,6 +108,7 @@ func newFakeInstance(params newFakeInstanceParams) Instance {
 		configDir:  params.ConfigDir,
 		accessible: params.Accessible,
 		runtime:    params.Runtime,
+		project:    params.Project,
 	}
 }
 
@@ -126,6 +135,7 @@ func fakeInstanceFactory(data InstanceData) (Instance, error) {
 		configDir:  data.Paths.Configuration,
 		accessible: true,
 		runtime:    data.Runtime,
+		project:    data.Project,
 	}, nil
 }
 
@@ -179,6 +189,25 @@ func newTestRegistry(storageDir string) runtime.Registry {
 	}
 	_ = reg.Register(fake.New())
 	return reg
+}
+
+// fakeGitDetector is a test double for the git.Detector interface
+type fakeGitDetector struct {
+	repoInfo *git.RepositoryInfo
+	err      error
+}
+
+func newFakeGitDetector() *fakeGitDetector {
+	return &fakeGitDetector{
+		err: git.ErrNotGitRepository,
+	}
+}
+
+func (f *fakeGitDetector) DetectRepository(ctx context.Context, dir string) (*git.RepositoryInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.repoInfo, nil
 }
 
 func TestNewManager(t *testing.T) {
@@ -239,7 +268,7 @@ func TestNewManager(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() unexpected error = %v", err)
 		}
@@ -271,7 +300,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -301,7 +330,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		_, err := manager.Add(context.Background(), AddOptions{Instance: nil, RuntimeType: "fake"})
 		if err == nil {
@@ -323,7 +352,7 @@ func TestManager_Add(t *testing.T) {
 			"duplicate-id-0000000000000000000000000000000000000000000000000000000a",
 			"unique-id-1-0000000000000000000000000000000000000000000000000000000b",
 		})
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		// Create instances without IDs (empty ID)
@@ -374,7 +403,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -400,7 +429,7 @@ func TestManager_Add(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -437,7 +466,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instances, err := manager.List()
 		if err != nil {
@@ -453,7 +482,7 @@ func TestManager_List(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -483,7 +512,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		// Create empty storage file
 		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
@@ -506,7 +535,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -539,7 +568,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		_, err := manager.Get("nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -556,7 +585,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -586,7 +615,7 @@ func TestManager_Delete(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		err := manager.Delete(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -599,7 +628,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		source1 := filepath.Join(instanceTmpDir, "source1")
@@ -642,7 +671,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -656,7 +685,7 @@ func TestManager_Delete(t *testing.T) {
 		manager1.Delete(ctx, generatedID)
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 		_, err := manager2.Get(generatedID)
 		if err != ErrInstanceNotFound {
 			t.Errorf("Get() from new manager error = %v, want %v", err, ErrInstanceNotFound)
@@ -668,7 +697,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -710,7 +739,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -742,7 +771,7 @@ func TestManager_Start(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		err := manager.Start(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -772,7 +801,7 @@ func TestManager_Start(t *testing.T) {
 				runtime:    RuntimeData{}, // Empty runtime
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -812,7 +841,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -823,7 +852,7 @@ func TestManager_Start(t *testing.T) {
 		manager1.Start(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "running" {
@@ -840,7 +869,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -874,7 +903,7 @@ func TestManager_Stop(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		err := manager.Stop(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -887,7 +916,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -927,7 +956,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -939,7 +968,7 @@ func TestManager_Stop(t *testing.T) {
 		manager1.Stop(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "stopped" {
@@ -952,7 +981,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -996,7 +1025,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1040,7 +1069,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1084,7 +1113,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inaccessibleSource := filepath.Join(instanceTmpDir, "nonexistent-source")
@@ -1133,7 +1162,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: accessible,
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		accessibleConfig := filepath.Join(instanceTmpDir, "accessible-config")
 
@@ -1176,7 +1205,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1200,7 +1229,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		removed, err := manager.Reconcile()
 		if err != nil {
@@ -1223,7 +1252,7 @@ func TestManager_Persistence(t *testing.T) {
 		instanceTmpDir := t.TempDir()
 
 		// Create first manager and add instance
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 		expectedSource := filepath.Join(instanceTmpDir, "source")
 		expectedConfig := filepath.Join(instanceTmpDir, "config")
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1236,7 +1265,7 @@ func TestManager_Persistence(t *testing.T) {
 		generatedID := added.GetID()
 
 		// Create second manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 		instances, err := manager2.List()
 		if err != nil {
 			t.Fatalf("List() from second manager unexpected error = %v", err)
@@ -1257,7 +1286,7 @@ func TestManager_Persistence(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -1309,7 +1338,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		var wg sync.WaitGroup
@@ -1342,7 +1371,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		// Add some instances first
@@ -1386,7 +1415,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		// Cast to concrete type to access unexported methods
 		mgr := m.(*manager)
@@ -1419,7 +1448,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1444,7 +1473,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1483,7 +1512,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1519,7 +1548,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1540,7 +1569,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1557,7 +1586,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1582,7 +1611,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1600,7 +1629,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir))
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 


### PR DESCRIPTION
Implements project abstraction that allows grouping workspaces belonging to the same project across different branches, forks, or subdirectories.

The project identifier is automatically detected from:
- Git repository with remote: uses upstream (or origin) URL + relative path
- Git repository without remote: uses repository root + relative path
- Non-git directory: uses source directory path

Users can override auto-detection with the --project flag to specify custom identifiers for organizational needs (e.g., team names, clients).

Closes #89, #41

This will be needed for giving specific user configuration per project (see #88)