### PR TITLE
fix(cmd): hide usage help when command errors occur

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -56,11 +56,10 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", i.output)
 	}
 
-	// Silence Cobra's error and usage output when JSON mode is enabled
-	// This prevents "Error: ..." and usage info from being printed
+	// Silence Cobra's default error output to stderr when JSON mode is enabled,
+	// because we write the error in the JSON response to stdout instead
 	if i.output == "json" {
 		cmd.SilenceErrors = true
-		cmd.SilenceUsage = true
 	}
 
 	// Get storage directory from global flag

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -39,9 +39,10 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:   "kortex-cli",
-		Short: "Launch and manage AI agent workspaces with custom configurations",
-		Args:  cobra.NoArgs,
+		Use:          "kortex-cli",
+		Short:        "Launch and manage AI agent workspaces with custom configurations",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 	}
 
 	// Add subcommands

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -41,11 +41,10 @@ func (w *workspaceListCmd) preRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
 	}
 
-	// Silence Cobra's error and usage output when JSON mode is enabled
-	// This prevents "Error: ..." and usage info from being printed
+	// Silence Cobra's default error output to stderr when JSON mode is enabled,
+	// because we write the error in the JSON response to stdout instead
 	if w.output == "json" {
 		cmd.SilenceErrors = true
-		cmd.SilenceUsage = true
 	}
 
 	// Get storage directory from global flag

--- a/pkg/cmd/workspace_remove.go
+++ b/pkg/cmd/workspace_remove.go
@@ -45,11 +45,10 @@ func (w *workspaceRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
 	}
 
-	// Silence Cobra's error and usage output when JSON mode is enabled
-	// This prevents "Error: ..." and usage info from being printed
+	// Silence Cobra's default error output to stderr when JSON mode is enabled,
+	// because we write the error in the JSON response to stdout instead
 	if w.output == "json" {
 		cmd.SilenceErrors = true
-		cmd.SilenceUsage = true
 	}
 
 	w.id = args[0]

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -45,11 +45,10 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
 	}
 
-	// Silence Cobra's error and usage output when JSON mode is enabled
-	// This prevents "Error: ..." and usage info from being printed
+	// Silence Cobra's default error output to stderr when JSON mode is enabled,
+	// because we write the error in the JSON response to stdout instead
 	if w.output == "json" {
 		cmd.SilenceErrors = true
-		cmd.SilenceUsage = true
 	}
 
 	w.id = args[0]

--- a/pkg/cmd/workspace_stop.go
+++ b/pkg/cmd/workspace_stop.go
@@ -45,11 +45,10 @@ func (w *workspaceStopCmd) preRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
 	}
 
-	// Silence Cobra's error and usage output when JSON mode is enabled
-	// This prevents "Error: ..." and usage info from being printed
+	// Silence Cobra's default error output to stderr when JSON mode is enabled,
+	// because we write the error in the JSON response to stdout instead
 	if w.output == "json" {
 		cmd.SilenceErrors = true
-		cmd.SilenceUsage = true
 	}
 
 	w.id = args[0]


### PR DESCRIPTION
## Summary
- Set `SilenceUsage: true` on the root command so Cobra never prints usage/help text alongside error messages
- Removed redundant per-command `SilenceUsage` lines that were only active in JSON mode
- Kept `SilenceErrors` in JSON mode to suppress the `Error: ` prefix for clean JSON output

**Before:**
```
$ kortex-cli start aze
Error: workspace not found: aze
Use 'workspace list' to see available workspaces
Usage:
  kortex-cli start ID [flags]

Examples:
# Start workspace by ID
kortex-cli start abc123
...
```

**After:**
```
$ kortex-cli start aze
Error: workspace not found: aze
Use 'workspace list' to see available workspaces
```

Closes #102

## Test plan
- [x] All existing tests pass (`make test`)
- [x] Verified error output no longer includes help text
- [x] Verify `--help` flag still shows usage as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)