### PR TITLE
feat(cmd): display project in workspace info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kortex-hub/kortex-cli
 go 1.25.7
 
 require (
-	github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260319072318-abc0e6182754
+	github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260325063333-e05238511035
 	github.com/kortex-hub/kortex-cli-api/workspace-configuration/go v0.0.0-20260319072318-abc0e6182754
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260319072318-abc0e6182754 h1:MXU+DtCo9nOQs/i4t9bLJvnOHnjdzYTtBXrXzqYVqBo=
 github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260319072318-abc0e6182754/go.mod h1:jWKudiw26CIjuOsROQ80FOuuk2m2/5BVkuATpmD5xQQ=
+github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260325063333-e05238511035 h1:BjMrkRjfZSEWKF9yIAmIhUVvaLOtuqcaaqVmiU/5fJ8=
+github.com/kortex-hub/kortex-cli-api/cli/go v0.0.0-20260325063333-e05238511035/go.mod h1:jWKudiw26CIjuOsROQ80FOuuk2m2/5BVkuATpmD5xQQ=
 github.com/kortex-hub/kortex-cli-api/workspace-configuration/go v0.0.0-20260319072318-abc0e6182754 h1:Igfvw+SfpmqApUWA4uBhMq4vmhuinJLAGk9YMtSdTr8=
 github.com/kortex-hub/kortex-cli-api/workspace-configuration/go v0.0.0-20260319072318-abc0e6182754/go.mod h1:N4tLoDdBbAPYJ9ALLfYbqYScydJb546JgKQ6EjHswLw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/cmd/conversion.go
+++ b/pkg/cmd/conversion.go
@@ -37,8 +37,9 @@ func instanceToWorkspaceId(instance instances.Instance) api.WorkspaceId {
 // instanceToWorkspace converts an Instance to an api.Workspace
 func instanceToWorkspace(instance instances.Instance) api.Workspace {
 	return api.Workspace{
-		Id:   instance.GetID(),
-		Name: instance.GetName(),
+		Id:      instance.GetID(),
+		Name:    instance.GetName(),
+		Project: instance.GetProject(),
 		Paths: api.WorkspacePaths{
 			Configuration: instance.GetConfigDir(),
 			Source:        instance.GetSourceDir(),

--- a/pkg/cmd/conversion_test.go
+++ b/pkg/cmd/conversion_test.go
@@ -98,9 +98,10 @@ func TestInstanceToWorkspace(t *testing.T) {
 			t.Fatalf("Failed to create instance: %v", err)
 		}
 
-		// Manually set ID (in real usage, Manager sets this)
+		// Manually set ID and Project (in real usage, Manager sets these)
 		instanceData := instance.Dump()
 		instanceData.ID = "test-id-456"
+		instanceData.Project = "test-project"
 		instance, _ = instances.NewInstanceFromData(instanceData)
 
 		result := instanceToWorkspace(instance)
@@ -111,6 +112,10 @@ func TestInstanceToWorkspace(t *testing.T) {
 
 		if result.Name != "test-workspace" {
 			t.Errorf("Expected name 'test-workspace', got '%s'", result.Name)
+		}
+
+		if result.Project != "test-project" {
+			t.Errorf("Expected project 'test-project', got '%s'", result.Project)
 		}
 
 		if result.Paths.Source != sourceDir {
@@ -161,6 +166,9 @@ func TestInstanceToWorkspace(t *testing.T) {
 		}
 		if _, exists := parsed["name"]; !exists {
 			t.Error("Expected 'name' field in JSON")
+		}
+		if _, exists := parsed["project"]; !exists {
+			t.Error("Expected 'project' field in JSON")
 		}
 		if _, exists := parsed["paths"]; !exists {
 			t.Error("Expected 'paths' field in JSON")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -184,6 +184,7 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Registered workspace:\n")
 		cmd.Printf("  ID: %s\n", addedInstance.GetID())
 		cmd.Printf("  Name: %s\n", addedInstance.GetName())
+		cmd.Printf("  Project: %s\n", addedInstance.GetProject())
 		cmd.Printf("  Sources directory: %s\n", addedInstance.GetSourceDir())
 		cmd.Printf("  Configuration directory: %s\n", addedInstance.GetConfigDir())
 	} else {

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -1016,6 +1016,9 @@ func TestInitCmd_E2E(t *testing.T) {
 		if !strings.Contains(output, "ID:") {
 			t.Errorf("Expected verbose output to contain 'ID:', got: %s", output)
 		}
+		if !strings.Contains(output, "Project:") {
+			t.Errorf("Expected verbose output to contain 'Project:', got: %s", output)
+		}
 		if !strings.Contains(output, "Sources directory:") {
 			t.Errorf("Expected verbose output to contain 'Sources directory:', got: %s", output)
 		}
@@ -1053,6 +1056,10 @@ func TestInitCmd_E2E(t *testing.T) {
 
 		if !strings.Contains(output, inst.GetID()) {
 			t.Errorf("Expected verbose output to contain instance ID %s, got: %s", inst.GetID(), output)
+		}
+
+		if !strings.Contains(output, inst.GetProject()) {
+			t.Errorf("Expected verbose output to contain project %s, got: %s", inst.GetProject(), output)
 		}
 	})
 
@@ -1416,6 +1423,10 @@ func TestInitCmd_E2E(t *testing.T) {
 			t.Error("Expected non-empty Name in JSON output")
 		}
 
+		if workspace.Project == "" {
+			t.Error("Expected non-empty Project in JSON output")
+		}
+
 		if workspace.Paths.Source == "" {
 			t.Error("Expected non-empty Source path in JSON output")
 		}
@@ -1444,6 +1455,9 @@ func TestInitCmd_E2E(t *testing.T) {
 		}
 		if _, exists := parsed["name"]; !exists {
 			t.Error("Expected 'name' field in JSON")
+		}
+		if _, exists := parsed["project"]; !exists {
+			t.Error("Expected 'project' field in JSON")
 		}
 		if _, exists := parsed["paths"]; !exists {
 			t.Error("Expected 'paths' field in JSON")

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -92,6 +92,7 @@ func (w *workspaceListCmd) run(cmd *cobra.Command, args []string) error {
 	for _, instance := range instancesList {
 		cmd.Printf("ID: %s\n", instance.GetID())
 		cmd.Printf("  Name: %s\n", instance.GetName())
+		cmd.Printf("  Project: %s\n", instance.GetProject())
 		cmd.Printf("  Sources: %s\n", instance.GetSourceDir())
 		cmd.Printf("  Configuration: %s\n", instance.GetConfigDir())
 		cmd.Println()

--- a/pkg/cmd/workspace_list_test.go
+++ b/pkg/cmd/workspace_list_test.go
@@ -276,6 +276,10 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 		if !strings.Contains(result, expectedName) {
 			t.Errorf("Expected output to contain %q, got: %s", expectedName, result)
 		}
+		expectedProject := "  Project: " + addedInstance.GetProject()
+		if !strings.Contains(result, expectedProject) {
+			t.Errorf("Expected output to contain %q, got: %s", expectedProject, result)
+		}
 		expectedSources := "  Sources: " + sourcesDir
 		if !strings.Contains(result, expectedSources) {
 			t.Errorf("Expected output to contain %q, got: %s", expectedSources, result)
@@ -532,6 +536,9 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 		}
 		if workspace.Name != addedInstance.GetName() {
 			t.Errorf("Expected Name %s, got %s", addedInstance.GetName(), workspace.Name)
+		}
+		if workspace.Project != addedInstance.GetProject() {
+			t.Errorf("Expected Project %s, got %s", addedInstance.GetProject(), workspace.Project)
 		}
 		if workspace.Paths.Source != addedInstance.GetSourceDir() {
 			t.Errorf("Expected Source %s, got %s", addedInstance.GetSourceDir(), workspace.Paths.Source)


### PR DESCRIPTION
The init and list commands now display the project identifier in both text and JSON output formats. This helps users identify which project a workspace belongs to when managing multiple workspaces.

Closes #103