### PR TITLE
ci(release): add job to bump next version after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,4 +98,4 @@ jobs:
             --base main \
             --head "$BRANCH"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.KORTEX_BOT_TOKEN }}


### PR DESCRIPTION
After a release tag is pushed, a new bump-next-version job computes the next semantic version via svu, updates pkg/version/version.go with a -next suffix, and opens a PR targeting main.

Workflow-level permissions moved to per-job for least privilege.

Closes #123