### PR TITLE
docs(readme): add Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,49 @@ kortex-cli is a command-line interface for launching and managing AI agents with
 - Integrate with various LLM providers
 - Consistent interface across different agent types
 
+## Getting Started
+
+### Prerequisites
+
+- Go 1.25+
+- Make
+
+### Build
+
+```bash
+make build
+```
+
+This creates the `kortex-cli` binary in the current directory.
+
+### Run
+
+```bash
+# Display help and available commands
+./kortex-cli --help
+
+# Execute a specific command
+./kortex-cli <command> [flags]
+```
+
+### Install
+
+To install the binary to your `GOPATH/bin` for system-wide access:
+
+```bash
+make install
+```
+
+### Run Tests
+
+```bash
+# Run all tests
+make test
+
+# Run tests with coverage report
+make test-coverage
+```
+
 ## Glossary
 
 ### Agent


### PR DESCRIPTION
## Summary
- Adds a "Getting Started" section to the README with prerequisites, build, run, install, and test instructions
- Placed between the Introduction and Glossary sections for easy discoverability

## Test plan
- [ ] Verify `make build` command works as documented
- [ ] Verify `make test` command works as documented
- [ ] Review README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)