### PR TITLE
feat(logger): add --show-logs flag to surface runtime errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,26 @@ The StepLogger system provides user-facing progress feedback during runtime oper
 
 **For detailed StepLogger integration guidance, use:** `/working-with-steplogger`
 
+### Logger System
+
+The Logger system (`pkg/logger`) routes stdout and stderr from runtime CLI commands (e.g., `podman build`) to the user. It is controlled by the `--show-logs` flag.
+
+**Key Points:**
+- Commands inject a `logger.Logger` into context based on the `--show-logs` flag
+- Runtime methods retrieve it from context and pass its writers to CLI command execution
+- When `--show-logs` is set, output is written to the command's stdout/stderr; otherwise it is discarded
+- `--show-logs` cannot be combined with `--output json` (enforced in `preRun`)
+
+**Interface** (`pkg/logger/logger.go`):
+```go
+type Logger interface {
+    Stdout() io.Writer
+    Stderr() io.Writer
+}
+```
+
+**Context integration** (`pkg/logger/context.go`): `WithLogger()` / `FromContext()` — mirrors the StepLogger pattern.
+
 ### Config System
 
 The config system manages workspace configuration for **injecting environment variables and mounting directories** into workspaces (different from runtime-specific configuration).

--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ kortex-cli init [sources-directory] [flags]
 - `--project, -p <identifier>` - Custom project identifier to override auto-detection (default: auto-detected from git repository or source directory)
 - `--verbose, -v` - Show detailed output including all workspace information
 - `--output, -o <format>` - Output format (supported: `json`)
+- `--show-logs` - Show stdout and stderr from runtime commands (cannot be combined with `--output json`)
 - `--storage <path>` - Storage directory for kortex-cli data (default: `$HOME/.kortex-cli`)
 
 #### Examples
@@ -1203,6 +1204,11 @@ Output:
 **JSON output with short flags:**
 ```bash
 kortex-cli init -r fake -a claude -o json -v
+```
+
+**Show runtime command output (e.g., image build logs):**
+```bash
+kortex-cli init --runtime podman --agent claude --show-logs
 ```
 
 #### Workspace Naming
@@ -1308,6 +1314,7 @@ kortex-cli init /tmp/workspace --runtime fake --agent claude
 - JSON output format is useful for scripting and automation
 - Without `--verbose`, JSON output returns only the workspace ID
 - With `--verbose`, JSON output includes full workspace details (ID, name, agent, paths)
+- Use `--show-logs` to display the full stdout and stderr from runtime commands (e.g., `podman build` output during image creation)
 - **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure
 
 ### `workspace list` - List All Registered Workspaces
@@ -1412,6 +1419,7 @@ kortex-cli start ID [flags]
 #### Flags
 
 - `--output, -o <format>` - Output format (supported: `json`)
+- `--show-logs` - Show stdout and stderr from runtime commands (cannot be combined with `--output json`)
 - `--storage <path>` - Storage directory for kortex-cli data (default: `$HOME/.kortex-cli`)
 
 #### Examples
@@ -1450,6 +1458,11 @@ Output:
 **JSON output with short flag:**
 ```bash
 kortex-cli start a1b2c3d4e5f6... -o json
+```
+
+**Show runtime command output:**
+```bash
+kortex-cli workspace start a1b2c3d4e5f6... --show-logs
 ```
 
 #### Error Handling
@@ -1503,6 +1516,7 @@ kortex-cli stop ID [flags]
 #### Flags
 
 - `--output, -o <format>` - Output format (supported: `json`)
+- `--show-logs` - Show stdout and stderr from runtime commands (cannot be combined with `--output json`)
 - `--storage <path>` - Storage directory for kortex-cli data (default: `$HOME/.kortex-cli`)
 
 #### Examples
@@ -1541,6 +1555,11 @@ Output:
 **JSON output with short flag:**
 ```bash
 kortex-cli stop a1b2c3d4e5f6... -o json
+```
+
+**Show runtime command output:**
+```bash
+kortex-cli workspace stop a1b2c3d4e5f6... --show-logs
 ```
 
 #### Error Handling
@@ -1693,6 +1712,7 @@ kortex-cli remove ID [flags]
 #### Flags
 
 - `--output, -o <format>` - Output format (supported: `json`)
+- `--show-logs` - Show stdout and stderr from runtime commands (cannot be combined with `--output json`)
 - `--storage <path>` - Storage directory for kortex-cli data (default: `$HOME/.kortex-cli`)
 
 #### Examples
@@ -1731,6 +1751,11 @@ Output:
 **JSON output with short flag:**
 ```bash
 kortex-cli remove a1b2c3d4e5f6... -o json
+```
+
+**Show runtime command output:**
+```bash
+kortex-cli workspace remove a1b2c3d4e5f6... --show-logs
 ```
 
 #### Error Handling

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -28,6 +28,7 @@ import (
 	workspace "github.com/kortex-hub/kortex-cli-api/workspace-configuration/go"
 	"github.com/kortex-hub/kortex-cli/pkg/config"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
@@ -47,6 +48,7 @@ type initCmd struct {
 	workspaceConfig    *workspace.WorkspaceConfiguration
 	verbose            bool
 	output             string
+	showLogs           bool
 }
 
 // preRun validates the parameters and flags
@@ -54,6 +56,10 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Validate output format if specified
 	if i.output != "" && i.output != "json" {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", i.output)
+	}
+
+	if i.showLogs && i.output == "json" {
+		return fmt.Errorf("--show-logs cannot be used with --output json")
 	}
 
 	// Silence Cobra's default error output to stderr when JSON mode is enabled,
@@ -165,18 +171,26 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the init command logic
 func (i *initCmd) run(cmd *cobra.Command, args []string) error {
-	// Create appropriate logger based on output mode
-	var logger steplogger.StepLogger
+	// Create appropriate step logger based on output mode
+	var stepLogger steplogger.StepLogger
 	if i.output == "json" {
 		// No step logging in JSON mode
-		logger = steplogger.NewNoOpLogger()
+		stepLogger = steplogger.NewNoOpLogger()
 	} else {
-		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+		stepLogger = steplogger.NewTextLogger(cmd.ErrOrStderr())
 	}
-	defer logger.Complete()
+	defer stepLogger.Complete()
 
-	// Attach logger to context
-	ctx := steplogger.WithLogger(cmd.Context(), logger)
+	ctx := steplogger.WithLogger(cmd.Context(), stepLogger)
+
+	// Create appropriate logger based on --show-logs flag
+	var l logger.Logger
+	if i.showLogs {
+		l = logger.NewTextLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	} else {
+		l = logger.NewNoOpLogger()
+	}
+	ctx = logger.WithLogger(ctx, l)
 
 	// Create a new instance
 	instance, err := instances.NewInstance(instances.NewInstanceParams{
@@ -269,7 +283,10 @@ kortex-cli init --runtime fake --agent claude --name my-project
 kortex-cli init --runtime fake --agent goose --project my-custom-project
 
 # Show detailed output
-kortex-cli init --runtime fake --agent claude --verbose`,
+kortex-cli init --runtime fake --agent claude --verbose
+
+# Show runtime command output
+kortex-cli init --runtime fake --agent claude --show-logs`,
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -296,6 +313,8 @@ kortex-cli init --runtime fake --agent claude --verbose`,
 
 	// Add output flag
 	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.Flags().BoolVar(&c.showLogs, "show-logs", false, "Show stdout and stderr from runtime commands")
+
 	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
 	return cmd

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -411,6 +411,29 @@ func TestInitCmd_PreRun(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects --show-logs with --output json", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		c := &initCmd{
+			output:   "json",
+			showLogs: true,
+		}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workspace-configuration", "", "test flag")
+		cmd.Flags().String("storage", tempDir, "test storage flag")
+
+		err := c.preRun(cmd, []string{})
+		if err == nil {
+			t.Fatal("Expected preRun() to fail when --show-logs used with --output json")
+		}
+
+		if !strings.Contains(err.Error(), "--show-logs") {
+			t.Errorf("Expected error to mention '--show-logs', got: %v", err)
+		}
+	})
+
 	t.Run("outputs JSON error when manager creation fails with json output", func(t *testing.T) {
 		t.Parallel()
 
@@ -1983,7 +2006,7 @@ func TestInitCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 5
+	expectedCount := 6
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_remove.go
+++ b/pkg/cmd/workspace_remove.go
@@ -26,6 +26,7 @@ import (
 
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
@@ -33,9 +34,10 @@ import (
 
 // workspaceRemoveCmd contains the configuration for the workspace remove command
 type workspaceRemoveCmd struct {
-	manager instances.Manager
-	id      string
-	output  string
+	manager  instances.Manager
+	id       string
+	output   string
+	showLogs bool
 }
 
 // preRun validates the parameters and flags
@@ -43,6 +45,10 @@ func (w *workspaceRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Validate output format if specified
 	if w.output != "" && w.output != "json" {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
+	}
+
+	if w.showLogs && w.output == "json" {
+		return fmt.Errorf("--show-logs cannot be used with --output json")
 	}
 
 	// Silence Cobra's default error output to stderr when JSON mode is enabled,
@@ -83,18 +89,26 @@ func (w *workspaceRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace remove command logic
 func (w *workspaceRemoveCmd) run(cmd *cobra.Command, args []string) error {
-	// Create appropriate logger based on output mode
-	var logger steplogger.StepLogger
+	// Create appropriate step logger based on output mode
+	var stepLogger steplogger.StepLogger
 	if w.output == "json" {
 		// No step logging in JSON mode
-		logger = steplogger.NewNoOpLogger()
+		stepLogger = steplogger.NewNoOpLogger()
 	} else {
-		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+		stepLogger = steplogger.NewTextLogger(cmd.ErrOrStderr())
 	}
-	defer logger.Complete()
+	defer stepLogger.Complete()
 
-	// Attach logger to context
-	ctx := steplogger.WithLogger(cmd.Context(), logger)
+	ctx := steplogger.WithLogger(cmd.Context(), stepLogger)
+
+	// Create appropriate logger based on --show-logs flag
+	var l logger.Logger
+	if w.showLogs {
+		l = logger.NewTextLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	} else {
+		l = logger.NewNoOpLogger()
+	}
+	ctx = logger.WithLogger(ctx, l)
 
 	// Delete the instance
 	err := w.manager.Delete(ctx, w.id)
@@ -143,7 +157,10 @@ func NewWorkspaceRemoveCmd() *cobra.Command {
 		Short: "Remove a workspace",
 		Long:  "Remove a workspace by its ID",
 		Example: `# Remove workspace by ID
-kortex-cli workspace remove abc123`,
+kortex-cli workspace remove abc123
+
+# Remove workspace and show runtime command output
+kortex-cli workspace remove abc123 --show-logs`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeNonRunningWorkspaceID,
 		PreRunE:           c.preRun,
@@ -151,6 +168,8 @@ kortex-cli workspace remove abc123`,
 	}
 
 	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.Flags().BoolVar(&c.showLogs, "show-logs", false, "Show stdout and stderr from runtime commands")
+
 	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
 	return cmd

--- a/pkg/cmd/workspace_remove_test.go
+++ b/pkg/cmd/workspace_remove_test.go
@@ -147,6 +147,28 @@ func TestWorkspaceRemoveCmd_PreRun(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects --show-logs with --output json", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		c := &workspaceRemoveCmd{
+			output:   "json",
+			showLogs: true,
+		}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		err := c.preRun(cmd, []string{"test-id"})
+		if err == nil {
+			t.Fatal("Expected preRun() to fail when --show-logs used with --output json")
+		}
+
+		if !strings.Contains(err.Error(), "--show-logs") {
+			t.Errorf("Expected error to mention '--show-logs', got: %v", err)
+		}
+	})
+
 	t.Run("outputs JSON error when manager creation fails with json output", func(t *testing.T) {
 		t.Parallel()
 
@@ -723,7 +745,7 @@ func TestWorkspaceRemoveCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 1
+	expectedCount := 2
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -26,6 +26,7 @@ import (
 
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
@@ -33,9 +34,10 @@ import (
 
 // workspaceStartCmd contains the configuration for the workspace start command
 type workspaceStartCmd struct {
-	manager instances.Manager
-	id      string
-	output  string
+	manager  instances.Manager
+	id       string
+	output   string
+	showLogs bool
 }
 
 // preRun validates the parameters and flags
@@ -43,6 +45,10 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Validate output format if specified
 	if w.output != "" && w.output != "json" {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
+	}
+
+	if w.showLogs && w.output == "json" {
+		return fmt.Errorf("--show-logs cannot be used with --output json")
 	}
 
 	// Silence Cobra's default error output to stderr when JSON mode is enabled,
@@ -83,18 +89,26 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace start command logic
 func (w *workspaceStartCmd) run(cmd *cobra.Command, args []string) error {
-	// Create appropriate logger based on output mode
-	var logger steplogger.StepLogger
+	// Create appropriate step logger based on output mode
+	var stepLogger steplogger.StepLogger
 	if w.output == "json" {
 		// No step logging in JSON mode
-		logger = steplogger.NewNoOpLogger()
+		stepLogger = steplogger.NewNoOpLogger()
 	} else {
-		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+		stepLogger = steplogger.NewTextLogger(cmd.ErrOrStderr())
 	}
-	defer logger.Complete()
+	defer stepLogger.Complete()
 
-	// Attach logger to context
-	ctx := steplogger.WithLogger(cmd.Context(), logger)
+	ctx := steplogger.WithLogger(cmd.Context(), stepLogger)
+
+	// Create appropriate logger based on --show-logs flag
+	var l logger.Logger
+	if w.showLogs {
+		l = logger.NewTextLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	} else {
+		l = logger.NewNoOpLogger()
+	}
+	ctx = logger.WithLogger(ctx, l)
 
 	// Start the instance
 	err := w.manager.Start(ctx, w.id)
@@ -146,7 +160,10 @@ func NewWorkspaceStartCmd() *cobra.Command {
 kortex-cli workspace start abc123
 
 # Start workspace with JSON output
-kortex-cli workspace start abc123 --output json`,
+kortex-cli workspace start abc123 --output json
+
+# Start workspace and show runtime command output
+kortex-cli workspace start abc123 --show-logs`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeNonRunningWorkspaceID,
 		PreRunE:           c.preRun,
@@ -154,6 +171,8 @@ kortex-cli workspace start abc123 --output json`,
 	}
 
 	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.Flags().BoolVar(&c.showLogs, "show-logs", false, "Show stdout and stderr from runtime commands")
+
 	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
 	return cmd

--- a/pkg/cmd/workspace_start_test.go
+++ b/pkg/cmd/workspace_start_test.go
@@ -147,6 +147,28 @@ func TestWorkspaceStartCmd_PreRun(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects --show-logs with --output json", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		c := &workspaceStartCmd{
+			output:   "json",
+			showLogs: true,
+		}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		err := c.preRun(cmd, []string{"test-id"})
+		if err == nil {
+			t.Fatal("Expected preRun() to fail when --show-logs used with --output json")
+		}
+
+		if !strings.Contains(err.Error(), "--show-logs") {
+			t.Errorf("Expected error to mention '--show-logs', got: %v", err)
+		}
+	})
+
 	t.Run("outputs JSON error when manager creation fails with json output", func(t *testing.T) {
 		t.Parallel()
 
@@ -717,7 +739,7 @@ func TestWorkspaceStartCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 2
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_stop.go
+++ b/pkg/cmd/workspace_stop.go
@@ -26,6 +26,7 @@ import (
 
 	api "github.com/kortex-hub/kortex-cli-api/cli/go"
 	"github.com/kortex-hub/kortex-cli/pkg/instances"
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtimesetup"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 	"github.com/spf13/cobra"
@@ -33,9 +34,10 @@ import (
 
 // workspaceStopCmd contains the configuration for the workspace stop command
 type workspaceStopCmd struct {
-	manager instances.Manager
-	id      string
-	output  string
+	manager  instances.Manager
+	id       string
+	output   string
+	showLogs bool
 }
 
 // preRun validates the parameters and flags
@@ -43,6 +45,10 @@ func (w *workspaceStopCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Validate output format if specified
 	if w.output != "" && w.output != "json" {
 		return fmt.Errorf("unsupported output format: %s (supported: json)", w.output)
+	}
+
+	if w.showLogs && w.output == "json" {
+		return fmt.Errorf("--show-logs cannot be used with --output json")
 	}
 
 	// Silence Cobra's default error output to stderr when JSON mode is enabled,
@@ -83,18 +89,26 @@ func (w *workspaceStopCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace stop command logic
 func (w *workspaceStopCmd) run(cmd *cobra.Command, args []string) error {
-	// Create appropriate logger based on output mode
-	var logger steplogger.StepLogger
+	// Create appropriate step logger based on output mode
+	var stepLogger steplogger.StepLogger
 	if w.output == "json" {
 		// No step logging in JSON mode
-		logger = steplogger.NewNoOpLogger()
+		stepLogger = steplogger.NewNoOpLogger()
 	} else {
-		logger = steplogger.NewTextLogger(cmd.ErrOrStderr())
+		stepLogger = steplogger.NewTextLogger(cmd.ErrOrStderr())
 	}
-	defer logger.Complete()
+	defer stepLogger.Complete()
 
-	// Attach logger to context
-	ctx := steplogger.WithLogger(cmd.Context(), logger)
+	ctx := steplogger.WithLogger(cmd.Context(), stepLogger)
+
+	// Create appropriate logger based on --show-logs flag
+	var l logger.Logger
+	if w.showLogs {
+		l = logger.NewTextLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	} else {
+		l = logger.NewNoOpLogger()
+	}
+	ctx = logger.WithLogger(ctx, l)
 
 	// Stop the instance
 	err := w.manager.Stop(ctx, w.id)
@@ -146,7 +160,10 @@ func NewWorkspaceStopCmd() *cobra.Command {
 kortex-cli workspace stop abc123
 
 # Stop workspace with JSON output
-kortex-cli workspace stop abc123 --output json`,
+kortex-cli workspace stop abc123 --output json
+
+# Stop workspace and show runtime command output
+kortex-cli workspace stop abc123 --show-logs`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeRunningWorkspaceID,
 		PreRunE:           c.preRun,
@@ -154,6 +171,8 @@ kortex-cli workspace stop abc123 --output json`,
 	}
 
 	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.Flags().BoolVar(&c.showLogs, "show-logs", false, "Show stdout and stderr from runtime commands")
+
 	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
 	return cmd

--- a/pkg/cmd/workspace_stop_test.go
+++ b/pkg/cmd/workspace_stop_test.go
@@ -147,6 +147,28 @@ func TestWorkspaceStopCmd_PreRun(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects --show-logs with --output json", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		c := &workspaceStopCmd{
+			output:   "json",
+			showLogs: true,
+		}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		err := c.preRun(cmd, []string{"test-id"})
+		if err == nil {
+			t.Fatal("Expected preRun() to fail when --show-logs used with --output json")
+		}
+
+		if !strings.Contains(err.Error(), "--show-logs") {
+			t.Errorf("Expected error to mention '--show-logs', got: %v", err)
+		}
+	})
+
 	t.Run("outputs JSON error when manager creation fails with json output", func(t *testing.T) {
 		t.Parallel()
 
@@ -767,7 +789,7 @@ func TestWorkspaceStopCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 2
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/logger/context.go
+++ b/pkg/logger/context.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import "context"
+
+type contextKey struct{}
+
+// WithLogger returns a new context with the logger attached.
+func WithLogger(ctx context.Context, l Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, l)
+}
+
+// FromContext retrieves the logger from context.
+// Returns a NoOpLogger if no logger is in context.
+func FromContext(ctx context.Context) Logger {
+	if l, ok := ctx.Value(contextKey{}).(Logger); ok {
+		return l
+	}
+	return NewNoOpLogger()
+}

--- a/pkg/logger/context_test.go
+++ b/pkg/logger/context_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestWithLogger_AndFromContext(t *testing.T) {
+	t.Parallel()
+
+	l := NewTextLogger(&bytes.Buffer{}, &bytes.Buffer{})
+
+	ctx := WithLogger(context.Background(), l)
+
+	retrieved := FromContext(ctx)
+
+	if retrieved != l {
+		t.Error("Expected to retrieve the same logger from context")
+	}
+}
+
+func TestFromContext_NoLogger(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	retrieved := FromContext(ctx)
+
+	if _, ok := retrieved.(*noopLogger); !ok {
+		t.Error("Expected noopLogger when context has no logger")
+	}
+}
+
+func TestFromContext_WrongType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), contextKey{}, "not a logger")
+
+	retrieved := FromContext(ctx)
+
+	if _, ok := retrieved.(*noopLogger); !ok {
+		t.Error("Expected noopLogger when context value is wrong type")
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logger provides interfaces and implementations for routing
+// stdout/stderr output from runtime CLI commands to the user.
+package logger
+
+import "io"
+
+// Logger provides writers for routing stdout and stderr of runtime CLI commands.
+type Logger interface {
+	// Stdout returns the writer for standard output from runtime commands.
+	Stdout() io.Writer
+
+	// Stderr returns the writer for standard error from runtime commands.
+	Stderr() io.Writer
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestNoOpLogger_DiscardOutput(t *testing.T) {
+	t.Parallel()
+
+	l := NewNoOpLogger()
+
+	if l.Stdout() != io.Discard {
+		t.Error("Expected noopLogger.Stdout() to return io.Discard")
+	}
+
+	if l.Stderr() != io.Discard {
+		t.Error("Expected noopLogger.Stderr() to return io.Discard")
+	}
+}
+
+func TestNoOpLogger_WritesAreDiscarded(t *testing.T) {
+	t.Parallel()
+
+	l := NewNoOpLogger()
+
+	n, err := l.Stdout().Write([]byte("stdout data"))
+	if err != nil {
+		t.Errorf("Unexpected error writing to Stdout: %v", err)
+	}
+	if n != 11 {
+		t.Errorf("Expected 11 bytes written, got %d", n)
+	}
+
+	n, err = l.Stderr().Write([]byte("stderr data"))
+	if err != nil {
+		t.Errorf("Unexpected error writing to Stderr: %v", err)
+	}
+	if n != 11 {
+		t.Errorf("Expected 11 bytes written, got %d", n)
+	}
+}
+
+func TestTextLogger_WritesToProviders(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	l := NewTextLogger(stdout, stderr)
+
+	if _, err := l.Stdout().Write([]byte("stdout data")); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if _, err := l.Stderr().Write([]byte("stderr data")); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if stdout.String() != "stdout data" {
+		t.Errorf("Expected stdout to contain 'stdout data', got: %q", stdout.String())
+	}
+	if stderr.String() != "stderr data" {
+		t.Errorf("Expected stderr to contain 'stderr data', got: %q", stderr.String())
+	}
+}
+
+func TestTextLogger_IndependentWriters(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	l := NewTextLogger(stdout, stderr)
+
+	l.Stdout().Write([]byte("out"))
+	l.Stderr().Write([]byte("err"))
+
+	if stderr.String() == stdout.String() {
+		t.Error("Expected stdout and stderr to be independent writers")
+	}
+}

--- a/pkg/logger/noop.go
+++ b/pkg/logger/noop.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import "io"
+
+// noopLogger is a no-op implementation of Logger that discards all output.
+type noopLogger struct{}
+
+// Compile-time check to ensure noopLogger implements Logger interface.
+var _ Logger = (*noopLogger)(nil)
+
+// NewNoOpLogger creates a new no-op logger.
+func NewNoOpLogger() Logger {
+	return &noopLogger{}
+}
+
+// Stdout returns a writer that discards all output.
+func (n *noopLogger) Stdout() io.Writer { return io.Discard }
+
+// Stderr returns a writer that discards all output.
+func (n *noopLogger) Stderr() io.Writer { return io.Discard }

--- a/pkg/logger/text.go
+++ b/pkg/logger/text.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import "io"
+
+// textLogger is an implementation of Logger that writes to the provided writers.
+type textLogger struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// Compile-time check to ensure textLogger implements Logger interface.
+var _ Logger = (*textLogger)(nil)
+
+// NewTextLogger creates a new logger that writes to the given stdout and stderr writers.
+// If either writer is nil, it defaults to io.Discard.
+func NewTextLogger(stdout, stderr io.Writer) Logger {
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	return &textLogger{
+		stdout: stdout,
+		stderr: stderr,
+	}
+}
+
+// Stdout returns the writer for standard output.
+func (t *textLogger) Stdout() io.Writer { return t.stdout }
+
+// Stderr returns the writer for standard error.
+func (t *textLogger) Stderr() io.Writer { return t.stderr }

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime/podman/config"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime/podman/constants"
@@ -128,7 +129,8 @@ func (p *podmanRuntime) buildImage(ctx context.Context, imageName, instanceDir s
 		instanceDir,
 	}
 
-	if err := p.executor.Run(ctx, args...); err != nil {
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), args...); err != nil {
 		return fmt.Errorf("failed to build podman image: %w", err)
 	}
 	return nil
@@ -206,7 +208,8 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 
 // createContainer creates a podman container and returns its ID.
 func (p *podmanRuntime) createContainer(ctx context.Context, args []string) (string, error) {
-	output, err := p.executor.Output(ctx, args...)
+	l := logger.FromContext(ctx)
+	output, err := p.executor.Output(ctx, l.Stderr(), args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create podman container: %w", err)
 	}
@@ -215,8 +218,8 @@ func (p *podmanRuntime) createContainer(ctx context.Context, args []string) (str
 
 // Create creates a new Podman runtime instance.
 func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
-	logger := steplogger.FromContext(ctx)
-	defer logger.Complete()
+	stepLogger := steplogger.FromContext(ctx)
+	defer stepLogger.Complete()
 
 	// Validate parameters
 	if err := p.validateCreateParams(params); err != nil {
@@ -224,10 +227,10 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}
 
 	// Create instance directory
-	logger.Start("Creating temporary build directory", "Temporary build directory created")
+	stepLogger.Start("Creating temporary build directory", "Temporary build directory created")
 	instanceDir, err := p.createInstanceDirectory(params.Name)
 	if err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 	// Clean up instance directory after use (whether success or error)
@@ -247,17 +250,17 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}
 
 	// Create Containerfile
-	logger.Start("Generating Containerfile", "Containerfile generated")
+	stepLogger.Start("Generating Containerfile", "Containerfile generated")
 	if err := p.createContainerfile(instanceDir, imageConfig, agentConfig); err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
 	// Build image
 	imageName := fmt.Sprintf("kortex-cli-%s", params.Name)
-	logger.Start(fmt.Sprintf("Building container image: %s", imageName), "Container image built")
+	stepLogger.Start(fmt.Sprintf("Building container image: %s", imageName), "Container image built")
 	if err := p.buildImage(ctx, imageName, instanceDir); err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
@@ -268,10 +271,10 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}
 
 	// Create container and get its ID directly from podman create output
-	logger.Start(fmt.Sprintf("Creating container: %s", params.Name), "Container created")
+	stepLogger.Start(fmt.Sprintf("Creating container: %s", params.Name), "Container created")
 	containerID, err := p.createContainer(ctx, createArgs)
 	if err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1075,11 +1076,11 @@ type fakeExecutor struct {
 	output    []byte
 }
 
-func (f *fakeExecutor) Run(ctx context.Context, args ...string) error {
+func (f *fakeExecutor) Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
 	return f.runErr
 }
 
-func (f *fakeExecutor) Output(ctx context.Context, args ...string) ([]byte, error) {
+func (f *fakeExecutor) Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error) {
 	if f.outputErr != nil {
 		return nil, f.outputErr
 	}

--- a/pkg/runtime/podman/exec/exec.go
+++ b/pkg/runtime/podman/exec/exec.go
@@ -17,19 +17,21 @@ package exec
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 )
 
 // Executor provides an interface for executing podman commands.
 type Executor interface {
-	// Run executes a podman command and waits for it to complete.
+	// Run executes a podman command, writing stdout and stderr to the provided writers.
 	// Returns an error if the command fails.
-	Run(ctx context.Context, args ...string) error
+	Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error
 
 	// Output executes a podman command and returns its standard output.
+	// Stderr is written to the provided writer.
 	// Returns an error if the command fails.
-	Output(ctx context.Context, args ...string) ([]byte, error)
+	Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error)
 
 	// RunInteractive executes a podman command with stdin/stdout/stderr connected to the terminal.
 	// This is used for interactive sessions where user input is required.
@@ -48,15 +50,19 @@ func New() Executor {
 	return &executor{}
 }
 
-// Run executes a podman command and waits for it to complete.
-func (e *executor) Run(ctx context.Context, args ...string) error {
+// Run executes a podman command, writing stdout and stderr to the provided writers.
+func (e *executor) Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
 	cmd := exec.CommandContext(ctx, "podman", args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	return cmd.Run()
 }
 
 // Output executes a podman command and returns its standard output.
-func (e *executor) Output(ctx context.Context, args ...string) ([]byte, error) {
+// Stderr is written to the provided writer.
+func (e *executor) Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "podman", args...)
+	cmd.Stderr = stderr
 	return cmd.Output()
 }
 

--- a/pkg/runtime/podman/exec/fake.go
+++ b/pkg/runtime/podman/exec/fake.go
@@ -16,6 +16,7 @@ package exec
 
 import (
 	"context"
+	"io"
 )
 
 // FakeExecutor is a fake implementation of Executor for testing.
@@ -52,7 +53,7 @@ func NewFake() *FakeExecutor {
 }
 
 // Run executes the RunFunc if set, otherwise returns nil.
-func (f *FakeExecutor) Run(ctx context.Context, args ...string) error {
+func (f *FakeExecutor) Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
 	f.RunCalls = append(f.RunCalls, args)
 	if f.RunFunc != nil {
 		return f.RunFunc(ctx, args...)
@@ -61,7 +62,7 @@ func (f *FakeExecutor) Run(ctx context.Context, args ...string) error {
 }
 
 // Output executes the OutputFunc if set, otherwise returns empty bytes.
-func (f *FakeExecutor) Output(ctx context.Context, args ...string) ([]byte, error) {
+func (f *FakeExecutor) Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error) {
 	f.OutputCalls = append(f.OutputCalls, args)
 	if f.OutputFunc != nil {
 		return f.OutputFunc(ctx, args...)

--- a/pkg/runtime/podman/info.go
+++ b/pkg/runtime/podman/info.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 )
 
@@ -42,7 +43,8 @@ func (p *podmanRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInf
 func (p *podmanRuntime) getContainerInfo(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
 	// Use podman inspect to get container details in a format we can parse
 	// Format: ID|State|ImageName (custom fields from creation)
-	output, err := p.executor.Output(ctx, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", id)
+	l := logger.FromContext(ctx)
+	output, err := p.executor.Output(ctx, l.Stderr(), "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", id)
 	if err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to inspect container: %w", err)
 	}

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -19,14 +19,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 // Remove removes a Podman container and its associated resources.
 func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
-	logger := steplogger.FromContext(ctx)
-	defer logger.Complete()
+	stepLogger := steplogger.FromContext(ctx)
+	defer stepLogger.Complete()
 
 	// Validate the ID parameter
 	if id == "" {
@@ -34,28 +35,28 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	}
 
 	// Check if the container exists and get its state
-	logger.Start("Checking container state", "Container state checked")
+	stepLogger.Start("Checking container state", "Container state checked")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
 		// If the container doesn't exist, treat it as already removed (idempotent)
 		if isNotFoundError(err) {
 			return nil
 		}
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return err
 	}
 
 	// Check if the container is running
 	if info.State == "running" {
 		err := fmt.Errorf("container %s is still running, stop it first", id)
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return err
 	}
 
 	// Remove the container
-	logger.Start(fmt.Sprintf("Removing container: %s", id), "Container removed")
+	stepLogger.Start(fmt.Sprintf("Removing container: %s", id), "Container removed")
 	if err := p.removeContainer(ctx, id); err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return err
 	}
 
@@ -64,7 +65,8 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 
 // removeContainer removes a podman container by ID.
 func (p *podmanRuntime) removeContainer(ctx context.Context, id string) error {
-	if err := p.executor.Run(ctx, "rm", id); err != nil {
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "rm", id); err != nil {
 		return fmt.Errorf("failed to remove podman container: %w", err)
 	}
 	return nil

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -18,14 +18,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
 // Start starts a previously created Podman container.
 func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
-	logger := steplogger.FromContext(ctx)
-	defer logger.Complete()
+	stepLogger := steplogger.FromContext(ctx)
+	defer stepLogger.Complete()
 
 	// Validate the ID parameter
 	if id == "" {
@@ -33,17 +34,17 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	}
 
 	// Start the container
-	logger.Start(fmt.Sprintf("Starting container: %s", id), "Container started")
+	stepLogger.Start(fmt.Sprintf("Starting container: %s", id), "Container started")
 	if err := p.startContainer(ctx, id); err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
 	// Get updated container information
-	logger.Start("Verifying container status", "Container status verified")
+	stepLogger.Start("Verifying container status", "Container status verified")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
-		logger.Fail(err)
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to get container info after start: %w", err)
 	}
 
@@ -52,7 +53,8 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 
 // startContainer starts a podman container by ID.
 func (p *podmanRuntime) startContainer(ctx context.Context, id string) error {
-	if err := p.executor.Run(ctx, "start", id); err != nil {
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", id); err != nil {
 		return fmt.Errorf("failed to start podman container: %w", err)
 	}
 	return nil

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kortex-hub/kortex-cli/pkg/logger"
 	"github.com/kortex-hub/kortex-cli/pkg/runtime"
 	"github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
@@ -44,7 +45,8 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 
 // stopContainer stops a podman container by ID.
 func (p *podmanRuntime) stopContainer(ctx context.Context, id string) error {
-	if err := p.executor.Run(ctx, "stop", id); err != nil {
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "stop", id); err != nil {
 		return fmt.Errorf("failed to stop podman container: %w", err)
 	}
 	return nil

--- a/skills/add-runtime/SKILL.md
+++ b/skills/add-runtime/SKILL.md
@@ -35,6 +35,7 @@ import (
     "context"
     "fmt"
     "github.com/kortex-hub/kortex-cli/pkg/runtime"
+    "github.com/kortex-hub/kortex-cli/pkg/logger"  // Optional: only if executing external commands
     "github.com/kortex-hub/kortex-cli/pkg/steplogger"
 )
 
@@ -75,21 +76,21 @@ func (r *<runtime-name>Runtime) Available() bool {
 
 // Create creates a new runtime instance
 func (r *<runtime-name>Runtime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
-    logger := steplogger.FromContext(ctx)
-    defer logger.Complete()
+    stepLogger := steplogger.FromContext(ctx)
+    defer stepLogger.Complete()
 
     // Step 1: Prepare environment
-    logger.Start("Preparing workspace environment", "Workspace environment prepared")
+    stepLogger.Start("Preparing workspace environment", "Workspace environment prepared")
     if err := r.prepareEnvironment(params); err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return runtime.RuntimeInfo{}, err
     }
 
     // Step 2: Create instance
-    logger.Start("Creating workspace instance", "Workspace instance created")
+    stepLogger.Start("Creating workspace instance", "Workspace instance created")
     info, err := r.createInstance(ctx, params)
     if err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return runtime.RuntimeInfo{}, err
     }
 
@@ -98,19 +99,19 @@ func (r *<runtime-name>Runtime) Create(ctx context.Context, params runtime.Creat
 
 // Start starts a runtime instance
 func (r *<runtime-name>Runtime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
-    logger := steplogger.FromContext(ctx)
-    defer logger.Complete()
+    stepLogger := steplogger.FromContext(ctx)
+    defer stepLogger.Complete()
 
-    logger.Start(fmt.Sprintf("Starting workspace: %s", id), "Workspace started")
+    stepLogger.Start(fmt.Sprintf("Starting workspace: %s", id), "Workspace started")
     if err := r.startInstance(ctx, id); err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return runtime.RuntimeInfo{}, err
     }
 
-    logger.Start("Verifying workspace status", "Workspace status verified")
+    stepLogger.Start("Verifying workspace status", "Workspace status verified")
     info, err := r.getInfo(ctx, id)
     if err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return runtime.RuntimeInfo{}, err
     }
 
@@ -119,12 +120,12 @@ func (r *<runtime-name>Runtime) Start(ctx context.Context, id string) (runtime.R
 
 // Stop stops a runtime instance
 func (r *<runtime-name>Runtime) Stop(ctx context.Context, id string) error {
-    logger := steplogger.FromContext(ctx)
-    defer logger.Complete()
+    stepLogger := steplogger.FromContext(ctx)
+    defer stepLogger.Complete()
 
-    logger.Start(fmt.Sprintf("Stopping workspace: %s", id), "Workspace stopped")
+    stepLogger.Start(fmt.Sprintf("Stopping workspace: %s", id), "Workspace stopped")
     if err := r.stopInstance(ctx, id); err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return err
     }
 
@@ -133,25 +134,25 @@ func (r *<runtime-name>Runtime) Stop(ctx context.Context, id string) error {
 
 // Remove removes a runtime instance
 func (r *<runtime-name>Runtime) Remove(ctx context.Context, id string) error {
-    logger := steplogger.FromContext(ctx)
-    defer logger.Complete()
+    stepLogger := steplogger.FromContext(ctx)
+    defer stepLogger.Complete()
 
-    logger.Start("Checking workspace state", "Workspace state checked")
+    stepLogger.Start("Checking workspace state", "Workspace state checked")
     state, err := r.checkState(ctx, id)
     if err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return err
     }
 
     if state == "running" {
         err := fmt.Errorf("workspace is still running, stop it first")
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return err
     }
 
-    logger.Start(fmt.Sprintf("Removing workspace: %s", id), "Workspace removed")
+    stepLogger.Start(fmt.Sprintf("Removing workspace: %s", id), "Workspace removed")
     if err := r.removeInstance(ctx, id); err != nil {
-        logger.Fail(err)
+        stepLogger.Fail(err)
         return err
     }
 
@@ -198,10 +199,10 @@ import (
 ```
 
 **Pattern:**
-1. Retrieve logger from context: `logger := steplogger.FromContext(ctx)`
-2. Defer completion: `defer logger.Complete()`
-3. Start each step: `logger.Start("In progress message", "Completion message")`
-4. Fail on errors: `logger.Fail(err)` before returning the error
+1. Retrieve logger from context: `stepLogger := steplogger.FromContext(ctx)`
+2. Defer completion: `defer stepLogger.Complete()`
+3. Start each step: `stepLogger.Start("In progress message", "Completion message")`
+4. Fail on errors: `stepLogger.Fail(err)` before returning the error
 
 **Benefits:**
 - Users see progress during long-running operations
@@ -210,6 +211,36 @@ import (
 - No changes needed for JSON vs text output
 
 **See AGENTS.md** for complete StepLogger documentation and best practices.
+
+### 3.6. Logger Integration (for CLI Command Execution)
+
+If your runtime executes external CLI commands (e.g., via `exec.Command`), use `pkg/logger` to route stdout/stderr to the user when `--show-logs` is passed.
+
+**Required imports:**
+```go
+import (
+    "github.com/kortex-hub/kortex-cli/pkg/logger"
+)
+```
+
+**Pattern — retrieve from context and pass to exec:**
+```go
+func (r *<runtime-name>Runtime) runSomething(ctx context.Context, args ...string) error {
+    l := logger.FromContext(ctx)
+    cmd := exec.CommandContext(ctx, "<tool>", args...)
+    cmd.Stdout = l.Stdout()
+    cmd.Stderr = l.Stderr()
+    return cmd.Run()
+}
+```
+
+**Variable naming convention:**
+- Use `stepLogger` for `steplogger.StepLogger`
+- Use `l` for `logger.Logger`
+
+**When `--show-logs` is not set**, `logger.FromContext` returns a no-op logger that discards all output, so the pattern is safe to use unconditionally.
+
+**See AGENTS.md** for the `--show-logs` flag pattern and complete Logger documentation.
 
 ### 4. Add Tests
 

--- a/skills/implementing-command-patterns/SKILL.md
+++ b/skills/implementing-command-patterns/SKILL.md
@@ -224,6 +224,68 @@ func outputErrorIfJSON(cmd interface{ OutOrStdout() io.Writer }, output string, 
 
 **Reference:** See `pkg/cmd/init.go`, `pkg/cmd/workspace_remove.go`, and `pkg/cmd/workspace_list.go` for complete implementations.
 
+## The --show-logs Flag Pattern
+
+Commands that trigger runtime CLI execution (e.g., `podman build`, `podman start`) should expose a `--show-logs` flag to let users see the raw stdout/stderr from those commands.
+
+### Rules
+
+1. Add `showLogs bool` to the command struct bound to `--show-logs`
+2. In `preRun`, reject the combination of `--show-logs` and `--output json`
+3. In `run`, create a `logger.Logger` from the flag value and inject it into context
+4. (Optional) For progress feedback, also create a `steplogger.StepLogger` as shown in `/working-with-steplogger`
+### Pattern
+
+```go
+import (
+    "github.com/kortex-hub/kortex-cli/pkg/logger"
+    "github.com/kortex-hub/kortex-cli/pkg/steplogger"
+)
+
+type myCmd struct {
+    output   string
+    showLogs bool
+    manager  instances.Manager
+}
+
+func (m *myCmd) preRun(cmd *cobra.Command, args []string) error {
+    if m.output != "" && m.output != "json" {
+        return fmt.Errorf("unsupported output format: %s (supported: json)", m.output)
+    }
+    if m.showLogs && m.output == "json" {
+        return fmt.Errorf("--show-logs cannot be used with --output json")
+    }
+    // ... rest of preRun
+}
+
+func (m *myCmd) run(cmd *cobra.Command, args []string) error {
+    var l logger.Logger
+    if m.showLogs {
+        l = logger.NewTextLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+    } else {
+        l = logger.NewNoOpLogger()
+    }
+    ctx := logger.WithLogger(cmd.Context(), l)
+
+    return m.manager.DoSomething(ctx)
+}
+
+func NewMyCmd() *cobra.Command {
+    c := &myCmd{}
+    cmd := &cobra.Command{ /* ... */ }
+
+    cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+    cmd.Flags().BoolVar(&c.showLogs, "show-logs", false, "Show stdout and stderr from runtime commands")
+
+    cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
+    return cmd
+}
+```
+
+**Note:** Register all `RegisterFlagCompletionFunc` calls after all flag definitions.
+
+**Reference:** See `pkg/cmd/workspace_start.go`, `pkg/cmd/workspace_stop.go`, `pkg/cmd/workspace_remove.go`, and `pkg/cmd/init.go`.
+
 ## Interactive Commands (No JSON Output)
 
 Some commands are inherently interactive and do not support JSON output. These commands connect stdin/stdout/stderr directly to a user's terminal.


### PR DESCRIPTION
Adds a pkg/logger package (Logger interface with Stdout/Stderr writers) and a --show-logs flag to the init, workspace start, workspace stop, and workspace remove commands. When set, stdout and stderr from runtime CLI commands (e.g., podman build/start/stop/rm) are forwarded to the user. --show-logs cannot be combined with --output json. Updates the Podman executor Run/Output signatures to accept explicit io.Writer parameters, updates all call sites, adds tests, examples, README, and skill documentation.

Closes #108