### PR TITLE
chore: use CODECOV_TOKEN if from a local branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,3 +60,4 @@ jobs:
         with:
           files: ./coverage.out
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
use the secret if available

Fixes #92 