### PR TITLE
ci(release): fix next version computation in bump-next-version job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout main branch
+      - name: Checkout release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -73,8 +72,13 @@ jobs:
       - name: Compute next version
         id: version
         run: |
-          NEXT_VERSION=$(svu next | sed 's/^v//')
+          NEXT_VERSION=$(svu minor | sed 's/^v//')
           echo "next_version=${NEXT_VERSION}-next" >> $GITHUB_OUTPUT
+
+      - name: Checkout main branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
 
       - name: Update version file
         run: |


### PR DESCRIPTION
svu was computing the next version from the main branch, which could resolve to a tag predating the release. Instead, check out the release tag first so svu sees it as the current version, then switch to main to apply the update. Also switch from `svu next` to `svu minor` to always bump the minor version, and drop unnecessary fetch-depth=0.

Fixes #123