### PR TITLE
feat(cmd): group commands and indicate aliases in help output

### DIFF
--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -29,7 +29,7 @@ func NewListCmd() *cobra.Command {
 	// Create an alias command that delegates to workspace list
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   workspaceListCmd.Short,
+		Short:   workspaceListCmd.Short + " (alias for 'workspace list')",
 		Long:    workspaceListCmd.Long,
 		Example: AdaptExampleForAlias(workspaceListCmd.Example, "workspace list", "list"),
 		Args:    workspaceListCmd.Args,

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -34,9 +35,14 @@ func TestListCmd(t *testing.T) {
 		t.Errorf("Expected Use to be 'list', got '%s'", cmd.Use)
 	}
 
-	// Verify it has the same behavior as workspace list
+	// Verify it includes the original workspace list Short description
 	workspaceListCmd := NewWorkspaceListCmd()
-	if cmd.Short != workspaceListCmd.Short {
-		t.Errorf("Expected Short to match workspace list, got '%s'", cmd.Short)
+	if !strings.Contains(cmd.Short, workspaceListCmd.Short) {
+		t.Errorf("Expected Short to contain workspace list Short '%s', got '%s'", workspaceListCmd.Short, cmd.Short)
+	}
+
+	// Verify it includes the alias indicator
+	if !strings.Contains(cmd.Short, "(alias for 'workspace list')") {
+		t.Errorf("Expected Short to contain alias indicator, got '%s'", cmd.Short)
 	}
 }

--- a/pkg/cmd/remove.go
+++ b/pkg/cmd/remove.go
@@ -29,7 +29,7 @@ func NewRemoveCmd() *cobra.Command {
 	// Create an alias command that delegates to workspace remove
 	cmd := &cobra.Command{
 		Use:               "remove NAME|ID",
-		Short:             workspaceRemoveCmd.Short,
+		Short:             workspaceRemoveCmd.Short + " (alias for 'workspace remove')",
 		Long:              workspaceRemoveCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceRemoveCmd.Example, "workspace remove", "remove"),
 		Args:              workspaceRemoveCmd.Args,

--- a/pkg/cmd/remove_test.go
+++ b/pkg/cmd/remove_test.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -34,9 +35,14 @@ func TestRemoveCmd(t *testing.T) {
 		t.Errorf("Expected Use to be 'remove NAME|ID', got '%s'", cmd.Use)
 	}
 
-	// Verify it has the same behavior as workspace remove
+	// Verify it includes the original workspace remove Short description
 	workspaceRemoveCmd := NewWorkspaceRemoveCmd()
-	if cmd.Short != workspaceRemoveCmd.Short {
-		t.Errorf("Expected Short to match workspace remove, got '%s'", cmd.Short)
+	if !strings.Contains(cmd.Short, workspaceRemoveCmd.Short) {
+		t.Errorf("Expected Short to contain workspace remove Short '%s', got '%s'", workspaceRemoveCmd.Short, cmd.Short)
+	}
+
+	// Verify it includes the alias indicator
+	if !strings.Contains(cmd.Short, "(alias for 'workspace remove')") {
+		t.Errorf("Expected Short to contain alias indicator, got '%s'", cmd.Short)
 	}
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -45,15 +45,47 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	// Add subcommands
+	// Add command groups
+	rootCmd.AddGroup(&cobra.Group{
+		ID:    "main",
+		Title: "Main Commands:",
+	})
+	rootCmd.AddGroup(&cobra.Group{
+		ID:    "workspace",
+		Title: "Workspace Commands:",
+	})
+
+	// Add subcommands with groups
+	initCmd := NewInitCmd()
+	initCmd.GroupID = "main"
+	rootCmd.AddCommand(initCmd)
+
+	listCmd := NewListCmd()
+	listCmd.GroupID = "main"
+	rootCmd.AddCommand(listCmd)
+
+	removeCmd := NewRemoveCmd()
+	removeCmd.GroupID = "main"
+	rootCmd.AddCommand(removeCmd)
+
+	startCmd := NewStartCmd()
+	startCmd.GroupID = "main"
+	rootCmd.AddCommand(startCmd)
+
+	stopCmd := NewStopCmd()
+	stopCmd.GroupID = "main"
+	rootCmd.AddCommand(stopCmd)
+
+	terminalCmd := NewTerminalCmd()
+	terminalCmd.GroupID = "main"
+	rootCmd.AddCommand(terminalCmd)
+
+	workspaceCmd := NewWorkspaceCmd()
+	workspaceCmd.GroupID = "workspace"
+	rootCmd.AddCommand(workspaceCmd)
+
+	// Commands without a group (will appear under "Additional Commands")
 	rootCmd.AddCommand(NewVersionCmd())
-	rootCmd.AddCommand(NewInitCmd())
-	rootCmd.AddCommand(NewWorkspaceCmd())
-	rootCmd.AddCommand(NewListCmd())
-	rootCmd.AddCommand(NewRemoveCmd())
-	rootCmd.AddCommand(NewStartCmd())
-	rootCmd.AddCommand(NewStopCmd())
-	rootCmd.AddCommand(NewTerminalCmd())
 
 	// Global flags
 	rootCmd.PersistentFlags().String("storage", defaultStoragePath, "Directory where kortex-cli will store all its files")

--- a/pkg/cmd/start.go
+++ b/pkg/cmd/start.go
@@ -29,7 +29,7 @@ func NewStartCmd() *cobra.Command {
 	// Create an alias command that delegates to workspace start
 	cmd := &cobra.Command{
 		Use:               "start NAME|ID",
-		Short:             workspaceStartCmd.Short,
+		Short:             workspaceStartCmd.Short + " (alias for 'workspace start')",
 		Long:              workspaceStartCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceStartCmd.Example, "workspace start", "start"),
 		Args:              workspaceStartCmd.Args,

--- a/pkg/cmd/stop.go
+++ b/pkg/cmd/stop.go
@@ -29,7 +29,7 @@ func NewStopCmd() *cobra.Command {
 	// Create an alias command that delegates to workspace stop
 	cmd := &cobra.Command{
 		Use:               "stop NAME|ID",
-		Short:             workspaceStopCmd.Short,
+		Short:             workspaceStopCmd.Short + " (alias for 'workspace stop')",
 		Long:              workspaceStopCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceStopCmd.Example, "workspace stop", "stop"),
 		Args:              workspaceStopCmd.Args,

--- a/pkg/cmd/terminal.go
+++ b/pkg/cmd/terminal.go
@@ -29,7 +29,7 @@ func NewTerminalCmd() *cobra.Command {
 	// Create an alias command that delegates to workspace terminal
 	cmd := &cobra.Command{
 		Use:               "terminal NAME|ID [COMMAND...]",
-		Short:             workspaceTerminalCmd.Short,
+		Short:             workspaceTerminalCmd.Short + " (alias for 'workspace terminal')",
 		Long:              workspaceTerminalCmd.Long,
 		Example:           AdaptExampleForAlias(workspaceTerminalCmd.Example, "workspace terminal", "terminal"),
 		Args:              workspaceTerminalCmd.Args,

--- a/pkg/cmd/terminal_test.go
+++ b/pkg/cmd/terminal_test.go
@@ -47,9 +47,14 @@ func TestTerminalCmd_DelegatesToWorkspaceTerminal(t *testing.T) {
 	terminalCmd := NewTerminalCmd()
 	workspaceTerminalCmd := NewWorkspaceTerminalCmd()
 
-	// Verify it delegates to workspace terminal
-	if terminalCmd.Short != workspaceTerminalCmd.Short {
-		t.Errorf("Short mismatch: alias=%s, workspace=%s", terminalCmd.Short, workspaceTerminalCmd.Short)
+	// Verify it includes the original workspace terminal Short description
+	if !strings.Contains(terminalCmd.Short, workspaceTerminalCmd.Short) {
+		t.Errorf("Expected Short to contain workspace terminal Short '%s', got '%s'", workspaceTerminalCmd.Short, terminalCmd.Short)
+	}
+
+	// Verify it includes the alias indicator
+	if !strings.Contains(terminalCmd.Short, "(alias for 'workspace terminal')") {
+		t.Errorf("Expected Short to contain alias indicator, got '%s'", terminalCmd.Short)
 	}
 
 	if terminalCmd.Long != workspaceTerminalCmd.Long {

--- a/skills/add-command-simple/SKILL.md
+++ b/skills/add-command-simple/SKILL.md
@@ -141,6 +141,28 @@ In `pkg/cmd/root.go`, add to the `NewRootCmd()` function:
 rootCmd.AddCommand(New<Command>Cmd())
 ```
 
+**Optional: Assign to a command group**
+
+If you want the command to appear in a specific group in the help output:
+
+```go
+// Define a group if it doesn't exist yet
+rootCmd.AddGroup(&cobra.Group{
+    ID:    "mygroup",
+    Title: "My Command Group:",
+})
+
+// Create and assign command to the group
+myCmd := New<Command>Cmd()
+myCmd.GroupID = "mygroup"
+rootCmd.AddCommand(myCmd)
+```
+
+Existing groups:
+- `main` - Main Commands (for commonly used workspace operations)
+- `workspace` - Workspace Commands (for the workspace parent command)
+- Commands without a group appear under "Additional Commands"
+
 ### 3. Create Tests
 
 Create `pkg/cmd/<command>_test.go`:

--- a/skills/add-command-with-json/SKILL.md
+++ b/skills/add-command-with-json/SKILL.md
@@ -165,6 +165,28 @@ In `pkg/cmd/root.go`, add to the `NewRootCmd()` function:
 rootCmd.AddCommand(New<Command>Cmd())
 ```
 
+**Optional: Assign to a command group**
+
+If you want the command to appear in a specific group in the help output:
+
+```go
+// Define a group if it doesn't exist yet
+rootCmd.AddGroup(&cobra.Group{
+    ID:    "mygroup",
+    Title: "My Command Group:",
+})
+
+// Create and assign command to the group
+myCmd := New<Command>Cmd()
+myCmd.GroupID = "mygroup"
+rootCmd.AddCommand(myCmd)
+```
+
+Existing groups:
+- `main` - Main Commands (for commonly used workspace operations)
+- `workspace` - Workspace Commands (for the workspace parent command)
+- Commands without a group appear under "Additional Commands"
+
 ### 3. Create Tests
 
 Create `pkg/cmd/<command>_test.go`:

--- a/skills/add-parent-command/SKILL.md
+++ b/skills/add-parent-command/SKILL.md
@@ -136,6 +136,28 @@ In `pkg/cmd/root.go`, add to the `NewRootCmd()` function:
 rootCmd.AddCommand(New<Parent>Cmd())
 ```
 
+**Optional: Assign to a command group**
+
+If you want the parent command to appear in a specific group in the help output:
+
+```go
+// Define a group if it doesn't exist yet
+rootCmd.AddGroup(&cobra.Group{
+    ID:    "mygroup",
+    Title: "My Command Group:",
+})
+
+// Create and assign parent command to the group
+parentCmd := New<Parent>Cmd()
+parentCmd.GroupID = "mygroup"
+rootCmd.AddCommand(parentCmd)
+```
+
+Existing groups:
+- `main` - Main Commands (for commonly used workspace operations)
+- `workspace` - Workspace Commands (for the workspace parent command)
+- Commands without a group appear under "Additional Commands"
+
 ### 4. Create Tests
 
 Create `pkg/cmd/<parent>_test.go`:


### PR DESCRIPTION
Organizes commands into "Main Commands", "Workspace Commands", and "Additional Commands" groups for better discoverability. Alias commands now show "(alias for 'workspace <command>')" in their descriptions to clarify the relationship between root-level and workspace subcommands.

Closes #144

```
% ./kortex-cli help
Launch and manage AI agent workspaces with custom configurations

Usage:
  kortex-cli [command]

Main Commands:
  init        Register a new workspace
  list        List all registered workspaces (alias for 'workspace list')
  remove      Remove a workspace (alias for 'workspace remove')
  start       Start a workspace (alias for 'workspace start')
  stop        Stop a workspace (alias for 'workspace stop')
  terminal    Connect to a running workspace with an interactive terminal (alias for 'workspace terminal')

Workspace Commands:
  workspace   Manage workspaces

Additional Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  version     Print the version number of kortex-cli

Flags:
  -h, --help             help for kortex-cli
      --storage string   Directory where kortex-cli will store all its files (default "/Users/phmartin/.kortex-cli")

Use "kortex-cli [command] --help" for more information about a command.
```