### PR TITLE
ci: skip codecov upload when token unavailable

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,8 +55,9 @@ jobs:
         run: make test-coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.os == 'ubuntu-24.04' && secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
           fail_ci_if_error: true


### PR DESCRIPTION
External contributors don't have access to repository secrets, causing PR checks to fail when uploading coverage to Codecov. This change adds a conditional check to only upload coverage when the token is available, allowing external PRs to pass while still uploading coverage for internal contributors.

Fixes #92 