### PR TITLE
feat(ui): add step logger for runtime operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,219 @@ if err := runtimesetup.RegisterAll(manager); err != nil {
 
 This automatically registers all runtimes from `pkg/runtimesetup/register.go` that report as available (e.g., only registers Podman if `podman` CLI is installed).
 
+### StepLogger System
+
+The StepLogger system provides user-facing progress feedback during runtime operations. It displays operational steps with spinners and completion messages in text mode, improving the user experience for long-running operations.
+
+**Key Components:**
+- **StepLogger Interface** (`pkg/steplogger/steplogger.go`): Contract for logging operational steps
+- **TextLogger** (`pkg/steplogger/text.go`): Implementation with spinner animations for text output
+- **NoOpLogger** (`pkg/steplogger/noop.go`): Silent implementation for JSON mode and tests
+- **Context Integration** (`pkg/steplogger/context.go`): Attach/retrieve loggers from context
+
+**Injecting StepLogger into Context:**
+
+Commands are responsible for creating and injecting the appropriate StepLogger into the context before calling runtime methods:
+
+```go
+func (c *myCmd) run(cmd *cobra.Command, args []string) error {
+    // Create appropriate logger based on output mode
+    var logger steplogger.StepLogger
+    if c.output == "json" {
+        // No step logging in JSON mode
+        logger = steplogger.NewNoOpLogger()
+    } else {
+        // Use text logger with spinners for text output
+        logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+    }
+    defer logger.Complete()
+
+    // Attach logger to context
+    ctx := steplogger.WithLogger(cmd.Context(), logger)
+
+    // Pass context to runtime methods
+    info, err := runtime.Create(ctx, params)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+```
+
+**Logger Selection Rules:**
+- **JSON mode** (`--output json`): Use `steplogger.NewNoOpLogger()` - completely silent, no output
+- **Text mode** (default): Use `steplogger.NewTextLogger(cmd.ErrOrStderr())` - displays spinners and messages to stderr
+
+**Important:**
+- Always call `defer logger.Complete()` immediately after creating the logger
+- Attach the logger to context using `steplogger.WithLogger(cmd.Context(), logger)`
+- Pass the context (not `cmd.Context()`) to all runtime methods
+- Output to stderr (`cmd.ErrOrStderr()`) so it doesn't interfere with stdout JSON output
+
+**Reference:** See `pkg/cmd/init.go`, `pkg/cmd/workspace_start.go`, `pkg/cmd/workspace_stop.go`, and `pkg/cmd/workspace_remove.go` for complete examples.
+
+**Using StepLogger in Runtime Methods:**
+
+All runtime methods that accept a `context.Context` should use the StepLogger for user feedback.
+
+**Note for Runtime Implementers:** You don't need to create or inject the StepLogger - it's already in the context. Simply retrieve it using `steplogger.FromContext(ctx)` and use it as shown below:
+
+```go
+func (r *myRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    // Step 1: Create resources
+    logger.Start("Creating workspace directory", "Workspace directory created")
+    if err := r.createDirectory(params.Name); err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    // Step 2: Build image
+    logger.Start("Building container image", "Container image built")
+    if err := r.buildImage(ctx, params.Name); err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    // Step 3: Create instance
+    logger.Start("Creating instance", "Instance created")
+    info, err := r.createInstance(ctx, params)
+    if err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    return info, nil
+}
+```
+
+**StepLogger Methods:**
+
+- **`Start(inProgress, completed string)`** - Begin a new step with progress and completion messages
+  - Automatically completes the previous step if one exists
+  - `inProgress`: Message shown while the step is running (e.g., "Building container image")
+  - `completed`: Message shown when the step completes (e.g., "Container image built")
+
+- **`Complete()`** - Mark the current step as successfully completed
+  - Typically called with `defer` at the start of the method to complete the last step
+
+- **`Fail(err error)`** - Mark the current step as failed
+  - Displays the error message to the user
+  - Should be called before returning the error
+
+**Best Practices:**
+
+1. **Always call `Complete()` with defer** at the start of the method
+2. **Use descriptive messages** that inform users about what's happening
+3. **Call `Fail()` before returning errors** to show which step failed
+4. **Retrieve logger from context** using `steplogger.FromContext(ctx)`
+5. **Don't worry about JSON mode** - the NoOpLogger is automatically used when `--output json` is set
+
+**Example Pattern for All Runtime Methods:**
+
+```go
+// Create
+func (r *myRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start("Creating resource", "Resource created")
+    // ... implementation ...
+}
+
+// Start
+func (r *myRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start("Starting instance", "Instance started")
+    // ... implementation ...
+}
+
+// Stop
+func (r *myRuntime) Stop(ctx context.Context, id string) error {
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start("Stopping instance", "Instance stopped")
+    // ... implementation ...
+}
+
+// Remove
+func (r *myRuntime) Remove(ctx context.Context, id string) error {
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start("Removing instance", "Instance removed")
+    // ... implementation ...
+}
+```
+
+**Automatic Behavior:**
+
+- **Text Mode**: Displays animated spinners during operations and completion checkmarks
+- **JSON Mode**: Silent - no output to avoid polluting JSON responses
+- **Testing**: Use `steplogger.NewNoOpLogger()` or don't attach a logger (defaults to NoOp)
+
+**Reference Implementation:**
+
+See `pkg/runtime/podman/` for complete examples:
+- `create.go` - Multi-step Create operation with 4 steps
+- `start.go` - Start operation with verification step
+- `stop.go` - Simple single-step Stop operation
+- `remove.go` - Remove operation with state checking
+
+**Testing StepLogger:**
+
+Create a fake step logger to verify step behavior in tests:
+
+```go
+// Create fake logger
+type fakeStepLogger struct {
+    startCalls    []stepCall
+    failCalls     []error
+    completeCalls int
+}
+
+type stepCall struct {
+    inProgress string
+    completed  string
+}
+
+func (f *fakeStepLogger) Start(inProgress, completed string) {
+    f.startCalls = append(f.startCalls, stepCall{inProgress, completed})
+}
+
+func (f *fakeStepLogger) Fail(err error) {
+    f.failCalls = append(f.failCalls, err)
+}
+
+func (f *fakeStepLogger) Complete() {
+    f.completeCalls++
+}
+
+// Use in tests
+func TestCreate_StepLogger(t *testing.T) {
+    fakeLogger := &fakeStepLogger{}
+    ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+    _, err := runtime.Create(ctx, params)
+
+    // Verify step calls
+    if len(fakeLogger.startCalls) != 3 {
+        t.Errorf("Expected 3 Start() calls, got %d", len(fakeLogger.startCalls))
+    }
+    if fakeLogger.completeCalls != 1 {
+        t.Errorf("Expected 1 Complete() call, got %d", fakeLogger.completeCalls)
+    }
+}
+```
+
+**Reference:** See `pkg/runtime/podman/steplogger_test.go` and step logger tests in `create_test.go`, `start_test.go`, `stop_test.go`, `remove_test.go`.
+
 ### Config System
 
 The config system manages workspace configuration stored in the `.kortex` directory. It provides an interface for reading and validating workspace settings including environment variables and mount points.

--- a/README.md
+++ b/README.md
@@ -394,16 +394,37 @@ The container's working directory is set to `/workspace/sources`, which is where
 ```bash
 # Register a workspace with the Podman runtime
 kortex-cli init /path/to/project --runtime podman
+```
 
-# Start the workspace (builds image and starts container)
+**User Experience:**
+
+When you register a workspace with the Podman runtime, you'll see progress feedback for each operation:
+
+```text
+⠋ Creating temporary build directory
+✓ Temporary build directory created
+⠋ Generating Containerfile
+✓ Containerfile generated
+⠋ Building container image: kortex-cli-myproject
+✓ Container image built
+⠋ Creating container: myproject
+✓ Container created
+```
+
+The `init` command will:
+1. Create a temporary build directory - **with progress spinner**
+2. Generate a Containerfile with the configuration above - **with progress spinner**
+3. Build a custom image (tagged as `kortex-cli-<workspace-name>`) - **with progress spinner**
+4. Create a container with your source code mounted - **with progress spinner**
+
+After registration, you can start the workspace:
+
+```bash
+# Start the workspace
 kortex-cli start <workspace-id>
 ```
 
-The first time you start a workspace, the Podman runtime will:
-1. Create a Containerfile with the configuration above
-2. Build a custom image (tagged as `kortex-cli-<workspace-name>`)
-3. Create a container with your source code mounted
-4. Start the container and make it ready for use
+**Note:** When using `--output json`, all progress spinners are hidden to avoid polluting the JSON output.
 
 ## Workspace Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/kortex-hub/kortex-cli-api/workspace-configuration/go v0.0.0-20260319072318-abc0e6182754
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/yarlson/pin v0.9.1
 )
 
 require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,5 +13,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/yarlson/pin v0.9.1 h1:ZfbMMTSpZw9X7ebq9QS6FAUq66PTv56S4WN4puO2HK0=
+github.com/yarlson/pin v0.9.1/go.mod h1:FC/d9PacAtwh05XzSznZWhA447uvimitjgDDl5YaVLE=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kortex-hub/kortex-cli/pkg/config"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
 )
 
@@ -154,6 +155,19 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the init command logic
 func (i *initCmd) run(cmd *cobra.Command, args []string) error {
+	// Create appropriate logger based on output mode
+	var logger steplogger.StepLogger
+	if i.output == "json" {
+		// No step logging in JSON mode
+		logger = steplogger.NewNoOpLogger()
+	} else {
+		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+	}
+	defer logger.Complete()
+
+	// Attach logger to context
+	ctx := steplogger.WithLogger(cmd.Context(), logger)
+
 	// Create a new instance
 	instance, err := instances.NewInstance(instances.NewInstanceParams{
 		SourceDir: i.absSourcesDir,
@@ -166,7 +180,7 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 
 	// Add the instance to the manager
 	// Manager handles config loading and merging internally
-	addedInstance, err := i.manager.Add(cmd.Context(), instances.AddOptions{
+	addedInstance, err := i.manager.Add(ctx, instances.AddOptions{
 		Instance:        instance,
 		RuntimeType:     i.runtime,
 		WorkspaceConfig: i.workspaceConfig,

--- a/pkg/cmd/workspace_remove.go
+++ b/pkg/cmd/workspace_remove.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
 )
 
@@ -83,8 +84,21 @@ func (w *workspaceRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace remove command logic
 func (w *workspaceRemoveCmd) run(cmd *cobra.Command, args []string) error {
+	// Create appropriate logger based on output mode
+	var logger steplogger.StepLogger
+	if w.output == "json" {
+		// No step logging in JSON mode
+		logger = steplogger.NewNoOpLogger()
+	} else {
+		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+	}
+	defer logger.Complete()
+
+	// Attach logger to context
+	ctx := steplogger.WithLogger(cmd.Context(), logger)
+
 	// Delete the instance
-	err := w.manager.Delete(cmd.Context(), w.id)
+	err := w.manager.Delete(ctx, w.id)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
 			if w.output == "json" {

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
 )
 
@@ -83,8 +84,21 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace start command logic
 func (w *workspaceStartCmd) run(cmd *cobra.Command, args []string) error {
+	// Create appropriate logger based on output mode
+	var logger steplogger.StepLogger
+	if w.output == "json" {
+		// No step logging in JSON mode
+		logger = steplogger.NewNoOpLogger()
+	} else {
+		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+	}
+	defer logger.Complete()
+
+	// Attach logger to context
+	ctx := steplogger.WithLogger(cmd.Context(), logger)
+
 	// Start the instance
-	err := w.manager.Start(cmd.Context(), w.id)
+	err := w.manager.Start(ctx, w.id)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
 			if w.output == "json" {

--- a/pkg/cmd/workspace_stop.go
+++ b/pkg/cmd/workspace_stop.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
 )
 
@@ -83,8 +84,21 @@ func (w *workspaceStopCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace stop command logic
 func (w *workspaceStopCmd) run(cmd *cobra.Command, args []string) error {
+	// Create appropriate logger based on output mode
+	var logger steplogger.StepLogger
+	if w.output == "json" {
+		// No step logging in JSON mode
+		logger = steplogger.NewNoOpLogger()
+	} else {
+		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+	}
+	defer logger.Complete()
+
+	// Attach logger to context
+	ctx := steplogger.WithLogger(cmd.Context(), logger)
+
 	// Stop the instance
-	err := w.manager.Stop(cmd.Context(), w.id)
+	err := w.manager.Stop(ctx, w.id)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
 			if w.output == "json" {

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 // validateDependencyPath validates that a dependency path doesn't escape above /workspace.
@@ -224,25 +225,34 @@ func (p *podmanRuntime) createContainer(ctx context.Context, args []string) (str
 
 // Create creates a new Podman runtime instance.
 func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+	logger := steplogger.FromContext(ctx)
+	defer logger.Complete()
+
 	// Validate parameters
 	if err := p.validateCreateParams(params); err != nil {
 		return runtime.RuntimeInfo{}, err
 	}
 
 	// Create instance directory
+	logger.Start("Creating temporary build directory", "Temporary build directory created")
 	instanceDir, err := p.createInstanceDirectory(params.Name)
 	if err != nil {
+		logger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
 	// Create Containerfile
+	logger.Start("Generating Containerfile", "Containerfile generated")
 	if err := p.createContainerfile(instanceDir); err != nil {
+		logger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
 	// Build image
 	imageName := fmt.Sprintf("kortex-cli-%s", params.Name)
+	logger.Start(fmt.Sprintf("Building container image: %s", imageName), "Container image built")
 	if err := p.buildImage(ctx, imageName, instanceDir); err != nil {
+		logger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
@@ -253,8 +263,10 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}
 
 	// Create container and get its ID directly from podman create output
+	logger.Start(fmt.Sprintf("Creating container: %s", params.Name), "Container created")
 	containerID, err := p.createContainer(ctx, createArgs)
 	if err != nil {
+		logger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -15,6 +15,7 @@
 package podman
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -24,6 +25,8 @@ import (
 
 	workspace "github.com/kortex-hub/kortex-cli-api/workspace-configuration/go"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+	"github.com/kortex-hub/kortex-cli/pkg/runtime/podman/exec"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 func TestValidateDependencyPath(t *testing.T) {
@@ -534,4 +537,325 @@ func TestBuildContainerArgs(t *testing.T) {
 			t.Error("Expected sleep infinity command")
 		}
 	})
+}
+
+func TestCreate_StepLogger_Success(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcePath := t.TempDir()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return nil
+	}
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte("container-id-123"), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.storageDir = storageDir
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	params := runtime.CreateParams{
+		Name:       "test-workspace",
+		SourcePath: sourcePath,
+	}
+
+	_, err := p.Create(ctx, params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify no Fail calls
+	if len(fakeLogger.failCalls) != 0 {
+		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
+	}
+
+	// Verify Start was called 4 times with correct messages
+	expectedSteps := []stepCall{
+		{
+			inProgress: "Creating temporary build directory",
+			completed:  "Temporary build directory created",
+		},
+		{
+			inProgress: "Generating Containerfile",
+			completed:  "Containerfile generated",
+		},
+		{
+			inProgress: "Building container image: kortex-cli-test-workspace",
+			completed:  "Container image built",
+		},
+		{
+			inProgress: "Creating container: test-workspace",
+			completed:  "Container created",
+		},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
+	}
+
+	for i, expected := range expectedSteps {
+		actual := fakeLogger.startCalls[i]
+		if actual.inProgress != expected.inProgress {
+			t.Errorf("Step %d: expected inProgress %q, got %q", i, expected.inProgress, actual.inProgress)
+		}
+		if actual.completed != expected.completed {
+			t.Errorf("Step %d: expected completed %q, got %q", i, expected.completed, actual.completed)
+		}
+	}
+}
+
+func TestCreate_StepLogger_FailOnCreateInstanceDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Use a file as storage dir to cause createInstanceDirectory to fail
+	storageDir := t.TempDir()
+	notADir := filepath.Join(storageDir, "file")
+	os.WriteFile(notADir, []byte("test"), 0644)
+
+	sourcePath := t.TempDir()
+
+	p := &podmanRuntime{
+		system:     &fakeSystem{},
+		executor:   exec.NewFake(),
+		storageDir: notADir, // Will fail when trying to create subdirectory
+	}
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	params := runtime.CreateParams{
+		Name:       "test-workspace",
+		SourcePath: sourcePath,
+	}
+
+	_, err := p.Create(ctx, params)
+	if err == nil {
+		t.Fatal("Expected Create() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called for the first step
+	if len(fakeLogger.startCalls) != 1 {
+		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
+	}
+
+	if fakeLogger.startCalls[0].inProgress != "Creating temporary build directory" {
+		t.Errorf("Expected first step to be 'Creating temporary build directory', got %q", fakeLogger.startCalls[0].inProgress)
+	}
+
+	// Verify Fail was called once with the error
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestCreate_StepLogger_FailOnCreateContainerfile(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcePath := t.TempDir()
+
+	// Create instance directory and a directory named "Containerfile" to cause path collision
+	instanceDir := filepath.Join(storageDir, "instances", "test-workspace")
+	os.MkdirAll(instanceDir, 0755)
+	containerfileDir := filepath.Join(instanceDir, "Containerfile")
+	os.Mkdir(containerfileDir, 0755) // This will cause os.WriteFile to fail
+	defer os.RemoveAll(containerfileDir)
+
+	p := &podmanRuntime{
+		system:     &fakeSystem{},
+		executor:   exec.NewFake(),
+		storageDir: storageDir,
+	}
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	params := runtime.CreateParams{
+		Name:       "test-workspace",
+		SourcePath: sourcePath,
+	}
+
+	_, err := p.Create(ctx, params)
+	if err == nil {
+		t.Fatal("Expected Create() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called twice (create dir, then create containerfile)
+	if len(fakeLogger.startCalls) != 2 {
+		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
+	}
+
+	expectedSteps := []string{
+		"Creating temporary build directory",
+		"Generating Containerfile",
+	}
+
+	for i, expected := range expectedSteps {
+		if fakeLogger.startCalls[i].inProgress != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, fakeLogger.startCalls[i].inProgress)
+		}
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestCreate_StepLogger_FailOnBuildImage(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcePath := t.TempDir()
+
+	fakeExec := exec.NewFake()
+	// Make Run fail on build command
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		if len(args) > 0 && args[0] == "build" {
+			return fmt.Errorf("build failed")
+		}
+		return nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.storageDir = storageDir
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	params := runtime.CreateParams{
+		Name:       "test-workspace",
+		SourcePath: sourcePath,
+	}
+
+	_, err := p.Create(ctx, params)
+	if err == nil {
+		t.Fatal("Expected Create() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called 3 times (create dir, containerfile, build image)
+	if len(fakeLogger.startCalls) != 3 {
+		t.Fatalf("Expected 3 Start() calls, got %d", len(fakeLogger.startCalls))
+	}
+
+	expectedSteps := []string{
+		"Creating temporary build directory",
+		"Generating Containerfile",
+		"Building container image: kortex-cli-test-workspace",
+	}
+
+	for i, expected := range expectedSteps {
+		if fakeLogger.startCalls[i].inProgress != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, fakeLogger.startCalls[i].inProgress)
+		}
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcePath := t.TempDir()
+
+	fakeExec := exec.NewFake()
+	// Make Run succeed for build, but Output fail for create
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return nil
+	}
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "create" {
+			return nil, fmt.Errorf("create container failed")
+		}
+		return []byte("output"), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.storageDir = storageDir
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	params := runtime.CreateParams{
+		Name:       "test-workspace",
+		SourcePath: sourcePath,
+	}
+
+	_, err := p.Create(ctx, params)
+	if err == nil {
+		t.Fatal("Expected Create() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called 4 times (all steps)
+	if len(fakeLogger.startCalls) != 4 {
+		t.Fatalf("Expected 4 Start() calls, got %d", len(fakeLogger.startCalls))
+	}
+
+	expectedSteps := []string{
+		"Creating temporary build directory",
+		"Generating Containerfile",
+		"Building container image: kortex-cli-test-workspace",
+		"Creating container: test-workspace",
+	}
+
+	for i, expected := range expectedSteps {
+		if fakeLogger.startCalls[i].inProgress != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, fakeLogger.startCalls[i].inProgress)
+		}
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
 }

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -20,32 +20,46 @@ import (
 	"strings"
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 // Remove removes a Podman container and its associated resources.
 func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
+	logger := steplogger.FromContext(ctx)
+	defer logger.Complete()
+
 	// Validate the ID parameter
 	if id == "" {
 		return fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
 	}
 
 	// Check if the container exists and get its state
+	logger.Start("Checking container state", "Container state checked")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
 		// If the container doesn't exist, treat it as already removed (idempotent)
 		if isNotFoundError(err) {
 			return nil
 		}
+		logger.Fail(err)
 		return err
 	}
 
 	// Check if the container is running
 	if info.State == "running" {
-		return fmt.Errorf("container %s is still running, stop it first", id)
+		err := fmt.Errorf("container %s is still running, stop it first", id)
+		logger.Fail(err)
+		return err
 	}
 
 	// Remove the container
-	return p.removeContainer(ctx, id)
+	logger.Start(fmt.Sprintf("Removing container: %s", id), "Container removed")
+	if err := p.removeContainer(ctx, id); err != nil {
+		logger.Fail(err)
+		return err
+	}
+
+	return nil
 }
 
 // removeContainer removes a podman container by ID.

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime/podman/exec"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 func TestRemove_ValidatesID(t *testing.T) {
@@ -244,4 +245,257 @@ func stringContains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestRemove_StepLogger_Success(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	// Set up OutputFunc to return stopped container info
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		output := fmt.Sprintf("%s|exited|kortex-cli-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Remove(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify no Fail calls
+	if len(fakeLogger.failCalls) != 0 {
+		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
+	}
+
+	// Verify Start was called 2 times with correct messages
+	expectedSteps := []stepCall{
+		{
+			inProgress: "Checking container state",
+			completed:  "Container state checked",
+		},
+		{
+			inProgress: "Removing container: abc123def456",
+			completed:  "Container removed",
+		},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
+	}
+
+	for i, expected := range expectedSteps {
+		actual := fakeLogger.startCalls[i]
+		if actual.inProgress != expected.inProgress {
+			t.Errorf("Step %d: expected inProgress %q, got %q", i, expected.inProgress, actual.inProgress)
+		}
+		if actual.completed != expected.completed {
+			t.Errorf("Step %d: expected completed %q, got %q", i, expected.completed, actual.completed)
+		}
+	}
+}
+
+func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up OutputFunc to return a "not found" error
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("no such container: %s", containerID)
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Remove(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Remove() should be idempotent for not found, got error: %v", err)
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called once (checking container state)
+	if len(fakeLogger.startCalls) != 1 {
+		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
+	}
+
+	if fakeLogger.startCalls[0].inProgress != "Checking container state" {
+		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
+	}
+
+	// Verify no Fail calls (idempotent operation)
+	if len(fakeLogger.failCalls) != 0 {
+		t.Errorf("Expected no Fail() calls for not found (idempotent), got %d", len(fakeLogger.failCalls))
+	}
+}
+
+func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up OutputFunc to return malformed output (not an error that matches isNotFoundError)
+	// This will cause getContainerInfo to fail with a parsing error
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte("invalid|output"), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Remove(ctx, containerID)
+	if err == nil {
+		t.Fatal("Expected Remove() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called once (checking container state)
+	if len(fakeLogger.startCalls) != 1 {
+		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
+	}
+
+	if fakeLogger.startCalls[0].inProgress != "Checking container state" {
+		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up OutputFunc to return a running container
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		output := fmt.Sprintf("%s|running|kortex-cli-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Remove(ctx, containerID)
+	if err == nil {
+		t.Fatal("Expected Remove() to fail for running container, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called once (checking container state)
+	if len(fakeLogger.startCalls) != 1 {
+		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
+	}
+
+	if fakeLogger.startCalls[0].inProgress != "Checking container state" {
+		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up OutputFunc to return stopped container info
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		output := fmt.Sprintf("%s|exited|kortex-cli-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	// Set up RunFunc to fail on remove
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		if len(args) > 0 && args[0] == "rm" {
+			return fmt.Errorf("failed to remove container")
+		}
+		return nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Remove(ctx, containerID)
+	if err == nil {
+		t.Fatal("Expected Remove() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called twice (checking state, removing container)
+	if len(fakeLogger.startCalls) != 2 {
+		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
+	}
+
+	expectedSteps := []string{
+		"Checking container state",
+		"Removing container: abc123",
+	}
+
+	for i, expected := range expectedSteps {
+		if fakeLogger.startCalls[i].inProgress != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, fakeLogger.startCalls[i].inProgress)
+		}
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
 }

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -19,23 +19,31 @@ import (
 	"fmt"
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 // Start starts a previously created Podman container.
 func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	logger := steplogger.FromContext(ctx)
+	defer logger.Complete()
+
 	// Validate the ID parameter
 	if id == "" {
 		return runtime.RuntimeInfo{}, fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
 	}
 
 	// Start the container
+	logger.Start(fmt.Sprintf("Starting container: %s", id), "Container started")
 	if err := p.startContainer(ctx, id); err != nil {
+		logger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
 	// Get updated container information
+	logger.Start("Verifying container status", "Container status verified")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
+		logger.Fail(err)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to get container info after start: %w", err)
 	}
 

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime/podman/exec"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 func TestStart_ValidatesID(t *testing.T) {
@@ -127,4 +128,163 @@ func TestStart_InspectFailure(t *testing.T) {
 	// Verify both Run and Output were called
 	fakeExec.AssertRunCalledWith(t, "start", containerID)
 	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
+}
+
+func TestStart_StepLogger_Success(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	// Set up OutputFunc to return container info
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		output := fmt.Sprintf("%s|running|kortex-cli-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	_, err := p.Start(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify no Fail calls
+	if len(fakeLogger.failCalls) != 0 {
+		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
+	}
+
+	// Verify Start was called 2 times with correct messages
+	expectedSteps := []stepCall{
+		{
+			inProgress: "Starting container: abc123def456",
+			completed:  "Container started",
+		},
+		{
+			inProgress: "Verifying container status",
+			completed:  "Container status verified",
+		},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
+	}
+
+	for i, expected := range expectedSteps {
+		actual := fakeLogger.startCalls[i]
+		if actual.inProgress != expected.inProgress {
+			t.Errorf("Step %d: expected inProgress %q, got %q", i, expected.inProgress, actual.inProgress)
+		}
+		if actual.completed != expected.completed {
+			t.Errorf("Step %d: expected completed %q, got %q", i, expected.completed, actual.completed)
+		}
+	}
+}
+
+func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up RunFunc to return an error
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return fmt.Errorf("container not found")
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	_, err := p.Start(ctx, containerID)
+	if err == nil {
+		t.Fatal("Expected Start() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called once (start container step)
+	if len(fakeLogger.startCalls) != 1 {
+		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
+	}
+
+	if fakeLogger.startCalls[0].inProgress != "Starting container: abc123" {
+		t.Errorf("Expected first step to be 'Starting container: abc123', got %q", fakeLogger.startCalls[0].inProgress)
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up RunFunc to succeed, but OutputFunc to fail
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return nil
+	}
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("failed to inspect container")
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	_, err := p.Start(ctx, containerID)
+	if err == nil {
+		t.Fatal("Expected Start() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called twice (start container, verify status)
+	if len(fakeLogger.startCalls) != 2 {
+		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
+	}
+
+	expectedSteps := []string{
+		"Starting container: abc123",
+		"Verifying container status",
+	}
+
+	for i, expected := range expectedSteps {
+		if fakeLogger.startCalls[i].inProgress != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, fakeLogger.startCalls[i].inProgress)
+		}
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
 }

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import "github.com/kortex-hub/kortex-cli/pkg/steplogger"
+
+// fakeStepLogger is a fake implementation of steplogger.StepLogger that records calls for testing.
+type fakeStepLogger struct {
+	startCalls    []stepCall
+	failCalls     []error
+	completeCalls int
+}
+
+type stepCall struct {
+	inProgress string
+	completed  string
+}
+
+// Ensure fakeStepLogger implements steplogger.StepLogger at compile time.
+var _ steplogger.StepLogger = (*fakeStepLogger)(nil)
+
+func (f *fakeStepLogger) Start(inProgress, completed string) {
+	f.startCalls = append(f.startCalls, stepCall{
+		inProgress: inProgress,
+		completed:  completed,
+	})
+}
+
+func (f *fakeStepLogger) Fail(err error) {
+	f.failCalls = append(f.failCalls, err)
+}
+
+func (f *fakeStepLogger) Complete() {
+	f.completeCalls++
+}

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -19,17 +19,27 @@ import (
 	"fmt"
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 // Stop stops a Podman container.
 func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
+	logger := steplogger.FromContext(ctx)
+	defer logger.Complete()
+
 	// Validate the ID parameter
 	if id == "" {
 		return fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
 	}
 
 	// Stop the container
-	return p.stopContainer(ctx, id)
+	logger.Start(fmt.Sprintf("Stopping container: %s", id), "Container stopped")
+	if err := p.stopContainer(ctx, id); err != nil {
+		logger.Fail(err)
+		return err
+	}
+
+	return nil
 }
 
 // stopContainer stops a podman container by ID.

--- a/pkg/runtime/podman/stop_test.go
+++ b/pkg/runtime/podman/stop_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime/podman/exec"
+	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 func TestStop_ValidatesID(t *testing.T) {
@@ -80,4 +81,98 @@ func TestStop_StopContainerFailure(t *testing.T) {
 
 	// Verify Run was called
 	fakeExec.AssertRunCalledWith(t, "stop", containerID)
+}
+
+func TestStop_StepLogger_Success(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Stop(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify no Fail calls
+	if len(fakeLogger.failCalls) != 0 {
+		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
+	}
+
+	// Verify Start was called once with correct messages
+	expectedSteps := []stepCall{
+		{
+			inProgress: "Stopping container: abc123def456",
+			completed:  "Container stopped",
+		},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
+	}
+
+	for i, expected := range expectedSteps {
+		actual := fakeLogger.startCalls[i]
+		if actual.inProgress != expected.inProgress {
+			t.Errorf("Step %d: expected inProgress %q, got %q", i, expected.inProgress, actual.inProgress)
+		}
+		if actual.completed != expected.completed {
+			t.Errorf("Step %d: expected completed %q, got %q", i, expected.completed, actual.completed)
+		}
+	}
+}
+
+func TestStop_StepLogger_FailOnStopContainer(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Set up RunFunc to return an error
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return fmt.Errorf("container not found")
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	err := p.Stop(ctx, containerID)
+	if err == nil {
+		t.Fatal("Expected Stop() to fail, got nil")
+	}
+
+	// Verify Complete was called once (deferred call)
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Verify Start was called once (stop container step)
+	if len(fakeLogger.startCalls) != 1 {
+		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
+	}
+
+	if fakeLogger.startCalls[0].inProgress != "Stopping container: abc123" {
+		t.Errorf("Expected first step to be 'Stopping container: abc123', got %q", fakeLogger.startCalls[0].inProgress)
+	}
+
+	// Verify Fail was called once
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
 }

--- a/pkg/steplogger/context.go
+++ b/pkg/steplogger/context.go
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package steplogger
+
+import "context"
+
+type contextKey struct{}
+
+// WithLogger returns a new context with the logger attached.
+func WithLogger(ctx context.Context, logger StepLogger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+// FromContext retrieves the logger from context.
+// Returns a NoOpLogger if no logger is in context.
+func FromContext(ctx context.Context) StepLogger {
+	if logger, ok := ctx.Value(contextKey{}).(StepLogger); ok {
+		return logger
+	}
+	return NewNoOpLogger()
+}

--- a/pkg/steplogger/context_test.go
+++ b/pkg/steplogger/context_test.go
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package steplogger
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestWithLogger_AndFromContext(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Add logger to context
+	ctx := WithLogger(context.Background(), logger)
+
+	// Retrieve logger from context
+	retrieved := FromContext(ctx)
+
+	// Should be the same logger
+	if retrieved != logger {
+		t.Error("Expected to retrieve the same logger from context")
+	}
+}
+
+func TestFromContext_NoLogger(t *testing.T) {
+	t.Parallel()
+
+	// Create context without logger
+	ctx := context.Background()
+
+	// Should return NoOpLogger
+	retrieved := FromContext(ctx)
+
+	// Verify it's a noopLogger
+	if _, ok := retrieved.(*noopLogger); !ok {
+		t.Error("Expected NoOpLogger when context has no logger")
+	}
+
+	retrieved.Start("test", "test done")
+	retrieved.Complete()
+	retrieved.Fail(nil)
+}
+
+func TestFromContext_WrongType(t *testing.T) {
+	t.Parallel()
+
+	// Create context with wrong value type
+	ctx := context.WithValue(context.Background(), contextKey{}, "not a logger")
+
+	// Should return NoOpLogger
+	retrieved := FromContext(ctx)
+
+	// Verify it's a NoOpLogger
+	if _, ok := retrieved.(*noopLogger); !ok {
+		t.Error("Expected NoOpLogger when context has no logger")
+	}
+
+	retrieved.Start("test", "test done")
+	retrieved.Complete()
+	retrieved.Fail(nil)
+}

--- a/pkg/steplogger/noop.go
+++ b/pkg/steplogger/noop.go
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package steplogger
+
+// noopLogger is a no-op implementation of StepLogger.
+// Used for tests, backward compatibility, and JSON mode.
+type noopLogger struct{}
+
+// Compile-time check to ensure noopLogger implements StepLogger interface
+var _ StepLogger = (*noopLogger)(nil)
+
+// NewNoOpLogger creates a new no-op step logger.
+func NewNoOpLogger() StepLogger {
+	return &noopLogger{}
+}
+
+// Start is a no-op.
+func (n *noopLogger) Start(inProgress, completed string) {}
+
+// Complete is a no-op.
+func (n *noopLogger) Complete() {}
+
+// Fail is a no-op.
+func (n *noopLogger) Fail(err error) {}

--- a/pkg/steplogger/steplogger.go
+++ b/pkg/steplogger/steplogger.go
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package steplogger provides interfaces and implementations for logging
+// operational steps during runtime operations.
+package steplogger
+
+// StepLogger provides an interface for logging operational steps.
+// Implementations can display steps differently based on output mode (text vs JSON).
+//
+// The Start() method takes two messages: one for in-progress state and one for completion.
+// It automatically completes the previous step with its completion message before starting a new one.
+// The Complete() method should be called with defer to complete the last step.
+// The Fail() method marks the current step as failed.
+type StepLogger interface {
+	// Start begins a new step with the given messages.
+	// The inProgress message is shown while the step is running.
+	// The completed message is shown when the step completes successfully.
+	// Automatically completes the previous step with its completion message if one exists.
+	Start(inProgress, completed string)
+
+	// Complete marks the current step as successfully completed using its completion message.
+	// Typically called with defer to complete the last step.
+	Complete()
+
+	// Fail marks the current step as failed with the given error.
+	// After failure, the step logger will not auto-complete on the next Start().
+	Fail(err error)
+}

--- a/pkg/steplogger/steplogger_test.go
+++ b/pkg/steplogger/steplogger_test.go
@@ -1,0 +1,164 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package steplogger
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNoOpLogger(t *testing.T) {
+	t.Parallel()
+
+	logger := NewNoOpLogger()
+
+	// Should not panic on any calls
+	logger.Start("test", "test complete")
+	logger.Complete()
+	logger.Fail(errors.New("test error"))
+	logger.Start("test2", "test2 complete")
+	logger.Complete()
+}
+
+func TestTextLogger_Basic(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start a step
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(100 * time.Millisecond) // Let spinner run briefly
+
+	// Complete the step
+	logger.Complete()
+
+	// Output should contain the completion message
+	output := buf.String()
+	if !strings.Contains(output, "Step 1 done") {
+		t.Errorf("Expected output to contain 'Step 1 done', got: %s", output)
+	}
+}
+
+func TestTextLogger_AutoComplete(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start first step
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Start second step (should auto-complete first)
+	logger.Start("Step 2", "Step 2 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Complete second step
+	logger.Complete()
+
+	// Output should contain both completion messages
+	output := buf.String()
+	if !strings.Contains(output, "Step 1 done") {
+		t.Errorf("Expected output to contain 'Step 1 done', got: %s", output)
+	}
+	if !strings.Contains(output, "Step 2 done") {
+		t.Errorf("Expected output to contain 'Step 2 done', got: %s", output)
+	}
+}
+
+func TestTextLogger_Fail(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start a step
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Fail the step
+	logger.Fail(errors.New("something went wrong"))
+
+	// Output should contain the error message
+	output := buf.String()
+	if !strings.Contains(output, "something went wrong") {
+		t.Errorf("Expected output to contain 'something went wrong', got: %s", output)
+	}
+	if strings.Contains(output, "Step 1 done") {
+		t.Errorf("Did not expect output to contain 'Step 1 done' after failure, got: %s", output)
+	}
+}
+
+func TestTextLogger_FailThenStart(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start a step
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Fail the step
+	logger.Fail(errors.New("step 1 failed"))
+
+	// Start another step (should not try to complete the failed step)
+	logger.Start("Step 2", "Step 2 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Complete second step
+	logger.Complete()
+
+	// Should contain error message and second completion
+	output := buf.String()
+	if !strings.Contains(output, "step 1 failed") {
+		t.Errorf("Expected output to contain 'step 1 failed', got: %s", output)
+	}
+	if !strings.Contains(output, "Step 2 done") {
+		t.Errorf("Expected output to contain 'Step 2 done', got: %s", output)
+	}
+	// Verify the failed step was not auto-completed
+	if strings.Contains(output, "Step 1 done") {
+		t.Errorf("Did not expect output to contain 'Step 1 done' after failure, got: %s", output)
+	}
+}
+
+func TestTextLogger_CompleteWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Complete without starting (should not panic)
+	logger.Complete()
+}
+
+func TestTextLogger_FailWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Fail without starting (should not panic)
+	logger.Fail(errors.New("test error"))
+}

--- a/pkg/steplogger/text.go
+++ b/pkg/steplogger/text.go
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package steplogger
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/yarlson/pin"
+)
+
+// textLogger is an implementation of StepLogger that outputs to a writer with spinners.
+type textLogger struct {
+	writer         io.Writer
+	mu             sync.Mutex
+	currentSpinner *pin.Pin
+	currentCancel  context.CancelFunc
+	completedMsg   string
+	failed         bool
+}
+
+// Compile-time check to ensure textLogger implements StepLogger interface
+var _ StepLogger = (*textLogger)(nil)
+
+// NewTextLogger creates a new text step logger that outputs to the given writer.
+func NewTextLogger(w io.Writer) StepLogger {
+	return &textLogger{
+		writer: w,
+	}
+}
+
+// Start begins a new step with the given messages.
+// Automatically completes the previous step with its completion message if one exists.
+func (t *textLogger) Start(inProgress, completed string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Auto-complete previous step if exists and wasn't failed
+	if t.currentSpinner != nil {
+		if !t.failed {
+			t.currentSpinner.Stop(t.completedMsg)
+		}
+		// Always cancel to clean up goroutines
+		if t.currentCancel != nil {
+			t.currentCancel()
+		}
+	}
+
+	// Reset failed state
+	t.failed = false
+
+	// Create and start new spinner with our writer
+	t.currentSpinner = pin.New(inProgress, pin.WithWriter(t.writer))
+	t.completedMsg = completed
+	t.currentCancel = t.currentSpinner.Start(context.Background())
+}
+
+// Complete marks the current step as successfully completed using its completion message.
+func (t *textLogger) Complete() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.currentSpinner != nil && !t.failed {
+		t.currentSpinner.Stop(t.completedMsg)
+		if t.currentCancel != nil {
+			t.currentCancel()
+		}
+		t.currentSpinner = nil
+		t.currentCancel = nil
+	}
+}
+
+// Fail marks the current step as failed with the given error.
+func (t *textLogger) Fail(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.currentSpinner != nil {
+		errMsg := "unknown error"
+		if err != nil {
+			errMsg = err.Error()
+		}
+		t.currentSpinner.Fail(errMsg)
+		if t.currentCancel != nil {
+			t.currentCancel()
+		}
+		t.failed = true
+		t.currentSpinner = nil
+		t.currentCancel = nil
+	}
+}

--- a/pkg/steplogger/text_test.go
+++ b/pkg/steplogger/text_test.go
@@ -1,0 +1,335 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package steplogger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTextLogger_CreatesSpinner(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start a step and let it run briefly
+	logger.Start("Processing", "Processed")
+	time.Sleep(100 * time.Millisecond)
+
+	// Complete the step
+	logger.Complete()
+
+	// Should have output
+	output := buf.String()
+	if output == "" {
+		t.Error("Expected output from text logger, got empty string")
+	}
+
+	// Should contain the completion message
+	if !strings.Contains(output, "Processed") {
+		t.Errorf("Expected output to contain completion message 'Processed', got: %s", output)
+	}
+}
+
+func TestTextLogger_UsesCompletionMessage(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start with specific messages
+	logger.Start("Loading data", "Data loaded successfully")
+	time.Sleep(50 * time.Millisecond)
+	logger.Complete()
+
+	output := buf.String()
+	if !strings.Contains(output, "Data loaded successfully") {
+		t.Errorf("Expected completion message 'Data loaded successfully', got: %s", output)
+	}
+}
+
+func TestTextLogger_MultipleSteps(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// First step
+	logger.Start("Step 1", "Step 1 complete")
+	time.Sleep(50 * time.Millisecond)
+
+	// Second step (auto-completes first)
+	logger.Start("Step 2", "Step 2 complete")
+	time.Sleep(50 * time.Millisecond)
+
+	// Third step (auto-completes second)
+	logger.Start("Step 3", "Step 3 complete")
+	time.Sleep(50 * time.Millisecond)
+
+	// Complete third step
+	logger.Complete()
+
+	output := buf.String()
+
+	// All completion messages should be present
+	if !strings.Contains(output, "Step 1 complete") {
+		t.Errorf("Missing 'Step 1 complete' in output: %s", output)
+	}
+	if !strings.Contains(output, "Step 2 complete") {
+		t.Errorf("Missing 'Step 2 complete' in output: %s", output)
+	}
+	if !strings.Contains(output, "Step 3 complete") {
+		t.Errorf("Missing 'Step 3 complete' in output: %s", output)
+	}
+}
+
+func TestTextLogger_FailShowsError(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	testErr := errors.New("database connection failed")
+
+	logger.Start("Connecting to database", "Connected to database")
+	time.Sleep(50 * time.Millisecond)
+	logger.Fail(testErr)
+
+	output := buf.String()
+	if !strings.Contains(output, "database connection failed") {
+		t.Errorf("Expected error message 'database connection failed', got: %s", output)
+	}
+}
+
+func TestTextLogger_FailDoesNotAutoComplete(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	logger.Start("First step", "First step done")
+	time.Sleep(50 * time.Millisecond)
+	logger.Fail(errors.New("first step failed"))
+
+	// Clear buffer to check second step
+	buf.Reset()
+
+	logger.Start("Second step", "Second step done")
+	time.Sleep(50 * time.Millisecond)
+	logger.Complete()
+
+	output := buf.String()
+
+	// Should NOT contain the first step's completion message
+	if strings.Contains(output, "First step done") {
+		t.Errorf("Failed step should not auto-complete, but output contains 'First step done': %s", output)
+	}
+
+	// Should contain the second step's completion message
+	if !strings.Contains(output, "Second step done") {
+		t.Errorf("Expected 'Second step done', got: %s", output)
+	}
+}
+
+func TestTextLogger_DeferPattern(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+
+	// Simulate the defer Complete() pattern
+	func() {
+		logger := NewTextLogger(buf)
+		defer logger.Complete()
+
+		logger.Start("Processing request", "Request processed")
+		time.Sleep(50 * time.Millisecond)
+
+		logger.Start("Saving to database", "Saved to database")
+		time.Sleep(50 * time.Millisecond)
+		// defer Complete() will complete the last step
+	}()
+
+	output := buf.String()
+
+	// Both steps should be completed
+	if !strings.Contains(output, "Request processed") {
+		t.Errorf("Missing 'Request processed' in output: %s", output)
+	}
+	if !strings.Contains(output, "Saved to database") {
+		t.Errorf("Missing 'Saved to database' in output: %s", output)
+	}
+}
+
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (sb *syncBuffer) Write(p []byte) (n int, err error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.Write(p)
+}
+
+func (sb *syncBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.String()
+}
+
+func TestTextLogger_ThreadSafety(t *testing.T) {
+	t.Parallel()
+
+	buf := &syncBuffer{}
+	logger := NewTextLogger(buf)
+
+	var wg sync.WaitGroup
+
+	// Start multiple goroutines that use the logger
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			logger.Start(
+				fmt.Sprintf("Step %d", n),
+				fmt.Sprintf("Step %d complete", n),
+			)
+			time.Sleep(10 * time.Millisecond)
+		}(i)
+	}
+
+	wg.Wait()
+	logger.Complete()
+
+	// Should not panic and should have output
+	output := buf.String()
+	if output == "" {
+		t.Error("Expected some output from concurrent operations")
+	}
+}
+
+func TestTextLogger_EmptyMessages(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Start with empty messages (edge case)
+	logger.Start("", "")
+	time.Sleep(50 * time.Millisecond)
+	logger.Complete()
+
+	// Should not panic
+}
+
+func TestTextLogger_MultipleCompletes(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Complete multiple times (should be safe)
+	logger.Complete()
+	logger.Complete()
+	logger.Complete()
+
+	// Should not panic
+}
+
+func TestTextLogger_MultipleFails(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(50 * time.Millisecond)
+
+	// Fail multiple times (only first should have effect)
+	logger.Fail(errors.New("first error"))
+	logger.Fail(errors.New("second error"))
+	logger.Fail(errors.New("third error"))
+
+	output := buf.String()
+
+	// Should contain first error
+	if !strings.Contains(output, "first error") {
+		t.Errorf("Expected 'first error', got: %s", output)
+	}
+	// Subsequent errors should not be recorded
+	if strings.Contains(output, "second error") {
+		t.Errorf("Unexpected 'second error' in output: %s", output)
+	}
+	if strings.Contains(output, "third error") {
+		t.Errorf("Unexpected 'third error' in output: %s", output)
+	}
+}
+
+func TestTextLogger_StartAfterComplete(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	logger.Start("Step 1", "Step 1 done")
+	time.Sleep(50 * time.Millisecond)
+	logger.Complete()
+
+	// Start another step after completing (should work)
+	logger.Start("Step 2", "Step 2 done")
+	time.Sleep(50 * time.Millisecond)
+	logger.Complete()
+
+	output := buf.String()
+	if !strings.Contains(output, "Step 1 done") {
+		t.Errorf("Missing 'Step 1 done' in output: %s", output)
+	}
+	if !strings.Contains(output, "Step 2 done") {
+		t.Errorf("Missing 'Step 2 done' in output: %s", output)
+	}
+}
+
+func TestTextLogger_RapidStartComplete(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := NewTextLogger(buf)
+
+	// Rapidly start and complete steps
+	for i := 0; i < 5; i++ {
+		logger.Start("Quick step", "Quick step done")
+		time.Sleep(5 * time.Millisecond)
+	}
+	logger.Complete()
+
+	output := buf.String()
+	// Should have output without panicking
+	if output == "" {
+		t.Error("Expected output from rapid operations")
+	}
+}

--- a/skills/add-command-simple/SKILL.md
+++ b/skills/add-command-simple/SKILL.md
@@ -30,6 +30,7 @@ import (
     "github.com/spf13/cobra"
     "github.com/kortex-hub/kortex-cli/pkg/instances"
     // "github.com/kortex-hub/kortex-cli/pkg/runtimesetup"  // Uncomment if registering runtimes
+    // "github.com/kortex-hub/kortex-cli/pkg/steplogger"    // Uncomment if calling runtime methods
     // Add other imports as needed
 )
 
@@ -104,6 +105,16 @@ func (c *<command>Cmd) preRun(cmd *cobra.Command, args []string) error {
 }
 
 func (c *<command>Cmd) run(cmd *cobra.Command, args []string) error {
+    // If your command calls runtime methods (Create, Start, Stop, Remove),
+    // inject StepLogger into context for user progress feedback:
+    //
+    // logger := steplogger.NewTextLogger(cmd.ErrOrStderr())
+    // defer logger.Complete()
+    // ctx := steplogger.WithLogger(cmd.Context(), logger)
+    //
+    // Then pass ctx to runtime methods:
+    // info, err := runtime.Start(ctx, workspaceID)
+
     // Perform the command logic
 
     data, err := c.manager.GetData()
@@ -284,6 +295,49 @@ make test
 ### 5. Update Documentation
 
 If the command warrants user-facing documentation, update relevant docs.
+
+## StepLogger Integration (for Runtime Operations)
+
+If your command calls runtime methods (Create, Start, Stop, Remove), you **MUST** inject a StepLogger into the context to provide user progress feedback.
+
+**When to use:**
+- Commands that call `runtime.Create()`, `runtime.Start()`, `runtime.Stop()`, or `runtime.Remove()`
+- Any command that performs long-running operations where users benefit from progress updates
+
+**How to integrate:**
+
+1. **Add the import** (uncomment in the imports section):
+```go
+"github.com/kortex-hub/kortex-cli/pkg/steplogger"
+```
+
+2. **Use in run() method** before calling runtime operations:
+```go
+func (c *<command>Cmd) run(cmd *cobra.Command, args []string) error {
+    // Create and attach logger
+    logger := steplogger.NewTextLogger(cmd.ErrOrStderr())
+    defer logger.Complete()
+    ctx := steplogger.WithLogger(cmd.Context(), logger)
+
+    // Call runtime methods with the context
+    info, err := runtime.Stop(ctx, workspaceID)
+    if err != nil {
+        return err
+    }
+
+    // ... rest of implementation
+}
+```
+
+**Benefits:**
+- Users see progress spinners during long operations (e.g., "⠋ Stopping container...")
+- Clear feedback on which step failed if an error occurs
+- Professional user experience with visual progress indicators
+
+**See also:**
+- AGENTS.md - Complete StepLogger documentation
+- `pkg/cmd/workspace_stop.go` - Example with Stop operation
+- `pkg/cmd/workspace_start.go` - Example with Start operation
 
 ## Key Points
 

--- a/skills/add-command-with-json/SKILL.md
+++ b/skills/add-command-with-json/SKILL.md
@@ -32,6 +32,7 @@ import (
     "github.com/spf13/cobra"
     "github.com/kortex-hub/kortex-cli/pkg/instances"
     // "github.com/kortex-hub/kortex-cli/pkg/runtimesetup"  // Uncomment if registering runtimes
+    // "github.com/kortex-hub/kortex-cli/pkg/steplogger"    // Uncomment if calling runtime methods
     // Add other imports as needed
 )
 
@@ -107,7 +108,28 @@ func (c *<command>Cmd) preRun(cmd *cobra.Command, args []string) error {
     return nil
 }
 
+// createStepLogger creates the appropriate StepLogger based on output mode.
+// Call this in your run() method if your command calls runtime operations.
+func (c *<command>Cmd) createStepLogger(cmd *cobra.Command) steplogger.StepLogger {
+    if c.output == "json" {
+        // No step logging in JSON mode - silent
+        return steplogger.NewNoOpLogger()
+    }
+    // Use text logger with spinners for text output
+    return steplogger.NewTextLogger(cmd.ErrOrStderr())
+}
+
 func (c *<command>Cmd) run(cmd *cobra.Command, args []string) error {
+    // If your command calls runtime methods (Create, Start, Stop, Remove),
+    // inject StepLogger into context for user progress feedback:
+    //
+    // logger := c.createStepLogger(cmd)
+    // defer logger.Complete()
+    // ctx := steplogger.WithLogger(cmd.Context(), logger)
+    //
+    // Then pass ctx to runtime methods:
+    // info, err := runtime.Create(ctx, params)
+
     // Perform the command logic
 
     // ALL errors use outputErrorIfJSON
@@ -286,6 +308,59 @@ make test
 ### 5. Update Documentation
 
 If the command warrants user-facing documentation, update relevant docs.
+
+## StepLogger Integration (for Runtime Operations)
+
+If your command calls runtime methods (Create, Start, Stop, Remove), you **MUST** inject a StepLogger into the context to provide user progress feedback.
+
+**When to use:**
+- Commands that call `runtime.Create()`, `runtime.Start()`, `runtime.Stop()`, or `runtime.Remove()`
+- Any command that performs long-running operations where users benefit from progress updates
+
+**How to integrate:**
+
+1. **Add the import** (uncomment in the imports section):
+```go
+"github.com/kortex-hub/kortex-cli/pkg/steplogger"
+```
+
+2. **Add the helper method** (already included in the template above):
+```go
+func (c *<command>Cmd) createStepLogger(cmd *cobra.Command) steplogger.StepLogger {
+    if c.output == "json" {
+        return steplogger.NewNoOpLogger()  // Silent in JSON mode
+    }
+    return steplogger.NewTextLogger(cmd.ErrOrStderr())  // Spinners in text mode
+}
+```
+
+3. **Use in run() method** before calling runtime operations:
+```go
+func (c *<command>Cmd) run(cmd *cobra.Command, args []string) error {
+    // Create and attach logger
+    logger := c.createStepLogger(cmd)
+    defer logger.Complete()
+    ctx := steplogger.WithLogger(cmd.Context(), logger)
+
+    // Call runtime methods with the context
+    info, err := runtime.Start(ctx, workspaceID)
+    if err != nil {
+        return outputErrorIfJSON(cmd, c.output, err)
+    }
+
+    // ... rest of implementation
+}
+```
+
+**Benefits:**
+- Users see progress spinners during long operations (e.g., "⠋ Starting container...")
+- Automatic silence in JSON mode (no pollution of JSON output)
+- Clear feedback on which step failed if an error occurs
+
+**See also:**
+- AGENTS.md - Complete StepLogger documentation
+- `pkg/cmd/init.go` - Example with Create operation
+- `pkg/cmd/workspace_start.go` - Example with Start operation
 
 ## Key Points
 

--- a/skills/add-runtime/SKILL.md
+++ b/skills/add-runtime/SKILL.md
@@ -33,7 +33,9 @@ package <runtime-name>
 
 import (
     "context"
+    "fmt"
     "github.com/kortex-hub/kortex-cli/pkg/runtime"
+    "github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 type <runtime-name>Runtime struct {
@@ -73,26 +75,86 @@ func (r *<runtime-name>Runtime) Available() bool {
 
 // Create creates a new runtime instance
 func (r *<runtime-name>Runtime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
-    // Implementation: create workspace on the platform
-    // Use params.Name, params.SourcePath, params.ConfigPath
-    return runtime.RuntimeInfo{}, nil
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    // Step 1: Prepare environment
+    logger.Start("Preparing workspace environment", "Workspace environment prepared")
+    if err := r.prepareEnvironment(params); err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    // Step 2: Create instance
+    logger.Start("Creating workspace instance", "Workspace instance created")
+    info, err := r.createInstance(ctx, params)
+    if err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    return info, nil
 }
 
 // Start starts a runtime instance
 func (r *<runtime-name>Runtime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
-    // Implementation: start the workspace
-    return runtime.RuntimeInfo{}, nil
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start(fmt.Sprintf("Starting workspace: %s", id), "Workspace started")
+    if err := r.startInstance(ctx, id); err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    logger.Start("Verifying workspace status", "Workspace status verified")
+    info, err := r.getInfo(ctx, id)
+    if err != nil {
+        logger.Fail(err)
+        return runtime.RuntimeInfo{}, err
+    }
+
+    return info, nil
 }
 
 // Stop stops a runtime instance
 func (r *<runtime-name>Runtime) Stop(ctx context.Context, id string) error {
-    // Implementation: stop the workspace
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start(fmt.Sprintf("Stopping workspace: %s", id), "Workspace stopped")
+    if err := r.stopInstance(ctx, id); err != nil {
+        logger.Fail(err)
+        return err
+    }
+
     return nil
 }
 
 // Remove removes a runtime instance
 func (r *<runtime-name>Runtime) Remove(ctx context.Context, id string) error {
-    // Implementation: remove the workspace
+    logger := steplogger.FromContext(ctx)
+    defer logger.Complete()
+
+    logger.Start("Checking workspace state", "Workspace state checked")
+    state, err := r.checkState(ctx, id)
+    if err != nil {
+        logger.Fail(err)
+        return err
+    }
+
+    if state == "running" {
+        err := fmt.Errorf("workspace is still running, stop it first")
+        logger.Fail(err)
+        return err
+    }
+
+    logger.Start(fmt.Sprintf("Removing workspace: %s", id), "Workspace removed")
+    if err := r.removeInstance(ctx, id); err != nil {
+        logger.Fail(err)
+        return err
+    }
+
     return nil
 }
 
@@ -124,6 +186,31 @@ var availableRuntimes = []runtimeFactory{
 }
 ```
 
+### 3.5. StepLogger Integration
+
+**IMPORTANT**: All runtime methods that accept `context.Context` MUST use StepLogger for user feedback.
+
+**Required imports:**
+```go
+import (
+    "github.com/kortex-hub/kortex-cli/pkg/steplogger"
+)
+```
+
+**Pattern:**
+1. Retrieve logger from context: `logger := steplogger.FromContext(ctx)`
+2. Defer completion: `defer logger.Complete()`
+3. Start each step: `logger.Start("In progress message", "Completion message")`
+4. Fail on errors: `logger.Fail(err)` before returning the error
+
+**Benefits:**
+- Users see progress during long-running operations
+- Clear feedback on which step failed
+- Automatic silence in JSON mode
+- No changes needed for JSON vs text output
+
+**See AGENTS.md** for complete StepLogger documentation and best practices.
+
 ### 4. Add Tests
 
 Create `pkg/runtime/<runtime-name>/<runtime-name>_test.go`:
@@ -134,6 +221,7 @@ package <runtime-name>
 import (
     "context"
     "testing"
+    "github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 func TestNew(t *testing.T) {
@@ -152,11 +240,65 @@ func TestNew(t *testing.T) {
 func TestCreate(t *testing.T) {
     t.Parallel()
 
-    // Add tests for Create method
+    // Test basic functionality
+    rt := New()
+    _, err := rt.Create(context.Background(), params)
+    if err != nil {
+        t.Fatalf("Create() failed: %v", err)
+    }
 }
 
-// Add tests for other methods...
+func TestCreate_StepLogger(t *testing.T) {
+    t.Parallel()
+
+    // Create fake step logger to track calls
+    fakeLogger := &fakeStepLogger{}
+    ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+    rt := New()
+    _, err := rt.Create(ctx, params)
+    if err != nil {
+        t.Fatalf("Create() failed: %v", err)
+    }
+
+    // Verify step logger was used correctly
+    if len(fakeLogger.startCalls) == 0 {
+        t.Error("Expected Start() to be called")
+    }
+    if fakeLogger.completeCalls != 1 {
+        t.Errorf("Expected Complete() to be called once, got %d", fakeLogger.completeCalls)
+    }
+}
+
+// Fake step logger for testing
+type fakeStepLogger struct {
+    startCalls    []stepCall
+    failCalls     []error
+    completeCalls int
+}
+
+type stepCall struct {
+    inProgress string
+    completed  string
+}
+
+func (f *fakeStepLogger) Start(inProgress, completed string) {
+    f.startCalls = append(f.startCalls, stepCall{inProgress, completed})
+}
+
+func (f *fakeStepLogger) Fail(err error) {
+    f.failCalls = append(f.failCalls, err)
+}
+
+func (f *fakeStepLogger) Complete() {
+    f.completeCalls++
+}
+
+// Add tests for other methods (Start, Stop, Remove)...
+// Each should include both functional and StepLogger tests
 ```
+
+**Reference:** See `pkg/runtime/podman/steplogger_test.go` and related test files for complete examples.
 
 ### 5. Update Copyright Headers
 


### PR DESCRIPTION
Implements a step logger system that displays progress during manager and runtime operations using terminal spinners. This provides user feedback during slow operations like container image builds.

The system includes:
- TextLogger with live spinners (using github.com/yarlson/pin)
- NoOpLogger for JSON mode and tests
- Context-based logger injection (zero breaking changes)
- Auto-complete on Start() for simplified usage

Step logging outputs to stderr to keep stdout clean for piping command results.

Closes #98

# Step Logger Implementation Plan

## Context

Issue #98 requests a step logger system to display progress during manager/runtime operations. Currently, operations like `kortex-cli init` and `kortex-cli workspace start` are silent until completion or failure, providing no feedback during slow operations (e.g., building container images with podman, which can take minutes).

The step logger will:
- Display live progress with spinners in text mode (using github.com/yarlson/pin)
- Be silent in JSON mode (no step output in JSON)
- Support both success and error scenarios
- Maintain backward compatibility with existing code

## Design Overview

### Architecture Pattern: Context-Based Logger Injection

**Key Decision:** Pass StepLogger through `context.Context` instead of changing method signatures.

**Benefits:**
- Zero breaking changes to Runtime and Manager interfaces
- Backward compatible - existing tests work without modification
- Follows Go idiom for request-scoped data
- Runtimes can opt-in by calling `steplogger.FromContext(ctx)`

### StepLogger Interface

```go
// pkg/steplogger/steplogger.go

type StepLogger interface {
    Start(inProgress, completed string)  // Begin a new step (auto-completes previous step)
    Complete()                            // Mark current step as successful
    Fail(err error)                      // Mark current step as failed
}
```

**Key Design Features:**
- `Start(inProgress, completed)` takes two messages:
  - `inProgress`: Shown while the step is running (e.g., "Building image...")
  - `completed`: Shown when the step completes successfully (e.g., "Image built")
- `Start()` automatically completes the previous step with its completion message before starting a new one
- `Complete()` can be called with `defer` to complete the last step with its completion message
- `Fail()` marks the current step as failed (no auto-complete after failure)
- Thread-safe - uses mutex internally

### Two Implementations

1. **TextLogger** - Live spinners using github.com/yarlson/pin for terminal output
2. **NoOpLogger** - No-op for tests, backward compatibility, and JSON mode

### Context Helpers

```go
// pkg/steplogger/context.go

// Attach logger to context
func WithLogger(ctx context.Context, logger StepLogger) context.Context

// Retrieve logger from context (returns NoOpLogger if none present)
func FromContext(ctx context.Context) StepLogger
```

## Implementation Sequence

### 1. Add Dependencies
- Add `github.com/yarlson/pin` to go.mod for spinner support

### 2. Create StepLogger Package

**Files to create:**
- `pkg/steplogger/steplogger.go` - Interface definitions and factory functions
- `pkg/steplogger/context.go` - Context integration (WithLogger, FromContext)
- `pkg/steplogger/noop.go` - NoOp implementation
- `pkg/steplogger/text.go` - Text/spinner implementation using pin
- `pkg/steplogger/steplogger_test.go` - Unit tests
- `pkg/steplogger/context_test.go` - Context helper tests

**Key Pattern:** All logger types are thread-safe (use sync.Mutex)

### 3. Update Runtime Implementations

**Podman Runtime** (`pkg/runtime/podman/`)

Update `create.go`:
```go
func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
    logger := steplogger.FromContext(ctx)
    defer logger.Complete() // Complete the last step

    logger.Start("Creating instance directory", "Instance directory created")
    instanceDir, err := p.createInstanceDirectory(params.Name)
    if err != nil {
        logger.Fail(err)
        return runtime.RuntimeInfo{}, err
    }

    logger.Start("Creating Containerfile", "Containerfile created") // Auto-completes previous with "Instance directory created"
    if err := p.createContainerfile(instanceDir); err != nil {
        logger.Fail(err)
        return runtime.RuntimeInfo{}, err
    }

    imageName := fmt.Sprintf("kortex-cli-%s", params.Name)
    logger.Start(fmt.Sprintf("Building container image: %s", imageName), "Container image built")
    if err := p.buildImage(ctx, imageName, instanceDir); err != nil {
        logger.Fail(err)
        return runtime.RuntimeInfo{}, err
    }

    logger.Start(fmt.Sprintf("Creating container: %s", params.Name), "Container created")
    createArgs, err := p.buildContainerArgs(params, imageName)
    if err != nil {
        logger.Fail(err)
        return runtime.RuntimeInfo{}, err
    }

    containerID, err := p.createContainer(ctx, createArgs)
    if err != nil {
        logger.Fail(err)
        return runtime.RuntimeInfo{}, err
    }
    // defer logger.Complete() completes this last step with "Container created"

    return runtime.RuntimeInfo{...}, nil
}
```

**Files to update:**
- `pkg/runtime/podman/create.go` - Add 4 steps
- `pkg/runtime/podman/start.go` - Add 2 steps
- `pkg/runtime/podman/stop.go` - Add 1 step
- `pkg/runtime/podman/remove.go` - Add 2 steps

**Fake Runtime** (optional for better test coverage):
- `pkg/runtime/fake/fake.go` - Add simulated steps

### 4. Update Commands

**Pattern for each command:**

```go
func (c *myCmd) run(cmd *cobra.Command, args []string) error {
    // Create appropriate logger based on output mode
    var logger steplogger.StepLogger

    if c.output == "json" {
        // No step logging in JSON mode
        logger = steplogger.NewNoOpLogger()
    } else {
        logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
    }
    defer logger.Complete() // Complete any pending step with its completion message

    // Attach logger to context
    ctx := steplogger.WithLogger(cmd.Context(), logger)

    // Call manager method with enhanced context
    err := c.manager.SomeOperation(ctx, ...)
    if err != nil {
        return outputErrorIfJSON(cmd, c.output, err)
    }

    // Handle JSON output (no steps)
    if c.output == "json" {
        return c.outputJSON(cmd)
    }

    // Text output
    cmd.Println(result)
    return nil
}
```

**Files to update:**
- `pkg/cmd/init.go` - Add logger creation
- `pkg/cmd/workspace_start.go` - Add logger creation
- `pkg/cmd/workspace_stop.go` - Add logger creation
- `pkg/cmd/workspace_remove.go` - Add logger creation

### 5. Add Tests

**StepLogger tests:**
- Unit tests for both logger implementations (TextLogger, NoOpLogger)
- Context helper tests (WithLogger, FromContext)
- Thread-safety tests (race detector)

**Runtime integration tests:**
- Verify correct steps are logged in text mode
- Verify step order
- Verify failure marking
- Test with NoOpLogger (backward compatibility and JSON mode)

**Command E2E tests:**
- Test JSON output works without steps (existing behavior)
- Test text mode (verify no panics, but don't test spinner output details)

### 6. Add Copyright Headers

Use `/copyright-headers` skill to add Apache 2.0 headers to all new files.

## JSON Output Format

JSON output is **unchanged** - no steps are included. The NoOpLogger is used in JSON mode, so all step logging is silently ignored.

Existing JSON responses remain as they are:

### Success Response
```json
{
  "id": "abc123"
}
```

### Error Response
```json
{
  "error": "failed to create runtime instance: failed to build podman image: exit status 1"
}
```

## Critical Files

**Core interface and factory:**
- `/workspace/sources/pkg/steplogger/steplogger.go` - Defines the entire API

**Context integration (enables zero-breaking-change rollout):**
- `/workspace/sources/pkg/steplogger/context.go` - WithLogger and FromContext helpers

**Primary integration point (most complex operation with 4+ steps):**
- `/workspace/sources/pkg/runtime/podman/create.go` - Shows how runtimes use the logger

**Command integration pattern:**
- `/workspace/sources/pkg/cmd/workspace_start.go` - Shows logger creation

## Verification

After implementation:

1. **Text mode verification:**
   ```bash
   kortex-cli init --runtime podman
   # Should show spinners for each step
   ```

2. **JSON mode verification:**
   ```bash
   kortex-cli init --runtime podman --output json
   # Should output JSON without steps (existing format unchanged)
   ```

3. **Run tests:**
   ```bash
   make test
   ```

4. **Backward compatibility:**
   - Existing tests should pass without modification
   - Commands without --output flag work as before

## Benefits

- **User experience:** Live progress feedback during slow operations
- **Debugging:** Step logs help identify where operations fail
- **Zero breaking changes:** Fully backward compatible
- **Clean design:** Follows existing code patterns and Go idioms
- **Simple API:** Auto-complete on Start() and defer Complete() make usage straightforward
