### PR TITLE
feat(instances): support default agent settings baked into workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,17 @@ The config system manages workspace configuration for **injecting environment va
 
 **Configuration Precedence:** Agent > Project > Global > Workspace (highest to lowest)
 
+### Agent Default Settings Files
+
+A separate mechanism (distinct from env/mount config) allows default dotfiles to be baked into the workspace image:
+
+- **Location:** `~/.kortex-cli/config/<agent>/` (e.g., `~/.kortex-cli/config/claude/`)
+- Files are read by `manager.readAgentSettings()` into a `map[string][]byte` and passed to the runtime via `runtime.CreateParams.AgentSettings`
+- The Podman runtime writes these files into the build context as `agent-settings/` and adds `COPY --chown=agent:agent agent-settings/. /home/agent/` to the Containerfile
+- Result: every file under `config/<agent>/` lands at the corresponding path under `/home/agent/` inside the image
+
+**For detailed guidance, use:** `/working-with-config-system`
+
 **For detailed configuration guidance, use:** `/working-with-config-system`
 
 ### Podman Runtime Configuration

--- a/README.md
+++ b/README.md
@@ -178,6 +178,60 @@ To reuse your host Claude Code settings (preferences, custom instructions, etc.)
 - No `ANTHROPIC_API_KEY` is needed when using Vertex AI — credentials are provided via the mounted gcloud configuration
 - To pin a specific Claude model, add a `ANTHROPIC_MODEL` environment variable (e.g., `"claude-opus-4-5"`)
 
+### Starting Claude with Default Settings
+
+This scenario demonstrates how to pre-configure Claude Code's settings so that when it starts inside a workspace, it skips the interactive onboarding flow (theme selection, trusted folder prompt, etc.) and uses your preferred defaults. This is useful when you want a consistent, ready-to-use Claude experience without sharing your local `~/.claude` directory.
+
+**Step 1: Create the agent settings directory**
+
+```bash
+mkdir -p ~/.kortex-cli/config/claude
+```
+
+**Step 2: Write the default Claude settings file**
+
+```bash
+cat > ~/.kortex-cli/config/claude/.claude.json << 'EOF'
+{
+  "theme": "dark-daltonized",
+  "hasCompletedOnboarding": true,
+  "projects": {
+    "/workspace/sources": {
+      "hasTrustDialogAccepted": true
+    }
+  }
+}
+EOF
+```
+
+**Fields:**
+
+- `theme` - The UI theme for Claude Code (e.g., `"dark"`, `"light"`, `"dark-daltonized"`)
+- `hasCompletedOnboarding` - Set to `true` to skip the first-run onboarding wizard
+- `projects["/workspace/sources"].hasTrustDialogAccepted` - Pre-accepts the trust dialog for the workspace sources directory, which is always mounted at `/workspace/sources` inside the container
+
+**Step 3: Register and start the workspace**
+
+```bash
+# Register a workspace — the settings file is embedded in the container image
+kortex-cli init /path/to/project --runtime podman --agent claude
+
+# Start the workspace
+kortex-cli start <workspace-id>
+
+# Connect — Claude Code starts directly without onboarding
+kortex-cli terminal <workspace-id>
+```
+
+When `init` runs, kortex-cli reads all files from `~/.kortex-cli/config/claude/` and copies them into the container image at `/home/agent/`, so `.claude.json` lands at `/home/agent/.claude.json`. Claude Code finds this file on startup and skips onboarding.
+
+**Notes:**
+
+- The settings are baked into the container image at `init` time, not mounted at runtime — changes to the files on the host require re-registering the workspace to take effect
+- Any file placed under `~/.kortex-cli/config/claude/` is copied into the container home directory, preserving the directory structure (e.g., `~/.kortex-cli/config/claude/.some-tool/config` becomes `/home/agent/.some-tool/config` inside the container)
+- This approach keeps your workspace self-contained — other developers using the same project are not affected, and your local `~/.claude` directory is not exposed inside the container
+- To apply changes to the settings, remove and re-register the workspace: `kortex-cli remove <workspace-id>` then `kortex-cli init` again
+
 ### Sharing a GitHub Token
 
 This scenario demonstrates how to make a GitHub token available inside workspaces using the multi-level configuration system — either globally for all projects or scoped to a specific project.

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -205,12 +206,19 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		return nil, fmt.Errorf("failed to get runtime: %w", err)
 	}
 
+	// Read agent settings files from storage config directory
+	agentSettings, err := m.readAgentSettings(m.storageDir, opts.Agent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read agent settings: %w", err)
+	}
+
 	// Create runtime instance with merged configuration
 	runtimeInfo, err := rt.Create(ctx, runtime.CreateParams{
 		Name:            name,
 		SourcePath:      inst.GetSourceDir(),
 		WorkspaceConfig: mergedConfig,
 		Agent:           opts.Agent,
+		AgentSettings:   agentSettings,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)
@@ -701,4 +709,44 @@ func (m *manager) saveInstances(instances []Instance) error {
 	}
 
 	return os.WriteFile(m.storageFile, data, 0644)
+}
+
+// readAgentSettings reads all files from {storageDir}/config/{agentName}/ into a map.
+// Keys are relative paths using forward slashes; values are file contents.
+// Returns nil (no error) if the directory does not exist.
+func (m *manager) readAgentSettings(storageDir, agentName string) (map[string][]byte, error) {
+	if agentName == "" {
+		return nil, nil
+	}
+
+	// Validate agentName to prevent path traversal
+	if strings.Contains(agentName, "/") || strings.Contains(agentName, "\\") || strings.Contains(agentName, "..") {
+		return nil, fmt.Errorf("invalid agent name: %q", agentName)
+	}
+
+	agentSettingsDir := filepath.Join(storageDir, "config", agentName)
+	if _, err := os.Stat(agentSettingsDir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	settings := make(map[string][]byte)
+	err := fs.WalkDir(os.DirFS(agentSettingsDir), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(filepath.Join(agentSettingsDir, filepath.FromSlash(path)))
+		if err != nil {
+			return fmt.Errorf("failed to read agent settings file %s: %w", path, err)
+		}
+		settings[path] = content
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk agent settings directory: %w", err)
+	}
+
+	return settings, nil
 }

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -2214,3 +2214,137 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		}
 	})
 }
+
+func TestReadAgentSettings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when agent name is empty", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mgr := &manager{storageDir: tmpDir}
+
+		result, err := mgr.readAgentSettings(tmpDir, "")
+		if err != nil {
+			t.Fatalf("readAgentSettings() unexpected error = %v", err)
+		}
+		if result != nil {
+			t.Errorf("Expected nil result for empty agent name, got %v", result)
+		}
+	})
+
+	t.Run("returns nil when directory does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mgr := &manager{storageDir: tmpDir}
+
+		result, err := mgr.readAgentSettings(tmpDir, "claude")
+		if err != nil {
+			t.Fatalf("readAgentSettings() unexpected error = %v", err)
+		}
+		if result != nil {
+			t.Errorf("Expected nil result when directory does not exist, got %v", result)
+		}
+	})
+
+	t.Run("reads files into map with relative paths", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mgr := &manager{storageDir: tmpDir}
+
+		// Create agent settings directory with a nested file
+		agentDir := filepath.Join(tmpDir, "config", "claude")
+		if err := os.MkdirAll(filepath.Join(agentDir, ".claude"), 0755); err != nil {
+			t.Fatalf("Failed to create test directory: %v", err)
+		}
+		settingsContent := []byte(`{"theme":"dark"}`)
+		if err := os.WriteFile(filepath.Join(agentDir, ".claude", "settings.json"), settingsContent, 0600); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		result, err := mgr.readAgentSettings(tmpDir, "claude")
+		if err != nil {
+			t.Fatalf("readAgentSettings() unexpected error = %v", err)
+		}
+
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 file in result, got %d", len(result))
+		}
+
+		content, ok := result[".claude/settings.json"]
+		if !ok {
+			t.Error("Expected key '.claude/settings.json' in result map")
+		}
+		if string(content) != `{"theme":"dark"}` {
+			t.Errorf("Expected content %q, got %q", `{"theme":"dark"}`, string(content))
+		}
+	})
+
+	t.Run("reads multiple files recursively", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mgr := &manager{storageDir: tmpDir}
+
+		agentDir := filepath.Join(tmpDir, "config", "claude")
+		if err := os.MkdirAll(filepath.Join(agentDir, ".claude"), 0755); err != nil {
+			t.Fatalf("Failed to create test directory: %v", err)
+		}
+		files := map[string][]byte{
+			".claude/settings.json": []byte(`{"theme":"dark"}`),
+			".gitconfig":            []byte("[user]\n\tname = Agent\n"),
+		}
+		for relPath, content := range files {
+			dest := filepath.Join(agentDir, filepath.FromSlash(relPath))
+			if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+				t.Fatalf("Failed to create parent dir for %s: %v", relPath, err)
+			}
+			if err := os.WriteFile(dest, content, 0600); err != nil {
+				t.Fatalf("Failed to write %s: %v", relPath, err)
+			}
+		}
+
+		result, err := mgr.readAgentSettings(tmpDir, "claude")
+		if err != nil {
+			t.Fatalf("readAgentSettings() unexpected error = %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Fatalf("Expected 2 files in result, got %d", len(result))
+		}
+		for relPath, expectedContent := range files {
+			got, ok := result[relPath]
+			if !ok {
+				t.Errorf("Expected key %q in result map", relPath)
+				continue
+			}
+			if string(got) != string(expectedContent) {
+				t.Errorf("Content mismatch for %q: expected %q, got %q", relPath, expectedContent, got)
+			}
+		}
+	})
+
+	t.Run("returns empty map for empty directory", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mgr := &manager{storageDir: tmpDir}
+
+		// Create empty agent settings directory
+		agentDir := filepath.Join(tmpDir, "config", "claude")
+		if err := os.MkdirAll(agentDir, 0755); err != nil {
+			t.Fatalf("Failed to create agent directory: %v", err)
+		}
+
+		result, err := mgr.readAgentSettings(tmpDir, "claude")
+		if err != nil {
+			t.Fatalf("readAgentSettings() unexpected error = %v", err)
+		}
+
+		if len(result) != 0 {
+			t.Errorf("Expected empty map for empty directory, got %d entries", len(result))
+		}
+	})
+}

--- a/pkg/runtime/podman/containerfile.go
+++ b/pkg/runtime/podman/containerfile.go
@@ -43,7 +43,9 @@ func generateSudoers(sudoBinaries []string) string {
 }
 
 // generateContainerfile generates the Containerfile content from image and agent configurations.
-func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.AgentConfig) string {
+// If hasAgentSettings is true, a COPY instruction is added to embed the agent-settings
+// directory (written to the build context) into the agent user's home directory.
+func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, hasAgentSettings bool) string {
 	if imageConfig == nil {
 		return ""
 	}
@@ -84,6 +86,13 @@ func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.
 
 	// Copy Containerfile to home directory for reference
 	lines = append(lines, fmt.Sprintf("COPY Containerfile /home/%s/Containerfile", constants.ContainerUser))
+
+	// Copy agent default settings into home directory before the RUN commands,
+	// so that agent install scripts can read and build upon the defaults.
+	if hasAgentSettings {
+		lines = append(lines, fmt.Sprintf("COPY --chown=%s:%s agent-settings/. /home/%s/",
+			constants.ContainerUser, constants.ContainerGroup, constants.ContainerUser))
+	}
 
 	// Custom RUN commands from image config
 	for _, cmd := range imageConfig.RunCommands {

--- a/pkg/runtime/podman/containerfile_test.go
+++ b/pkg/runtime/podman/containerfile_test.go
@@ -96,7 +96,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig)
+		result := generateContainerfile(imageConfig, agentConfig, false)
 
 		// Check for FROM line with correct base image
 		expectedFrom := "FROM registry.fedoraproject.org/fedora:latest"
@@ -161,7 +161,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig)
+		result := generateContainerfile(imageConfig, agentConfig, false)
 
 		expectedFrom := "FROM registry.fedoraproject.org/fedora:40"
 		if !strings.Contains(result, expectedFrom) {
@@ -184,7 +184,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig)
+		result := generateContainerfile(imageConfig, agentConfig, false)
 
 		// Should have all packages in a single RUN command
 		if !strings.Contains(result, "RUN dnf install -y package1 package2 package3 package4") {
@@ -207,7 +207,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig)
+		result := generateContainerfile(imageConfig, agentConfig, false)
 
 		// Should not have dnf install line
 		if strings.Contains(result, "dnf install") {
@@ -231,7 +231,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig)
+		result := generateContainerfile(imageConfig, agentConfig, false)
 
 		// Should have both RUN commands
 		if !strings.Contains(result, "RUN echo 'image setup'") {
@@ -239,6 +239,61 @@ func TestGenerateContainerfile(t *testing.T) {
 		}
 		if !strings.Contains(result, "RUN echo 'agent setup'") {
 			t.Error("Expected agent RUN command")
+		}
+	})
+
+	t.Run("adds COPY instruction for agent settings when hasAgentSettings is true", func(t *testing.T) {
+		t.Parallel()
+
+		imageConfig := &config.ImageConfig{
+			Version:     "latest",
+			Packages:    []string{},
+			Sudo:        []string{},
+			RunCommands: []string{"echo 'image setup'"},
+		}
+		agentConfig := &config.AgentConfig{
+			Packages:        []string{},
+			RunCommands:     []string{"echo 'agent setup'"},
+			TerminalCommand: []string{"claude"},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, true)
+
+		expected := "COPY --chown=agent:agent agent-settings/. /home/agent/"
+		if !strings.Contains(result, expected) {
+			t.Errorf("Expected Containerfile to contain %q, got:\n%s", expected, result)
+		}
+
+		// Verify the COPY comes before all RUN commands so agent install scripts can
+		// read and build upon the defaults.
+		settingsPos := strings.Index(result, expected)
+		imageRunPos := strings.Index(result, "RUN echo 'image setup'")
+		agentRunPos := strings.Index(result, "RUN echo 'agent setup'")
+
+		if settingsPos > imageRunPos || settingsPos > agentRunPos {
+			t.Error("Expected COPY agent-settings to appear before all RUN commands")
+		}
+	})
+
+	t.Run("no agent-settings COPY when hasAgentSettings is false", func(t *testing.T) {
+		t.Parallel()
+
+		imageConfig := &config.ImageConfig{
+			Version:     "latest",
+			Packages:    []string{},
+			Sudo:        []string{},
+			RunCommands: []string{},
+		}
+		agentConfig := &config.AgentConfig{
+			Packages:        []string{},
+			RunCommands:     []string{},
+			TerminalCommand: []string{"claude"},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false)
+
+		if strings.Contains(result, "agent-settings") {
+			t.Errorf("Expected no agent-settings COPY line, got:\n%s", result)
 		}
 	})
 
@@ -258,7 +313,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig)
+		result := generateContainerfile(imageConfig, agentConfig, false)
 
 		// Find positions
 		imagePos := strings.Index(result, "RUN echo 'image'")

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -52,7 +52,9 @@ func (p *podmanRuntime) createInstanceDirectory(name string) (string, error) {
 }
 
 // createContainerfile creates a Containerfile in the instance directory using the provided configs.
-func (p *podmanRuntime) createContainerfile(instanceDir string, imageConfig *config.ImageConfig, agentConfig *config.AgentConfig) error {
+// If settings is non-empty, the files are written to an agent-settings/ subdirectory of instanceDir
+// so they can be embedded in the image via a COPY instruction.
+func (p *podmanRuntime) createContainerfile(instanceDir string, imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, settings map[string][]byte) error {
 	// Generate sudoers content
 	sudoersContent := generateSudoers(imageConfig.Sudo)
 	sudoersPath := filepath.Join(instanceDir, "sudoers")
@@ -60,8 +62,25 @@ func (p *podmanRuntime) createContainerfile(instanceDir string, imageConfig *con
 		return fmt.Errorf("failed to write sudoers: %w", err)
 	}
 
+	// Write agent settings files to the build context if provided
+	if len(settings) > 0 {
+		settingsDir := filepath.Join(instanceDir, "agent-settings")
+		if err := os.MkdirAll(settingsDir, 0755); err != nil {
+			return fmt.Errorf("failed to create agent settings dir: %w", err)
+		}
+		for relPath, content := range settings {
+			destPath := filepath.Join(settingsDir, filepath.FromSlash(relPath))
+			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+				return fmt.Errorf("failed to create directory for %s: %w", relPath, err)
+			}
+			if err := os.WriteFile(destPath, content, 0600); err != nil {
+				return fmt.Errorf("failed to write agent settings file %s: %w", relPath, err)
+			}
+		}
+	}
+
 	// Generate Containerfile content
-	containerfileContent := generateContainerfile(imageConfig, agentConfig)
+	containerfileContent := generateContainerfile(imageConfig, agentConfig, len(settings) > 0)
 	containerfilePath := filepath.Join(instanceDir, "Containerfile")
 	if err := os.WriteFile(containerfilePath, []byte(containerfileContent), 0644); err != nil {
 		return fmt.Errorf("failed to write Containerfile: %w", err)
@@ -185,7 +204,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 
 	// Create Containerfile
 	stepLogger.Start("Generating Containerfile", "Containerfile generated")
-	if err := p.createContainerfile(instanceDir, imageConfig, agentConfig); err != nil {
+	if err := p.createContainerfile(instanceDir, imageConfig, agentConfig, params.AgentSettings); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -194,7 +194,7 @@ func TestCreateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		err := p.createContainerfile(instanceDir, imageConfig, agentConfig)
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil)
 		if err != nil {
 			t.Fatalf("createContainerfile() failed: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestCreateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"custom-agent"},
 		}
 
-		err := p.createContainerfile(instanceDir, imageConfig, agentConfig)
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil)
 		if err != nil {
 			t.Fatalf("createContainerfile() failed: %v", err)
 		}
@@ -286,6 +286,110 @@ func TestCreateContainerfile(t *testing.T) {
 
 		if !strings.Contains(string(sudoersContent), "/usr/bin/custom") {
 			t.Error("Expected sudoers to contain custom binary")
+		}
+	})
+
+	t.Run("writes agent settings files to build context", func(t *testing.T) {
+		t.Parallel()
+
+		instanceDir := t.TempDir()
+		p := &podmanRuntime{}
+
+		imageConfig := &config.ImageConfig{
+			Version:     "latest",
+			Packages:    []string{},
+			Sudo:        []string{},
+			RunCommands: []string{},
+		}
+		agentConfig := &config.AgentConfig{
+			Packages:        []string{},
+			RunCommands:     []string{},
+			TerminalCommand: []string{"claude"},
+		}
+		settings := map[string][]byte{
+			".claude/settings.json": []byte(`{"theme":"dark"}`),
+			".gitconfig":            []byte("[user]\n\tname = Agent\n"),
+		}
+
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, settings)
+		if err != nil {
+			t.Fatalf("createContainerfile() failed: %v", err)
+		}
+
+		// Verify agent-settings directory was created
+		settingsDir := filepath.Join(instanceDir, "agent-settings")
+		if _, err := os.Stat(settingsDir); os.IsNotExist(err) {
+			t.Error("Expected agent-settings directory to be created")
+		}
+
+		// Verify nested file is written correctly
+		claudeSettings := filepath.Join(settingsDir, ".claude", "settings.json")
+		content, err := os.ReadFile(claudeSettings)
+		if err != nil {
+			t.Fatalf("Failed to read .claude/settings.json: %v", err)
+		}
+		if string(content) != `{"theme":"dark"}` {
+			t.Errorf("Expected settings content %q, got %q", `{"theme":"dark"}`, string(content))
+		}
+
+		// Verify flat file is written correctly
+		gitconfig := filepath.Join(settingsDir, ".gitconfig")
+		content, err = os.ReadFile(gitconfig)
+		if err != nil {
+			t.Fatalf("Failed to read .gitconfig: %v", err)
+		}
+		if string(content) != "[user]\n\tname = Agent\n" {
+			t.Errorf("Expected gitconfig content %q, got %q", "[user]\n\tname = Agent\n", string(content))
+		}
+
+		// Verify Containerfile contains the COPY instruction for agent settings
+		containerfilePath := filepath.Join(instanceDir, "Containerfile")
+		containerfileContent, err := os.ReadFile(containerfilePath)
+		if err != nil {
+			t.Fatalf("Failed to read Containerfile: %v", err)
+		}
+		if !strings.Contains(string(containerfileContent), "COPY --chown=agent:agent agent-settings/. /home/agent/") {
+			t.Error("Expected Containerfile to contain COPY instruction for agent settings")
+		}
+	})
+
+	t.Run("no agent-settings dir or COPY when settings is nil", func(t *testing.T) {
+		t.Parallel()
+
+		instanceDir := t.TempDir()
+		p := &podmanRuntime{}
+
+		imageConfig := &config.ImageConfig{
+			Version:     "latest",
+			Packages:    []string{},
+			Sudo:        []string{},
+			RunCommands: []string{},
+		}
+		agentConfig := &config.AgentConfig{
+			Packages:        []string{},
+			RunCommands:     []string{},
+			TerminalCommand: []string{"claude"},
+		}
+
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil)
+		if err != nil {
+			t.Fatalf("createContainerfile() failed: %v", err)
+		}
+
+		// Verify agent-settings directory was NOT created
+		settingsDir := filepath.Join(instanceDir, "agent-settings")
+		if _, err := os.Stat(settingsDir); !os.IsNotExist(err) {
+			t.Error("Expected agent-settings directory to NOT be created when settings is nil")
+		}
+
+		// Verify Containerfile does not contain agent-settings COPY
+		containerfilePath := filepath.Join(instanceDir, "Containerfile")
+		containerfileContent, err := os.ReadFile(containerfilePath)
+		if err != nil {
+			t.Fatalf("Failed to read Containerfile: %v", err)
+		}
+		if strings.Contains(string(containerfileContent), "agent-settings") {
+			t.Error("Expected Containerfile to NOT contain agent-settings when settings is nil")
 		}
 	})
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -61,6 +61,12 @@ type CreateParams struct {
 
 	// Agent is the agent name for loading agent-specific configuration (required, cannot be empty).
 	Agent string
+
+	// AgentSettings contains the agent settings files to embed into the agent user's
+	// home directory in the workspace image. Keys are relative file paths using
+	// forward slashes (e.g., ".claude/settings.json"), values are file contents.
+	// This map can be nil or empty if no default settings are configured.
+	AgentSettings map[string][]byte
 }
 
 // RuntimeInfo contains information about a runtime instance.

--- a/skills/add-runtime/SKILL.md
+++ b/skills/add-runtime/SKILL.md
@@ -94,6 +94,19 @@ func (r *<runtime-name>Runtime) Create(ctx context.Context, params runtime.Creat
         return runtime.RuntimeInfo{}, err
     }
 
+    // Step 3: Copy agent default settings files into the workspace home directory.
+    // params.AgentSettings is a map[string][]byte (relative forward-slash path → content)
+    // populated from <storage-dir>/config/<agent>/ by the instances manager.
+    // For image-based runtimes (e.g., Podman), embed these files BEFORE install RUN commands
+    // so agent install scripts can read and build upon the defaults.
+    if len(params.AgentSettings) > 0 {
+        stepLogger.Start("Copying agent settings to workspace", "Agent settings copied")
+        if err := r.copyAgentSettings(ctx, info.ID, params.AgentSettings); err != nil {
+            stepLogger.Fail(err)
+            return runtime.RuntimeInfo{}, err
+        }
+    }
+
     return info, nil
 }
 

--- a/skills/working-with-config-system/SKILL.md
+++ b/skills/working-with-config-system/SKILL.md
@@ -27,6 +27,25 @@ The multi-level configuration system allows users to customize workspace setting
 
 These configurations control what gets injected **into** workspaces (environment variables, mounts), not how the workspace runtime is built or configured.
 
+## Agent Default Settings Files
+
+In addition to the env/mount configuration above, kortex-cli supports **default settings files** that are baked directly into the workspace image at `init` time.
+
+**Location:** `~/.kortex-cli/config/<agent>/` (one directory per agent name)
+
+Any file placed in this directory is copied into the agent user's home directory (`/home/agent/`) inside the container image, preserving the directory structure. For example:
+
+```text
+~/.kortex-cli/config/claude/
+└── .claude.json          → /home/agent/.claude.json inside the image
+```
+
+This is distinct from `agents.json`:
+- `agents.json` — injects **environment variables and mounts** at runtime
+- `config/<agent>/` — embeds **dotfiles / settings files** directly into the image at build time
+
+**Implementation:** `manager.readAgentSettings(storageDir, agentName)` in `pkg/instances/manager.go` walks this directory and returns a `map[string][]byte` (relative forward-slash path → content). The map is passed to the runtime via `runtime.CreateParams.AgentSettings`. The Podman runtime writes the files into the build context and adds a `COPY --chown=agent:agent agent-settings/. /home/agent/` instruction to the Containerfile.
+
 ## Key Components
 
 - **Config Interface** (`pkg/config/config.go`): Interface for managing configuration directories

--- a/skills/working-with-instances-manager/SKILL.md
+++ b/skills/working-with-instances-manager/SKILL.md
@@ -62,7 +62,8 @@ The `Add()` method:
 2. Loads project config (global `""` + project-specific merged)
 3. Loads agent config (if agent name provided)
 4. Merges configs: workspace → global → project → agent
-5. Passes merged config to runtime for injection into workspace
+5. Reads agent settings files from `<storage-dir>/config/<agent>/` into `map[string][]byte`
+6. Passes merged config and agent settings to runtime for injection into workspace
 
 ### List - Get All Instances
 

--- a/skills/working-with-podman-runtime-config/SKILL.md
+++ b/skills/working-with-podman-runtime-config/SKILL.md
@@ -150,7 +150,8 @@ The config system is used to generate Containerfiles dynamically:
 import "github.com/kortex-hub/kortex-cli/pkg/runtime/podman"
 
 // Generate Containerfile content from configs
-containerfileContent := generateContainerfile(imageConfig, agentConfig)
+// hasAgentSettings = true adds a COPY instruction for default settings files
+containerfileContent := generateContainerfile(imageConfig, agentConfig, hasAgentSettings)
 
 // Generate sudoers file content from sudo binaries
 sudoersContent := generateSudoers(imageConfig.Sudo)
@@ -161,7 +162,24 @@ The `generateContainerfile` function creates a Containerfile with:
 - Merged packages from image and agent configs
 - User/group setup (hardcoded as `agent:agent`)
 - Sudoers configuration with single `ALLOWED` Cmnd_Alias
+- When `hasAgentSettings` is true: `COPY --chown=agent:agent agent-settings/. /home/agent/` (placed before RUN commands)
 - Custom RUN commands from both configs (image commands first, then agent commands)
+
+## Agent Default Settings Files
+
+When `runtime.CreateParams.AgentSettings` is non-empty, `createContainerfile()` writes the map entries as files into an `agent-settings/` subdirectory of the build context (the instance directory), then sets `hasAgentSettings = true` so `generateContainerfile` emits a `COPY` instruction.
+
+```text
+Build context (instance dir):
+├── Containerfile
+├── sudoers
+└── agent-settings/          ← created from CreateParams.AgentSettings
+    └── .claude.json          ← key ".claude.json", value = file contents
+```
+
+The `COPY --chown=agent:agent agent-settings/. /home/agent/` instruction is placed **before** all `RUN` commands from both `image.json` and the agent config, so that agent install scripts can read and build upon the defaults (e.g., the Claude install script may modify settings files, which is expected behavior).
+
+This mechanism is populated by `manager.readAgentSettings()` in `pkg/instances/manager.go`, which walks `<storage-dir>/config/<agent>/` and passes the result as `AgentSettings` in `CreateParams`.
 
 ## Hardcoded Values
 


### PR DESCRIPTION
Users can place files under <storage-dir>/config/<agent>/ and have them automatically embedded into the container image during `kortex-cli init`. The manager reads the files into a map[string][]byte and passes them to the runtime via CreateParams.AgentSettings. The Podman runtime writes them into the build context as agent-settings/ and emits a COPY instruction in the Containerfile before the RUN commands, so agent install scripts can read and build upon the defaults.

With this PR, the user will need to set all settings necessary to skip the onboarding. Next PR (issue #150) will add these settings automatically

Closes #142