### PR TITLE
fix(cmd): output data to stdout instead of stderr (#105)

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -180,15 +180,16 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Handle text output
+	out := cmd.OutOrStdout()
 	if i.verbose {
-		cmd.Printf("Registered workspace:\n")
-		cmd.Printf("  ID: %s\n", addedInstance.GetID())
-		cmd.Printf("  Name: %s\n", addedInstance.GetName())
-		cmd.Printf("  Project: %s\n", addedInstance.GetProject())
-		cmd.Printf("  Sources directory: %s\n", addedInstance.GetSourceDir())
-		cmd.Printf("  Configuration directory: %s\n", addedInstance.GetConfigDir())
+		fmt.Fprintf(out, "Registered workspace:\n")
+		fmt.Fprintf(out, "  ID: %s\n", addedInstance.GetID())
+		fmt.Fprintf(out, "  Name: %s\n", addedInstance.GetName())
+		fmt.Fprintf(out, "  Project: %s\n", addedInstance.GetProject())
+		fmt.Fprintf(out, "  Sources directory: %s\n", addedInstance.GetSourceDir())
+		fmt.Fprintf(out, "  Configuration directory: %s\n", addedInstance.GetConfigDir())
 	} else {
-		cmd.Println(addedInstance.GetID())
+		fmt.Fprintln(out, addedInstance.GetID())
 	}
 
 	return nil

--- a/pkg/cmd/stdout_test.go
+++ b/pkg/cmd/stdout_test.go
@@ -1,0 +1,340 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kortex-hub/kortex-cli/pkg/instances"
+	"github.com/kortex-hub/kortex-cli/pkg/runtime/fake"
+)
+
+// TestCommands_OutputToStdout verifies that all commands output data to stdout (not stderr)
+// when not in JSON mode. This is important for shell script compatibility.
+func TestCommands_OutputToStdout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("init command outputs ID to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", sourcesDir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		if stdoutContent == "" {
+			t.Error("Expected output in stdout, got empty string")
+		}
+
+		// Should contain a workspace ID (64 character hex string)
+		if len(strings.TrimSpace(stdoutContent)) != 64 {
+			t.Errorf("Expected 64 character ID in stdout, got: %q", stdoutContent)
+		}
+	})
+
+	t.Run("init command with verbose outputs to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", "--verbose", sourcesDir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		if !strings.Contains(stdoutContent, "Registered workspace:") {
+			t.Errorf("Expected verbose output in stdout, got: %q", stdoutContent)
+		}
+		if !strings.Contains(stdoutContent, "ID:") {
+			t.Errorf("Expected ID in stdout, got: %q", stdoutContent)
+		}
+		if !strings.Contains(stdoutContent, "Name:") {
+			t.Errorf("Expected Name in stdout, got: %q", stdoutContent)
+		}
+	})
+
+	t.Run("list command outputs to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		// First, create a workspace
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		// Register fake runtime
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kortex"),
+			Name:      "test-workspace",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		_, err = manager.Add(context.Background(), instances.AddOptions{
+			Instance:    instance,
+			RuntimeType: "fake",
+		})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		// Now test list command
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "list"})
+
+		err = rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		if !strings.Contains(stdoutContent, "ID:") {
+			t.Errorf("Expected workspace info in stdout, got: %q", stdoutContent)
+		}
+		if !strings.Contains(stdoutContent, "test-workspace") {
+			t.Errorf("Expected workspace name in stdout, got: %q", stdoutContent)
+		}
+	})
+
+	t.Run("list command with no workspaces outputs to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "list"})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		if !strings.Contains(stdoutContent, "No workspaces registered") {
+			t.Errorf("Expected message in stdout, got: %q", stdoutContent)
+		}
+	})
+
+	t.Run("start command outputs ID to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		// First, create a workspace
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		// Register fake runtime
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kortex"),
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		added, err := manager.Add(context.Background(), instances.AddOptions{
+			Instance:    instance,
+			RuntimeType: "fake",
+		})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		// Now test start command
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "start", added.GetID()})
+
+		err = rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		expectedID := added.GetID() + "\n"
+		if stdoutContent != expectedID {
+			t.Errorf("Expected ID in stdout, got: %q (expected: %q)", stdoutContent, expectedID)
+		}
+	})
+
+	t.Run("stop command outputs ID to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		// First, create and start a workspace
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		// Register fake runtime
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kortex"),
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		added, err := manager.Add(context.Background(), instances.AddOptions{
+			Instance:    instance,
+			RuntimeType: "fake",
+		})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+		err = manager.Start(context.Background(), added.GetID())
+		if err != nil {
+			t.Fatalf("Failed to start instance: %v", err)
+		}
+
+		// Now test stop command
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "stop", added.GetID()})
+
+		err = rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		expectedID := added.GetID() + "\n"
+		if stdoutContent != expectedID {
+			t.Errorf("Expected ID in stdout, got: %q (expected: %q)", stdoutContent, expectedID)
+		}
+	})
+
+	t.Run("remove command outputs ID to stdout", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		// First, create a workspace
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		// Register fake runtime
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kortex"),
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		added, err := manager.Add(context.Background(), instances.AddOptions{
+			Instance:    instance,
+			RuntimeType: "fake",
+		})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		// Now test remove command
+		rootCmd := NewRootCmd()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "remove", added.GetID()})
+
+		err = rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify output is in stdout
+		stdoutContent := stdout.String()
+		expectedID := added.GetID() + "\n"
+		if stdoutContent != expectedID {
+			t.Errorf("Expected ID in stdout, got: %q (expected: %q)", stdoutContent, expectedID)
+		}
+	})
+}

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -84,18 +84,19 @@ func (w *workspaceListCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display the instances in text format
+	out := cmd.OutOrStdout()
 	if len(instancesList) == 0 {
-		cmd.Println("No workspaces registered")
+		fmt.Fprintln(out, "No workspaces registered")
 		return nil
 	}
 
 	for _, instance := range instancesList {
-		cmd.Printf("ID: %s\n", instance.GetID())
-		cmd.Printf("  Name: %s\n", instance.GetName())
-		cmd.Printf("  Project: %s\n", instance.GetProject())
-		cmd.Printf("  Sources: %s\n", instance.GetSourceDir())
-		cmd.Printf("  Configuration: %s\n", instance.GetConfigDir())
-		cmd.Println()
+		fmt.Fprintf(out, "ID: %s\n", instance.GetID())
+		fmt.Fprintf(out, "  Name: %s\n", instance.GetName())
+		fmt.Fprintf(out, "  Project: %s\n", instance.GetProject())
+		fmt.Fprintf(out, "  Sources: %s\n", instance.GetSourceDir())
+		fmt.Fprintf(out, "  Configuration: %s\n", instance.GetConfigDir())
+		fmt.Fprintln(out)
 	}
 
 	return nil

--- a/pkg/cmd/workspace_remove.go
+++ b/pkg/cmd/workspace_remove.go
@@ -101,7 +101,8 @@ func (w *workspaceRemoveCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Output only the ID (text mode)
-	cmd.Println(w.id)
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, w.id)
 	return nil
 }
 

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -101,7 +101,8 @@ func (w *workspaceStartCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Output only the ID (text mode)
-	cmd.Println(w.id)
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, w.id)
 	return nil
 }
 

--- a/pkg/cmd/workspace_stop.go
+++ b/pkg/cmd/workspace_stop.go
@@ -101,7 +101,8 @@ func (w *workspaceStopCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Output only the ID (text mode)
-	cmd.Println(w.id)
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, w.id)
 	return nil
 }
 


### PR DESCRIPTION
Commands were using cmd.Printf/Println which outputs to stderr by default in Cobra. This broke shell script compatibility as users couldn't pipe or capture command output. Changed to use fmt.Fprintf/Fprintln with cmd.OutOrStdout() to properly send data to stdout while keeping error messages in stderr.

Fixes #105 