### PR TITLE
ci(release): add goreleaser config and GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          version: latest
+          version: "~> v2.14"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,10 @@
 
 version: 2
 
+before:
+  hooks:
+    - go mod tidy
+
 builds:
   - main: ./cmd/kortex-cli
     binary: kortex-cli
@@ -39,10 +43,6 @@ archives:
     format_overrides:
       - goos: windows
         formats: zip
-
-checksum:
-  name_template: checksums.txt
-  algorithm: sha256
 
 changelog:
   sort: asc


### PR DESCRIPTION
Enable automated cross-platform binary releases triggered by version tags, so consumers can download pre-built
binaries instead of building from source.

- Add `.goreleaser.yaml` to cross-compile `kortex-cli` for 6 targets: linux/darwin/windows x amd64/arm64
- Add `.github/workflows/release.yml` triggered on `v*` tags to automate GitHub Releases with goreleaser
- Version is injected at build time via ldflags into `pkg/version.Version`
- Archives are `.tar.gz` for linux/macOS and `.zip` for Windows, with SHA-256 checksums

Closes #21