### PR TITLE
docs(readme): add configuration scenario examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Podman secrets are stored locally on the host and never written to the container
 **Notes:**
 
 - The `secret` field references a secret by name rather than embedding the token value directly, keeping credentials out of the configuration file
-- The project identifier used as the key must match what kortex-cli detected during `init` — run `kortex-cli list -o json -v` to see the project field for each registered workspace
+- The project identifier used as the key must match what kortex-cli detected during `init` — run `kortex-cli list -o json` to see the project field for each registered workspace
 - Configuration changes in `projects.json` take effect the next time you run `kortex-cli init` for that workspace; already-registered workspaces need to be removed and re-registered
 
 ### Working with Git Worktrees


### PR DESCRIPTION
Add three new scenarios under the Scenarios section to document common real-world configurations:
- Claude with a model from Vertex AI (CLAUDE_CODE_USE_VERTEX, credentials mount, optional Claude settings sharing)
- Sharing a GitHub token globally or per project via projects.json, including .gitconfig mount and Podman secret creation
- Working with git worktrees to run parallel agents on different branches, with per-user main branch mount via projects.json

Closes #132