### PR TITLE
feat(instances): support workspace access by name or ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A standardized protocol for connecting AI agents to external data sources and to
 Pre-configured capabilities or specialized functions that can be enabled for an agent. Skills extend what an agent can do, such as code review, testing, or specific domain knowledge.
 
 ### Workspace
-A registered directory containing your project source code and its configuration. Each workspace is tracked by kortex-cli with a unique ID and name for easy management.
+A registered directory containing your project source code and its configuration. Each workspace is tracked by kortex-cli with a unique ID and a human-readable name. Workspaces can be accessed using either their ID or name in all commands (start, stop, remove, terminal).
 
 ## Scenarios
 
@@ -130,11 +130,11 @@ Create or edit `~/.kortex-cli/config/agents.json` to add the required environmen
 # Register a workspace with the Podman runtime and Claude agent
 kortex-cli init /path/to/project --runtime podman --agent claude
 
-# Start the workspace
-kortex-cli start <workspace-id>
+# Start the workspace (using name or ID)
+kortex-cli start my-project
 
 # Connect to the workspace — Claude Code will use Vertex AI automatically
-kortex-cli terminal <workspace-id>
+kortex-cli terminal my-project
 ```
 
 When Claude Code starts, it detects `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and routes all requests to Vertex AI using the mounted application default credentials.
@@ -216,11 +216,11 @@ EOF
 # Register a workspace — the settings file is embedded in the container image
 kortex-cli init /path/to/project --runtime podman --agent claude
 
-# Start the workspace
-kortex-cli start <workspace-id>
+# Start the workspace (using name or ID)
+kortex-cli start my-project
 
 # Connect — Claude Code starts directly without onboarding
-kortex-cli terminal <workspace-id>
+kortex-cli terminal my-project
 ```
 
 When `init` runs, kortex-cli reads all files from `~/.kortex-cli/config/claude/` and copies them into the container image at `/home/agent/`, so `.claude.json` lands at `/home/agent/.claude.json`. Claude Code finds this file on startup and skips onboarding.
@@ -380,13 +380,13 @@ kortex-cli init /path/to/my-project/feature-b --runtime podman --agent claude
 **Step 5: Start and connect to each workspace independently**
 
 ```bash
-# Start both workspaces
-kortex-cli start <workspace-id-a>
-kortex-cli start <workspace-id-b>
+# Start both workspaces (using names or IDs)
+kortex-cli start feature-a
+kortex-cli start feature-b
 
 # Connect to each agent in separate terminals
-kortex-cli terminal <workspace-id-a>
-kortex-cli terminal <workspace-id-b>
+kortex-cli terminal feature-a
+kortex-cli terminal feature-b
 ```
 
 Each agent runs independently in its own container, operating on its own branch without interfering with the other.
@@ -1754,18 +1754,18 @@ kortex-cli list -o json
 
 ### `workspace start` - Start a Workspace
 
-Starts a registered workspace by its ID. Also available as the shorter alias `start`.
+Starts a registered workspace by its name or ID. Also available as the shorter alias `start`.
 
 #### Usage
 
 ```bash
-kortex-cli workspace start ID [flags]
-kortex-cli start ID [flags]
+kortex-cli workspace start NAME|ID [flags]
+kortex-cli start NAME|ID [flags]
 ```
 
 #### Arguments
 
-- `ID` - The unique identifier of the workspace to start (required)
+- `NAME|ID` - The workspace name or unique identifier (required)
 
 #### Flags
 
@@ -1781,18 +1781,24 @@ kortex-cli workspace start a1b2c3d4e5f6...
 ```
 Output: `a1b2c3d4e5f6...` (ID of started workspace)
 
+**Start a workspace by name:**
+```bash
+kortex-cli workspace start my-project
+```
+Output: `a1b2c3d4e5f6...` (ID of started workspace)
+
 **Use the short alias:**
 ```bash
-kortex-cli start a1b2c3d4e5f6...
+kortex-cli start my-project
 ```
 
-**View workspace IDs before starting:**
+**View workspace names and IDs before starting:**
 ```bash
-# First, list all workspaces to find the ID
+# First, list all workspaces to find the name or ID
 kortex-cli list
 
-# Then start the desired workspace
-kortex-cli start a1b2c3d4e5f6...
+# Then start the desired workspace (using either name or ID)
+kortex-cli start my-project
 ```
 
 **JSON output:**
@@ -1841,9 +1847,9 @@ Output:
 
 #### Notes
 
-- The workspace ID is required and can be obtained using the `workspace list` or `list` command
+- You can specify the workspace using either its name or ID (both can be obtained using the `workspace list` or `list` command)
+- The command always outputs the workspace ID, even when started by name
 - Starting a workspace launches its associated runtime instance
-- Upon successful start, the command outputs the ID of the started workspace
 - The workspace runtime state is updated to reflect that it's running
 - JSON output format is useful for scripting and automation
 - When using `--output json`, errors are also returned in JSON format for consistent parsing
@@ -1851,18 +1857,18 @@ Output:
 
 ### `workspace stop` - Stop a Workspace
 
-Stops a running workspace by its ID. Also available as the shorter alias `stop`.
+Stops a running workspace by its name or ID. Also available as the shorter alias `stop`.
 
 #### Usage
 
 ```bash
-kortex-cli workspace stop ID [flags]
-kortex-cli stop ID [flags]
+kortex-cli workspace stop NAME|ID [flags]
+kortex-cli stop NAME|ID [flags]
 ```
 
 #### Arguments
 
-- `ID` - The unique identifier of the workspace to stop (required)
+- `NAME|ID` - The workspace name or unique identifier (required)
 
 #### Flags
 
@@ -1878,18 +1884,24 @@ kortex-cli workspace stop a1b2c3d4e5f6...
 ```
 Output: `a1b2c3d4e5f6...` (ID of stopped workspace)
 
+**Stop a workspace by name:**
+```bash
+kortex-cli workspace stop my-project
+```
+Output: `a1b2c3d4e5f6...` (ID of stopped workspace)
+
 **Use the short alias:**
 ```bash
-kortex-cli stop a1b2c3d4e5f6...
+kortex-cli stop my-project
 ```
 
-**View workspace IDs before stopping:**
+**View workspace names and IDs before stopping:**
 ```bash
-# First, list all workspaces to find the ID
+# First, list all workspaces to find the name or ID
 kortex-cli list
 
-# Then stop the desired workspace
-kortex-cli stop a1b2c3d4e5f6...
+# Then stop the desired workspace (using either name or ID)
+kortex-cli stop my-project
 ```
 
 **JSON output:**
@@ -1938,9 +1950,9 @@ Output:
 
 #### Notes
 
-- The workspace ID is required and can be obtained using the `workspace list` or `list` command
+- You can specify the workspace using either its name or ID (both can be obtained using the `workspace list` or `list` command)
+- The command always outputs the workspace ID, even when stopped by name
 - Stopping a workspace stops its associated runtime instance
-- Upon successful stop, the command outputs the ID of the stopped workspace
 - The workspace runtime state is updated to reflect that it's stopped
 - JSON output format is useful for scripting and automation
 - When using `--output json`, errors are also returned in JSON format for consistent parsing
@@ -1953,13 +1965,13 @@ Connects to a running workspace with an interactive terminal session. Also avail
 #### Usage
 
 ```bash
-kortex-cli workspace terminal ID [COMMAND...] [flags]
-kortex-cli terminal ID [COMMAND...] [flags]
+kortex-cli workspace terminal NAME|ID [COMMAND...] [flags]
+kortex-cli terminal NAME|ID [COMMAND...] [flags]
 ```
 
 #### Arguments
 
-- `ID` - The unique identifier of the workspace to connect to (required)
+- `NAME|ID` - The workspace name or unique identifier (required)
 - `COMMAND...` - Optional command to execute instead of the default agent command
 
 #### Flags
@@ -1968,21 +1980,26 @@ kortex-cli terminal ID [COMMAND...] [flags]
 
 #### Examples
 
-**Connect using the default agent command:**
+**Connect using the default agent command (by ID):**
 ```bash
 kortex-cli workspace terminal a1b2c3d4e5f6...
+```
+
+**Connect using the default agent command (by name):**
+```bash
+kortex-cli workspace terminal my-project
 ```
 
 This starts an interactive session with the default agent (typically Claude Code) inside the running workspace container.
 
 **Use the short alias:**
 ```bash
-kortex-cli terminal a1b2c3d4e5f6...
+kortex-cli terminal my-project
 ```
 
 **Run a bash shell:**
 ```bash
-kortex-cli terminal a1b2c3d4e5f6... bash
+kortex-cli terminal my-project bash
 ```
 
 **Run a command with flags (use -- to prevent kortex-cli from parsing them):**
@@ -2034,7 +2051,7 @@ kortex-cli terminal a1b2c3d4e5f6...
 #### Notes
 
 - The workspace must be in a **running state** before you can connect to it. Use `workspace start` to start a workspace first
-- The workspace ID is required and can be obtained using the `workspace list` or `list` command
+- You can specify the workspace using either its name or ID (both can be obtained using the `workspace list` or `list` command)
 - By default (when no command is provided), the runtime uses the `terminal_command` from the agent's configuration file
   - For example, if the workspace was created with `--agent claude`, it will use the command defined in `claude.json` (typically `["claude"]`)
   - This ensures you connect directly to the configured agent
@@ -2047,18 +2064,18 @@ kortex-cli terminal a1b2c3d4e5f6...
 
 ### `workspace remove` - Remove a Workspace
 
-Removes a registered workspace by its ID. Also available as the shorter alias `remove`.
+Removes a registered workspace by its name or ID. Also available as the shorter alias `remove`.
 
 #### Usage
 
 ```bash
-kortex-cli workspace remove ID [flags]
-kortex-cli remove ID [flags]
+kortex-cli workspace remove NAME|ID [flags]
+kortex-cli remove NAME|ID [flags]
 ```
 
 #### Arguments
 
-- `ID` - The unique identifier of the workspace to remove (required)
+- `NAME|ID` - The workspace name or unique identifier (required)
 
 #### Flags
 
@@ -2074,18 +2091,24 @@ kortex-cli workspace remove a1b2c3d4e5f6...
 ```
 Output: `a1b2c3d4e5f6...` (ID of removed workspace)
 
+**Remove a workspace by name:**
+```bash
+kortex-cli workspace remove my-project
+```
+Output: `a1b2c3d4e5f6...` (ID of removed workspace)
+
 **Use the short alias:**
 ```bash
-kortex-cli remove a1b2c3d4e5f6...
+kortex-cli remove my-project
 ```
 
-**View workspace IDs before removing:**
+**View workspace names and IDs before removing:**
 ```bash
-# First, list all workspaces to find the ID
+# First, list all workspaces to find the name or ID
 kortex-cli list
 
-# Then remove the desired workspace
-kortex-cli remove a1b2c3d4e5f6...
+# Then remove the desired workspace (using either name or ID)
+kortex-cli remove my-project
 ```
 
 **JSON output:**
@@ -2134,10 +2157,10 @@ Output:
 
 #### Notes
 
-- The workspace ID is required and can be obtained using the `workspace list` or `list` command
+- You can specify the workspace using either its name or ID (both can be obtained using the `workspace list` or `list` command)
+- The command always outputs the workspace ID, even when removed by name
 - Removing a workspace only unregisters it from kortex-cli; it does not delete any files from the sources or configuration directories
-- If the workspace ID is not found, the command will fail with a helpful error message
-- Upon successful removal, the command outputs the ID of the removed workspace
+- If the workspace name or ID is not found, the command will fail with a helpful error message
 - JSON output format is useful for scripting and automation
 - When using `--output json`, errors are also returned in JSON format for consistent parsing
 - **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -30,7 +30,7 @@ import (
 // stateFilter is a function that determines if an instance with the given state should be included
 type stateFilter func(state string) bool
 
-// getFilteredWorkspaceIDs retrieves workspace IDs, optionally filtered by state
+// getFilteredWorkspaceIDs retrieves workspace IDs and names, optionally filtered by state
 func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, cobra.ShellCompDirective) {
 	// Get storage directory from global flag
 	storageDir, err := cmd.Flags().GetString("storage")
@@ -62,17 +62,19 @@ func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, 
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	// Extract IDs with optional filtering
-	var ids []string
+	// Extract IDs and names with optional filtering
+	var completions []string
 	for _, instance := range instancesList {
 		state := instance.GetRuntimeData().State
 		// Apply filter if provided, otherwise include all
 		if filter == nil || filter(state) {
-			ids = append(ids, instance.GetID())
+			// Add both ID and name for better discoverability
+			completions = append(completions, instance.GetID())
+			completions = append(completions, instance.GetName())
 		}
 	}
 
-	return ids, cobra.ShellCompDirectiveNoFileComp
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
 // completeNonRunningWorkspaceID provides completion for non-running workspaces (for start and remove)

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -97,14 +97,30 @@ func TestCompleteNonRunningWorkspaceID(t *testing.T) {
 		// Call completion function - should only return non-running instances
 		completions, directive := completeNonRunningWorkspaceID(cmd, []string{}, "")
 
-		// Verify we got only instance2 (instance1 is running)
-		if len(completions) != 1 {
-			t.Errorf("Expected 1 completion (non-running), got %d", len(completions))
+		// Verify we got instance2's ID and name (instance1 is running, so not included)
+		// Should return both ID and name for better discoverability
+		if len(completions) != 2 {
+			t.Errorf("Expected 2 completions (ID and name for non-running), got %d", len(completions))
 		}
 
-		// Verify only instance2 is in the completions
-		if len(completions) > 0 && completions[0] != addedInstance2.GetID() {
-			t.Errorf("Expected ID %s in completions, got %s", addedInstance2.GetID(), completions[0])
+		// Verify instance2 ID and name are in the completions
+		expectedID := addedInstance2.GetID()
+		expectedName := addedInstance2.GetName()
+		foundID := false
+		foundName := false
+		for _, completion := range completions {
+			if completion == expectedID {
+				foundID = true
+			}
+			if completion == expectedName {
+				foundName = true
+			}
+		}
+		if !foundID {
+			t.Errorf("Expected ID %s in completions, got %v", expectedID, completions)
+		}
+		if !foundName {
+			t.Errorf("Expected name %s in completions, got %v", expectedName, completions)
 		}
 
 		// Verify directive
@@ -254,14 +270,30 @@ func TestCompleteRunningWorkspaceID(t *testing.T) {
 		// Call completion function - should only return running instances
 		completions, directive := completeRunningWorkspaceID(cmd, []string{}, "")
 
-		// Verify we got only instance1 (instance2 is not running)
-		if len(completions) != 1 {
-			t.Errorf("Expected 1 completion (running), got %d", len(completions))
+		// Verify we got instance1's ID and name (instance2 is not running, so not included)
+		// Should return both ID and name for better discoverability
+		if len(completions) != 2 {
+			t.Errorf("Expected 2 completions (ID and name for running), got %d", len(completions))
 		}
 
-		// Verify only instance1 is in the completions
-		if len(completions) > 0 && completions[0] != addedInstance1.GetID() {
-			t.Errorf("Expected ID %s in completions, got %s", addedInstance1.GetID(), completions[0])
+		// Verify instance1 ID and name are in the completions
+		expectedID := addedInstance1.GetID()
+		expectedName := addedInstance1.GetName()
+		foundID := false
+		foundName := false
+		for _, completion := range completions {
+			if completion == expectedID {
+				foundID = true
+			}
+			if completion == expectedName {
+				foundName = true
+			}
+		}
+		if !foundID {
+			t.Errorf("Expected ID %s in completions, got %v", expectedID, completions)
+		}
+		if !foundName {
+			t.Errorf("Expected name %s in completions, got %v", expectedName, completions)
 		}
 
 		// Verify directive

--- a/pkg/cmd/remove.go
+++ b/pkg/cmd/remove.go
@@ -28,7 +28,7 @@ func NewRemoveCmd() *cobra.Command {
 
 	// Create an alias command that delegates to workspace remove
 	cmd := &cobra.Command{
-		Use:               "remove ID",
+		Use:               "remove NAME|ID",
 		Short:             workspaceRemoveCmd.Short,
 		Long:              workspaceRemoveCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceRemoveCmd.Example, "workspace remove", "remove"),

--- a/pkg/cmd/remove_test.go
+++ b/pkg/cmd/remove_test.go
@@ -30,8 +30,8 @@ func TestRemoveCmd(t *testing.T) {
 		t.Fatal("NewRemoveCmd() returned nil")
 	}
 
-	if cmd.Use != "remove ID" {
-		t.Errorf("Expected Use to be 'remove ID', got '%s'", cmd.Use)
+	if cmd.Use != "remove NAME|ID" {
+		t.Errorf("Expected Use to be 'remove NAME|ID', got '%s'", cmd.Use)
 	}
 
 	// Verify it has the same behavior as workspace remove

--- a/pkg/cmd/start.go
+++ b/pkg/cmd/start.go
@@ -28,7 +28,7 @@ func NewStartCmd() *cobra.Command {
 
 	// Create an alias command that delegates to workspace start
 	cmd := &cobra.Command{
-		Use:               "start ID",
+		Use:               "start NAME|ID",
 		Short:             workspaceStartCmd.Short,
 		Long:              workspaceStartCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceStartCmd.Example, "workspace start", "start"),

--- a/pkg/cmd/stop.go
+++ b/pkg/cmd/stop.go
@@ -28,7 +28,7 @@ func NewStopCmd() *cobra.Command {
 
 	// Create an alias command that delegates to workspace stop
 	cmd := &cobra.Command{
-		Use:               "stop ID",
+		Use:               "stop NAME|ID",
 		Short:             workspaceStopCmd.Short,
 		Long:              workspaceStopCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceStopCmd.Example, "workspace stop", "stop"),

--- a/pkg/cmd/terminal.go
+++ b/pkg/cmd/terminal.go
@@ -28,7 +28,7 @@ func NewTerminalCmd() *cobra.Command {
 
 	// Create an alias command that delegates to workspace terminal
 	cmd := &cobra.Command{
-		Use:               "terminal ID [COMMAND...]",
+		Use:               "terminal NAME|ID [COMMAND...]",
 		Short:             workspaceTerminalCmd.Short,
 		Long:              workspaceTerminalCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceTerminalCmd.Example, "workspace terminal", "terminal"),

--- a/pkg/cmd/terminal_test.go
+++ b/pkg/cmd/terminal_test.go
@@ -36,8 +36,8 @@ func TestTerminalCmd(t *testing.T) {
 		t.Fatal("NewTerminalCmd() returned nil")
 	}
 
-	if cmd.Use != "terminal ID [COMMAND...]" {
-		t.Errorf("Expected Use to be 'terminal ID [COMMAND...]', got '%s'", cmd.Use)
+	if cmd.Use != "terminal NAME|ID [COMMAND...]" {
+		t.Errorf("Expected Use to be 'terminal NAME|ID [COMMAND...]', got '%s'", cmd.Use)
 	}
 }
 

--- a/pkg/cmd/workspace_remove.go
+++ b/pkg/cmd/workspace_remove.go
@@ -35,7 +35,7 @@ import (
 // workspaceRemoveCmd contains the configuration for the workspace remove command
 type workspaceRemoveCmd struct {
 	manager  instances.Manager
-	id       string
+	nameOrID string
 	output   string
 	showLogs bool
 }
@@ -57,7 +57,7 @@ func (w *workspaceRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
 		cmd.SilenceErrors = true
 	}
 
-	w.id = args[0]
+	w.nameOrID = args[0]
 
 	// Get storage directory from global flag
 	storageDir, err := cmd.Flags().GetString("storage")
@@ -110,34 +110,43 @@ func (w *workspaceRemoveCmd) run(cmd *cobra.Command, args []string) error {
 	}
 	ctx = logger.WithLogger(ctx, l)
 
-	// Delete the instance
-	err := w.manager.Delete(ctx, w.id)
+	// Resolve name or ID to get the instance
+	instance, err := w.manager.Get(w.nameOrID)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
 			if w.output == "json" {
-				return outputErrorIfJSON(cmd, w.output, fmt.Errorf("workspace not found: %s", w.id))
+				return outputErrorIfJSON(cmd, w.output, fmt.Errorf("workspace not found: %s", w.nameOrID))
 			}
-			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.id)
+			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
 		}
+		return outputErrorIfJSON(cmd, w.output, err)
+	}
+
+	// Get the actual ID (in case user provided a name)
+	instanceID := instance.GetID()
+
+	// Delete the instance
+	err = w.manager.Delete(ctx, instanceID)
+	if err != nil {
 		return outputErrorIfJSON(cmd, w.output, err)
 	}
 
 	// Handle JSON output
 	if w.output == "json" {
-		return w.outputJSON(cmd)
+		return w.outputJSON(cmd, instanceID)
 	}
 
 	// Output only the ID (text mode)
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, w.id)
+	fmt.Fprintln(out, instanceID)
 	return nil
 }
 
 // outputJSON outputs the workspace ID as JSON
-func (w *workspaceRemoveCmd) outputJSON(cmd *cobra.Command) error {
+func (w *workspaceRemoveCmd) outputJSON(cmd *cobra.Command, id string) error {
 	// Return only the ID (per OpenAPI spec)
 	workspaceId := api.WorkspaceId{
-		Id: w.id,
+		Id: id,
 	}
 
 	jsonData, err := json.MarshalIndent(workspaceId, "", "  ")
@@ -153,11 +162,14 @@ func NewWorkspaceRemoveCmd() *cobra.Command {
 	c := &workspaceRemoveCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "remove ID",
+		Use:   "remove NAME|ID",
 		Short: "Remove a workspace",
-		Long:  "Remove a workspace by its ID",
+		Long:  "Remove a workspace by its name or ID",
 		Example: `# Remove workspace by ID
 kortex-cli workspace remove abc123
+
+# Remove workspace by name
+kortex-cli workspace remove my-project
 
 # Remove workspace and show runtime command output
 kortex-cli workspace remove abc123 --show-logs`,

--- a/pkg/cmd/workspace_remove_test.go
+++ b/pkg/cmd/workspace_remove_test.go
@@ -42,8 +42,8 @@ func TestWorkspaceRemoveCmd(t *testing.T) {
 		t.Fatal("NewWorkspaceRemoveCmd() returned nil")
 	}
 
-	if cmd.Use != "remove ID" {
-		t.Errorf("Expected Use to be 'remove ID', got '%s'", cmd.Use)
+	if cmd.Use != "remove NAME|ID" {
+		t.Errorf("Expected Use to be 'remove NAME|ID', got '%s'", cmd.Use)
 	}
 }
 
@@ -70,8 +70,8 @@ func TestWorkspaceRemoveCmd_PreRun(t *testing.T) {
 			t.Error("Expected manager to be created")
 		}
 
-		if c.id != "test-workspace-id" {
-			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.id)
+		if c.nameOrID != "test-workspace-id" {
+			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.nameOrID)
 		}
 	})
 
@@ -745,7 +745,7 @@ func TestWorkspaceRemoveCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 2
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -35,7 +35,7 @@ import (
 // workspaceStartCmd contains the configuration for the workspace start command
 type workspaceStartCmd struct {
 	manager  instances.Manager
-	id       string
+	nameOrID string
 	output   string
 	showLogs bool
 }
@@ -57,7 +57,7 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 		cmd.SilenceErrors = true
 	}
 
-	w.id = args[0]
+	w.nameOrID = args[0]
 
 	// Get storage directory from global flag
 	storageDir, err := cmd.Flags().GetString("storage")
@@ -110,34 +110,43 @@ func (w *workspaceStartCmd) run(cmd *cobra.Command, args []string) error {
 	}
 	ctx = logger.WithLogger(ctx, l)
 
-	// Start the instance
-	err := w.manager.Start(ctx, w.id)
+	// Resolve name or ID to get the instance
+	instance, err := w.manager.Get(w.nameOrID)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
 			if w.output == "json" {
-				return outputErrorIfJSON(cmd, w.output, fmt.Errorf("workspace not found: %s", w.id))
+				return outputErrorIfJSON(cmd, w.output, fmt.Errorf("workspace not found: %s", w.nameOrID))
 			}
-			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.id)
+			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
 		}
+		return outputErrorIfJSON(cmd, w.output, err)
+	}
+
+	// Get the actual ID (in case user provided a name)
+	instanceID := instance.GetID()
+
+	// Start the instance
+	err = w.manager.Start(ctx, instanceID)
+	if err != nil {
 		return outputErrorIfJSON(cmd, w.output, err)
 	}
 
 	// Handle JSON output
 	if w.output == "json" {
-		return w.outputJSON(cmd)
+		return w.outputJSON(cmd, instanceID)
 	}
 
 	// Output only the ID (text mode)
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, w.id)
+	fmt.Fprintln(out, instanceID)
 	return nil
 }
 
 // outputJSON outputs the workspace ID as JSON
-func (w *workspaceStartCmd) outputJSON(cmd *cobra.Command) error {
+func (w *workspaceStartCmd) outputJSON(cmd *cobra.Command, id string) error {
 	// Return only the ID (per OpenAPI spec)
 	workspaceId := api.WorkspaceId{
-		Id: w.id,
+		Id: id,
 	}
 
 	jsonData, err := json.MarshalIndent(workspaceId, "", "  ")
@@ -153,11 +162,14 @@ func NewWorkspaceStartCmd() *cobra.Command {
 	c := &workspaceStartCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "start ID",
+		Use:   "start NAME|ID",
 		Short: "Start a workspace",
-		Long:  "Start a workspace by its ID",
+		Long:  "Start a workspace by its name or ID",
 		Example: `# Start workspace by ID
 kortex-cli workspace start abc123
+
+# Start workspace by name
+kortex-cli workspace start my-project
 
 # Start workspace with JSON output
 kortex-cli workspace start abc123 --output json

--- a/pkg/cmd/workspace_start_test.go
+++ b/pkg/cmd/workspace_start_test.go
@@ -42,8 +42,8 @@ func TestWorkspaceStartCmd(t *testing.T) {
 		t.Fatal("NewWorkspaceStartCmd() returned nil")
 	}
 
-	if cmd.Use != "start ID" {
-		t.Errorf("Expected Use to be 'start ID', got '%s'", cmd.Use)
+	if cmd.Use != "start NAME|ID" {
+		t.Errorf("Expected Use to be 'start NAME|ID', got '%s'", cmd.Use)
 	}
 }
 
@@ -70,8 +70,8 @@ func TestWorkspaceStartCmd_PreRun(t *testing.T) {
 			t.Error("Expected manager to be created")
 		}
 
-		if c.id != "test-workspace-id" {
-			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.id)
+		if c.nameOrID != "test-workspace-id" {
+			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.nameOrID)
 		}
 	})
 
@@ -739,7 +739,7 @@ func TestWorkspaceStartCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 3
+	expectedCount := 4
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_stop.go
+++ b/pkg/cmd/workspace_stop.go
@@ -35,7 +35,7 @@ import (
 // workspaceStopCmd contains the configuration for the workspace stop command
 type workspaceStopCmd struct {
 	manager  instances.Manager
-	id       string
+	nameOrID string
 	output   string
 	showLogs bool
 }
@@ -57,7 +57,7 @@ func (w *workspaceStopCmd) preRun(cmd *cobra.Command, args []string) error {
 		cmd.SilenceErrors = true
 	}
 
-	w.id = args[0]
+	w.nameOrID = args[0]
 
 	// Get storage directory from global flag
 	storageDir, err := cmd.Flags().GetString("storage")
@@ -110,34 +110,43 @@ func (w *workspaceStopCmd) run(cmd *cobra.Command, args []string) error {
 	}
 	ctx = logger.WithLogger(ctx, l)
 
-	// Stop the instance
-	err := w.manager.Stop(ctx, w.id)
+	// Resolve name or ID to get the instance
+	instance, err := w.manager.Get(w.nameOrID)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
 			if w.output == "json" {
-				return outputErrorIfJSON(cmd, w.output, fmt.Errorf("workspace not found: %s", w.id))
+				return outputErrorIfJSON(cmd, w.output, fmt.Errorf("workspace not found: %s", w.nameOrID))
 			}
-			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.id)
+			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
 		}
+		return outputErrorIfJSON(cmd, w.output, err)
+	}
+
+	// Get the actual ID (in case user provided a name)
+	instanceID := instance.GetID()
+
+	// Stop the instance
+	err = w.manager.Stop(ctx, instanceID)
+	if err != nil {
 		return outputErrorIfJSON(cmd, w.output, err)
 	}
 
 	// Handle JSON output
 	if w.output == "json" {
-		return w.outputJSON(cmd)
+		return w.outputJSON(cmd, instanceID)
 	}
 
 	// Output only the ID (text mode)
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, w.id)
+	fmt.Fprintln(out, instanceID)
 	return nil
 }
 
 // outputJSON outputs the workspace ID as JSON
-func (w *workspaceStopCmd) outputJSON(cmd *cobra.Command) error {
+func (w *workspaceStopCmd) outputJSON(cmd *cobra.Command, id string) error {
 	// Return only the ID (per OpenAPI spec)
 	workspaceId := api.WorkspaceId{
-		Id: w.id,
+		Id: id,
 	}
 
 	jsonData, err := json.MarshalIndent(workspaceId, "", "  ")
@@ -153,11 +162,14 @@ func NewWorkspaceStopCmd() *cobra.Command {
 	c := &workspaceStopCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "stop ID",
+		Use:   "stop NAME|ID",
 		Short: "Stop a workspace",
-		Long:  "Stop a workspace by its ID",
+		Long:  "Stop a workspace by its name or ID",
 		Example: `# Stop workspace by ID
 kortex-cli workspace stop abc123
+
+# Stop workspace by name
+kortex-cli workspace stop my-project
 
 # Stop workspace with JSON output
 kortex-cli workspace stop abc123 --output json

--- a/pkg/cmd/workspace_stop_test.go
+++ b/pkg/cmd/workspace_stop_test.go
@@ -42,8 +42,8 @@ func TestWorkspaceStopCmd(t *testing.T) {
 		t.Fatal("NewWorkspaceStopCmd() returned nil")
 	}
 
-	if cmd.Use != "stop ID" {
-		t.Errorf("Expected Use to be 'stop ID', got '%s'", cmd.Use)
+	if cmd.Use != "stop NAME|ID" {
+		t.Errorf("Expected Use to be 'stop NAME|ID', got '%s'", cmd.Use)
 	}
 }
 
@@ -70,8 +70,8 @@ func TestWorkspaceStopCmd_PreRun(t *testing.T) {
 			t.Error("Expected manager to be created")
 		}
 
-		if c.id != "test-workspace-id" {
-			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.id)
+		if c.nameOrID != "test-workspace-id" {
+			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.nameOrID)
 		}
 	})
 
@@ -789,7 +789,7 @@ func TestWorkspaceStopCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 3
+	expectedCount := 4
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_terminal.go
+++ b/pkg/cmd/workspace_terminal.go
@@ -30,14 +30,14 @@ import (
 
 // workspaceTerminalCmd contains the configuration for the workspace terminal command
 type workspaceTerminalCmd struct {
-	manager instances.Manager
-	id      string
-	command []string
+	manager  instances.Manager
+	nameOrID string
+	command  []string
 }
 
 // preRun validates the parameters and flags
 func (w *workspaceTerminalCmd) preRun(cmd *cobra.Command, args []string) error {
-	w.id = args[0]
+	w.nameOrID = args[0]
 
 	// Extract command from args[1:] if provided
 	// If no command is provided, w.command will be empty and the runtime
@@ -76,12 +76,21 @@ func (w *workspaceTerminalCmd) preRun(cmd *cobra.Command, args []string) error {
 
 // run executes the workspace terminal command logic
 func (w *workspaceTerminalCmd) run(cmd *cobra.Command, args []string) error {
-	// Start terminal session
-	err := w.manager.Terminal(cmd.Context(), w.id, w.command)
+	// Resolve name or ID to get the instance
+	instance, err := w.manager.Get(w.nameOrID)
 	if err != nil {
 		if errors.Is(err, instances.ErrInstanceNotFound) {
-			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.id)
+			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
 		}
+		return err
+	}
+
+	// Get the actual ID (in case user provided a name)
+	instanceID := instance.GetID()
+
+	// Start terminal session
+	err = w.manager.Terminal(cmd.Context(), instanceID, w.command)
+	if err != nil {
 		return err
 	}
 
@@ -92,7 +101,7 @@ func NewWorkspaceTerminalCmd() *cobra.Command {
 	c := &workspaceTerminalCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "terminal ID [COMMAND...]",
+		Use:   "terminal NAME|ID [COMMAND...]",
 		Short: "Connect to a running workspace with an interactive terminal",
 		Long: `Connect to a running workspace with an interactive terminal session.
 
@@ -102,8 +111,11 @@ this by providing a custom command.
 
 The workspace must be in a running state. Use 'workspace start' to start a workspace
 before connecting.`,
-		Example: `# Connect using the default agent command
+		Example: `# Connect using the default agent command (by ID)
 kortex-cli workspace terminal abc123
+
+# Connect using the default agent command (by name)
+kortex-cli workspace terminal my-project
 
 # Run a bash shell
 kortex-cli workspace terminal abc123 bash

--- a/pkg/cmd/workspace_terminal_test.go
+++ b/pkg/cmd/workspace_terminal_test.go
@@ -38,8 +38,8 @@ func TestWorkspaceTerminalCmd(t *testing.T) {
 		t.Fatal("NewWorkspaceTerminalCmd() returned nil")
 	}
 
-	if cmd.Use != "terminal ID [COMMAND...]" {
-		t.Errorf("Expected Use to be 'terminal ID [COMMAND...]', got '%s'", cmd.Use)
+	if cmd.Use != "terminal NAME|ID [COMMAND...]" {
+		t.Errorf("Expected Use to be 'terminal NAME|ID [COMMAND...]', got '%s'", cmd.Use)
 	}
 }
 
@@ -66,8 +66,8 @@ func TestWorkspaceTerminalCmd_PreRun(t *testing.T) {
 			t.Error("Expected manager to be created")
 		}
 
-		if c.id != "test-workspace-id" {
-			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.id)
+		if c.nameOrID != "test-workspace-id" {
+			t.Errorf("Expected id to be 'test-workspace-id', got %s", c.nameOrID)
 		}
 
 		// Verify command is empty when no command args provided
@@ -94,8 +94,8 @@ func TestWorkspaceTerminalCmd_PreRun(t *testing.T) {
 			t.Fatalf("preRun() failed: %v", err)
 		}
 
-		if c.id != "test-id" {
-			t.Errorf("Expected id to be 'test-id', got %s", c.id)
+		if c.nameOrID != "test-id" {
+			t.Errorf("Expected id to be 'test-id', got %s", c.nameOrID)
 		}
 
 		// Verify command was extracted in preRun
@@ -126,7 +126,7 @@ func TestWorkspaceTerminalCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 3
+	expectedCount := 4
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -68,8 +68,8 @@ type Manager interface {
 	Terminal(ctx context.Context, id string, command []string) error
 	// List returns all registered instances
 	List() ([]Instance, error)
-	// Get retrieves a specific instance by ID
-	Get(id string) (Instance, error)
+	// Get retrieves a specific instance by name or ID
+	Get(nameOrID string) (Instance, error)
 	// Delete unregisters an instance by ID
 	Delete(ctx context.Context, id string) error
 	// Reconcile removes instances with inaccessible directories
@@ -441,8 +441,9 @@ func (m *manager) List() ([]Instance, error) {
 	return m.loadInstances()
 }
 
-// Get retrieves a specific instance by ID
-func (m *manager) Get(id string) (Instance, error) {
+// Get retrieves a specific instance by name or ID.
+// It first attempts to match by ID, then falls back to matching by name.
+func (m *manager) Get(nameOrID string) (Instance, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -451,9 +452,16 @@ func (m *manager) Get(id string) (Instance, error) {
 		return nil, err
 	}
 
-	// Look up by ID
+	// Try ID match first (backward compatible)
 	for _, instance := range instances {
-		if instance.GetID() == id {
+		if instance.GetID() == nameOrID {
+			return instance, nil
+		}
+	}
+
+	// Fall back to name match
+	for _, instance := range instances {
+		if instance.GetName() == nameOrID {
 			return instance, nil
 		}
 	}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -585,6 +585,93 @@ func TestManager_Get(t *testing.T) {
 			t.Errorf("Get() error = %v, want %v", err, ErrInstanceNotFound)
 		}
 	})
+
+	t.Run("retrieves existing instance by name", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		expectedSource := filepath.Join(instanceTmpDir, "source")
+		expectedConfig := filepath.Join(instanceTmpDir, "config")
+		expectedName := "my-workspace"
+		inst := newFakeInstance(newFakeInstanceParams{
+			Name:       expectedName,
+			SourceDir:  expectedSource,
+			ConfigDir:  expectedConfig,
+			Accessible: true,
+		})
+		added, _ := manager.Add(context.Background(), AddOptions{Instance: inst, RuntimeType: "fake"})
+
+		generatedID := added.GetID()
+
+		// Retrieve by name
+		retrieved, err := manager.Get(expectedName)
+		if err != nil {
+			t.Fatalf("Get() unexpected error = %v", err)
+		}
+		if retrieved.GetID() != generatedID {
+			t.Errorf("Get() returned instance with ID = %v, want %v", retrieved.GetID(), generatedID)
+		}
+		if retrieved.GetName() != expectedName {
+			t.Errorf("Get() returned instance with Name = %v, want %v", retrieved.GetName(), expectedName)
+		}
+		if retrieved.GetSourceDir() != expectedSource {
+			t.Errorf("Get() returned instance with SourceDir = %v, want %v", retrieved.GetSourceDir(), expectedSource)
+		}
+	})
+
+	t.Run("returns error for nonexistent name", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
+
+		_, err := manager.Get("nonexistent-name")
+		if err != ErrInstanceNotFound {
+			t.Errorf("Get() error = %v, want %v", err, ErrInstanceNotFound)
+		}
+	})
+
+	t.Run("ID takes precedence over name", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		// Create first instance
+		inst1 := newFakeInstance(newFakeInstanceParams{
+			Name:       "workspace-one",
+			SourceDir:  filepath.Join(instanceTmpDir, "source1"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config1"),
+			Accessible: true,
+		})
+		added1, _ := manager.Add(context.Background(), AddOptions{Instance: inst1, RuntimeType: "fake"})
+		id1 := added1.GetID()
+
+		// Create second instance
+		inst2 := newFakeInstance(newFakeInstanceParams{
+			Name:       "workspace-two",
+			SourceDir:  filepath.Join(instanceTmpDir, "source2"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config2"),
+			Accessible: true,
+		})
+		_, _ = manager.Add(context.Background(), AddOptions{Instance: inst2, RuntimeType: "fake"})
+
+		// Retrieve using the ID of first instance (should return first instance, not second)
+		retrieved, err := manager.Get(id1)
+		if err != nil {
+			t.Fatalf("Get() unexpected error = %v", err)
+		}
+		if retrieved.GetID() != id1 {
+			t.Errorf("Get() returned instance with ID = %v, want %v", retrieved.GetID(), id1)
+		}
+		if retrieved.GetName() != "workspace-one" {
+			t.Errorf("Get() returned instance with Name = %v, want %v", retrieved.GetName(), "workspace-one")
+		}
+	})
 }
 
 func TestManager_Delete(t *testing.T) {

--- a/skills/implementing-command-patterns/SKILL.md
+++ b/skills/implementing-command-patterns/SKILL.md
@@ -296,13 +296,13 @@ The `terminal` command provides an interactive session with a running workspace 
 
 ```go
 type workspaceTerminalCmd struct {
-    manager instances.Manager
-    id      string
-    command []string
+    manager  instances.Manager
+    nameOrID string
+    command  []string
 }
 
 func (w *workspaceTerminalCmd) preRun(cmd *cobra.Command, args []string) error {
-    w.id = args[0]
+    w.nameOrID = args[0]
 
     // Extract command from args[1:] if provided
     if len(args) > 1 {
@@ -337,12 +337,21 @@ func (w *workspaceTerminalCmd) preRun(cmd *cobra.Command, args []string) error {
 }
 
 func (w *workspaceTerminalCmd) run(cmd *cobra.Command, args []string) error {
-    // Connect to terminal - this is a blocking interactive call
-    err := w.manager.Terminal(cmd.Context(), w.id, w.command)
+    // Resolve name or ID to get the instance
+    instance, err := w.manager.Get(w.nameOrID)
     if err != nil {
         if errors.Is(err, instances.ErrInstanceNotFound) {
-            return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.id)
+            return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
         }
+        return err
+    }
+
+    // Get the actual ID (in case user provided a name)
+    instanceID := instance.GetID()
+
+    // Connect to terminal - this is a blocking interactive call
+    err = w.manager.Terminal(cmd.Context(), instanceID, w.command)
+    if err != nil {
         return err
     }
     return nil
@@ -364,10 +373,10 @@ func NewWorkspaceTerminalCmd() *cobra.Command {
     c := &workspaceTerminalCmd{}
 
     cmd := &cobra.Command{
-        Use:     "terminal ID [COMMAND...]",
+        Use:     "terminal NAME|ID [COMMAND...]",
         Short:   "Connect to a running workspace with an interactive terminal",
         Args:    cobra.MinimumNArgs(1),
-        ValidArgsFunction: completeRunningWorkspaceID,  // Only show running workspaces
+        ValidArgsFunction: completeRunningWorkspaceID,  // Shows running workspace IDs and names
         PreRunE: c.preRun,
         RunE:    c.run,
     }

--- a/skills/working-with-instances-manager/SKILL.md
+++ b/skills/working-with-instances-manager/SKILL.md
@@ -83,13 +83,13 @@ for _, instance := range instancesList {
 
 ### Get - Retrieve Specific Instance
 
-Get a specific instance by ID:
+Get a specific instance by name or ID:
 
 ```go
-instance, err := manager.Get(id)
+instance, err := manager.Get(nameOrID)
 if err != nil {
     if errors.Is(err, instances.ErrInstanceNotFound) {
-        return fmt.Errorf("workspace not found: %s", id)
+        return fmt.Errorf("workspace not found: %s", nameOrID)
     }
     return fmt.Errorf("instance not found: %w", err)
 }
@@ -97,12 +97,18 @@ if err != nil {
 fmt.Printf("Found instance: %s (State: %s)\n", instance.ID, instance.State)
 ```
 
+**Key Points:**
+- The `Get()` method accepts either a workspace name or ID
+- It first tries to match by ID, then falls back to matching by name
+- This allows commands to accept user-friendly names while still supporting IDs
+- The method always returns the instance with its ID, regardless of how it was looked up
+
 ### Delete - Remove Instance
 
-Delete an instance from the manager:
+Delete an instance from the manager (requires ID):
 
 ```go
-err := manager.Delete(id)
+err := manager.Delete(ctx, id)
 if err != nil {
     if errors.Is(err, instances.ErrInstanceNotFound) {
         return fmt.Errorf("workspace not found: %s", id)
@@ -111,25 +117,69 @@ if err != nil {
 }
 ```
 
-### Start - Start Instance Runtime
+**For commands accepting name or ID:**
 
-Start a stopped instance:
+Commands should resolve the name or ID to an instance first, then use the ID:
 
 ```go
-info, err := manager.Start(ctx, id)
+// Resolve name or ID to get the instance
+instance, err := manager.Get(nameOrID)
+if err != nil {
+    if errors.Is(err, instances.ErrInstanceNotFound) {
+        return fmt.Errorf("workspace not found: %s", nameOrID)
+    }
+    return err
+}
+
+// Use the resolved ID
+err = manager.Delete(ctx, instance.GetID())
+if err != nil {
+    return fmt.Errorf("failed to delete instance: %w", err)
+}
+```
+
+### Start - Start Instance Runtime
+
+Start a stopped instance (requires ID):
+
+```go
+err := manager.Start(ctx, id)
 if err != nil {
     if errors.Is(err, instances.ErrInstanceNotFound) {
         return fmt.Errorf("workspace not found: %s", id)
     }
     return fmt.Errorf("failed to start instance: %w", err)
 }
+```
 
-fmt.Printf("Started instance: %s (State: %s)\n", info.ID, info.State)
+**For commands accepting name or ID:**
+
+Commands should resolve the name or ID to an instance first, then use the ID:
+
+```go
+// Resolve name or ID to get the instance
+instance, err := manager.Get(nameOrID)
+if err != nil {
+    if errors.Is(err, instances.ErrInstanceNotFound) {
+        return fmt.Errorf("workspace not found: %s", nameOrID)
+    }
+    return err
+}
+
+// Use the resolved ID
+instanceID := instance.GetID()
+err = manager.Start(ctx, instanceID)
+if err != nil {
+    return fmt.Errorf("failed to start instance: %w", err)
+}
+
+// Output the ID (not the name)
+fmt.Fprintln(cmd.OutOrStdout(), instanceID)
 ```
 
 ### Stop - Stop Instance Runtime
 
-Stop a running instance:
+Stop a running instance (requires ID):
 
 ```go
 err := manager.Stop(ctx, id)
@@ -141,9 +191,34 @@ if err != nil {
 }
 ```
 
+**For commands accepting name or ID:**
+
+Commands should resolve the name or ID to an instance first, then use the ID:
+
+```go
+// Resolve name or ID to get the instance
+instance, err := manager.Get(nameOrID)
+if err != nil {
+    if errors.Is(err, instances.ErrInstanceNotFound) {
+        return fmt.Errorf("workspace not found: %s", nameOrID)
+    }
+    return err
+}
+
+// Use the resolved ID
+instanceID := instance.GetID()
+err = manager.Stop(ctx, instanceID)
+if err != nil {
+    return fmt.Errorf("failed to stop instance: %w", err)
+}
+
+// Output the ID (not the name)
+fmt.Fprintln(cmd.OutOrStdout(), instanceID)
+```
+
 ### Terminal - Interactive Terminal Session
 
-Connect to a running instance with an interactive terminal:
+Connect to a running instance with an interactive terminal (requires ID):
 
 ```go
 err := manager.Terminal(cmd.Context(), id, []string{"bash"})
@@ -168,16 +243,27 @@ if err != nil {
 - Returns an error if instance state is not "running"
 - Returns an error if the runtime doesn't implement `runtime.Terminal` interface
 
-**Example usage in a command:**
+**For commands accepting name or ID:**
+
+Commands should resolve the name or ID to an instance first, then use the ID:
 
 ```go
 func (w *workspaceTerminalCmd) run(cmd *cobra.Command, args []string) error {
-    // Start terminal session with the command extracted in preRun
-    err := w.manager.Terminal(cmd.Context(), w.id, w.command)
+    // Resolve name or ID to get the instance
+    instance, err := w.manager.Get(w.nameOrID)
     if err != nil {
         if errors.Is(err, instances.ErrInstanceNotFound) {
-            return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.id)
+            return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
         }
+        return err
+    }
+
+    // Get the actual ID (in case user provided a name)
+    instanceID := instance.GetID()
+
+    // Start terminal session
+    err = w.manager.Terminal(cmd.Context(), instanceID, w.command)
+    if err != nil {
         return err
     }
     return nil


### PR DESCRIPTION
Workspaces can now be accessed using either their human-readable name or unique ID in all commands (start, stop, remove, terminal). The Manager.Get() method accepts name or ID and tries ID match first (backward compatible), then falls back to name match. Commands always output the workspace ID for consistency.

Closes #32