### PR TITLE
chore: bump next version 0.3.0-next

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,4 +18,4 @@
 
 package version
 
-var Version = "0.2.0-next"
+var Version = "0.3.0-next"


### PR DESCRIPTION
CI failed, as the next version computed was `0.2.0-next`, not `0.3.0-next` (https://github.com/kortex-hub/kortex-cli/actions/runs/23802682894/job/69367388713)