### PR TITLE
feat(agent): add cursor agent with automatic onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,169 @@ Claude Code finds this file on startup and skips onboarding.
 - This approach keeps your workspace self-contained — other developers using the same project are not affected, and your local `~/.claude` directory is not exposed inside the container
 - To apply changes to the settings, remove and re-register the workspace: `kortex-cli remove <workspace-id>` then `kortex-cli init` again
 
+### Using Cursor CLI Agent
+
+This scenario demonstrates how to configure the Cursor agent in a kortex-cli workspace, covering API key injection, sharing your local Cursor settings, and pre-configuring the default model.
+
+#### Defining the Cursor API Key via a Secret
+
+Cursor requires a `CURSOR_API_KEY` environment variable to authenticate with the Cursor service. Rather than embedding the key as plain text, use the secret mechanism to keep credentials out of your configuration files.
+
+**Step 1: Create the secret**
+
+For the **Podman runtime**, create the secret once on your host machine using `podman secret create`:
+
+```bash
+echo "$CURSOR_API_KEY" | podman secret create cursor-api-key -
+```
+
+**Step 2: Reference the secret in agent configuration**
+
+Create or edit `~/.kortex-cli/config/agents.json` to inject the secret as an environment variable for the `cursor` agent:
+
+```json
+{
+  "cursor": {
+    "environment": [
+      {
+        "name": "CURSOR_API_KEY",
+        "secret": "cursor-api-key"
+      }
+    ]
+  }
+}
+```
+
+**Step 3: Register and start the workspace**
+
+```bash
+# Register a workspace with the Podman runtime and Cursor agent
+kortex-cli init /path/to/project --runtime podman --agent cursor
+
+# Start the workspace
+kortex-cli start my-project
+
+# Connect — Cursor starts with the API key available
+kortex-cli terminal my-project
+```
+
+The secret name (`cursor-api-key`) must match the `secret` field value in your configuration. At workspace creation time, kortex-cli passes the secret to Podman, which injects it as the `CURSOR_API_KEY` environment variable inside the container.
+
+#### Sharing Local Cursor Settings
+
+To reuse your host Cursor settings (preferences, keybindings, extensions configuration, etc.) inside the workspace, mount the `~/.cursor` directory.
+
+Edit `~/.kortex-cli/config/agents.json` to add the mount:
+
+```json
+{
+  "cursor": {
+    "environment": [
+      {
+        "name": "CURSOR_API_KEY",
+        "secret": "cursor-api-key"
+      }
+    ],
+    "mounts": [
+      {"host": "$HOME/.cursor", "target": "$HOME/.cursor"}
+    ]
+  }
+}
+```
+
+The `~/.cursor` directory contains your Cursor configuration (settings, model preferences, etc.). It is mounted read-write so that changes made inside the workspace are persisted back to your host.
+
+#### Using Default Settings
+
+If you want to pre-configure Cursor with default settings without exposing your local `~/.cursor` directory inside the container, create default settings files that are baked into the container image at workspace registration time. This is an alternative to mounting your local Cursor settings — use one approach or the other, not both.
+
+**Automatic Onboarding Skip**
+
+When you register a workspace with the Cursor agent, kortex-cli automatically creates a `.workspace-trusted` file in the Cursor projects directory for the workspace sources path, so Cursor skips its workspace trust dialog on first launch.
+
+**Step 1: Configure the agent environment**
+
+Create or edit `~/.kortex-cli/config/agents.json` to inject the API key. No mount is needed since settings are baked in:
+
+```json
+{
+  "cursor": {
+    "environment": [
+      {
+        "name": "CURSOR_API_KEY",
+        "secret": "cursor-api-key"
+      }
+    ]
+  }
+}
+```
+
+**Step 2: Create the agent settings directory**
+
+```bash
+mkdir -p ~/.kortex-cli/config/cursor/.cursor
+```
+
+**Step 3: Write the default Cursor settings file**
+
+As an example, you can configure a default model:
+
+```bash
+cat > ~/.kortex-cli/config/cursor/.cursor/cli-config.json << 'EOF'
+{
+  "model": {
+    "modelId": "claude-4.5-opus-high-thinking",
+    "displayModelId": "claude-4.5-opus-high-thinking",
+    "displayName": "Opus 4.5 Thinking",
+    "displayNameShort": "Opus 4.5 Thinking",
+    "aliases": [
+      "opus",
+      "opus-4.5",
+      "opus-4-5"
+    ],
+    "maxMode": false
+  },
+  "hasChangedDefaultModel": true
+}
+EOF
+```
+
+**Fields:**
+
+- `model.modelId` - The model identifier used internally by Cursor
+- `model.displayName` / `model.displayNameShort` - Human-readable model names shown in the UI
+- `model.aliases` - Shorthand names that can be used to reference the model
+- `model.maxMode` - Whether to enable max mode for this model
+- `hasChangedDefaultModel` - Tells Cursor that the model selection is intentional and should not prompt the user to choose a model
+
+**Step 4: Register and start the workspace**
+
+```bash
+# Register a workspace — the settings file is embedded in the container image
+kortex-cli init /path/to/project --runtime podman --agent cursor
+
+# Start the workspace
+kortex-cli start my-project
+
+# Connect — Cursor starts with the configured model
+kortex-cli terminal my-project
+```
+
+When `init` runs, kortex-cli:
+1. Reads all files from `~/.kortex-cli/config/cursor/` (e.g., your model settings)
+2. Automatically creates the workspace trust file so Cursor skips its trust dialog
+3. Copies the final settings into the container image at `/home/agent/.cursor/cli-config.json`
+
+Cursor finds this file on startup and uses the pre-configured model without prompting.
+
+**Notes:**
+
+- The settings are baked into the container image at `init` time, not mounted at runtime — changes to the files on the host require re-registering the workspace to take effect
+- Any file placed under `~/.kortex-cli/config/cursor/` is copied into the container home directory, preserving the directory structure (e.g., `~/.kortex-cli/config/cursor/.cursor/cli-config.json` becomes `/home/agent/.cursor/cli-config.json` inside the container)
+- To apply changes to the settings, remove and re-register the workspace: `kortex-cli remove <workspace-id>` then `kortex-cli init` again
+- This approach keeps your workspace self-contained — other developers using the same project are not affected, and your local `~/.cursor` directory is not exposed inside the container
+- Do not combine this approach with the `~/.cursor` mount from the previous section — the mounted directory would override the baked-in defaults at runtime
+
 ### Sharing a GitHub Token
 
 This scenario demonstrates how to make a GitHub token available inside workspaces using the multi-level configuration system — either globally for all projects or scoped to a specific project.

--- a/pkg/agent/cursor.go
+++ b/pkg/agent/cursor.go
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// cursorAgent is the implementation of Agent for Cursor.
+type cursorAgent struct{}
+
+// Compile-time check to ensure cursorAgent implements Agent interface
+var _ Agent = (*cursorAgent)(nil)
+
+// NewCursor creates a new Cursor agent implementation.
+func NewCursor() Agent {
+	return &cursorAgent{}
+}
+
+// Name returns the agent name.
+func (c *cursorAgent) Name() string {
+	return "cursor"
+}
+
+// SkipOnboarding modifies Cursor settings to skip onboarding prompts.
+// It creates a .workspace-trusted file in the Cursor projects directory
+// for the given workspace sources path.
+func (c *cursorAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string) (map[string][]byte, error) {
+	if settings == nil {
+		settings = make(map[string][]byte)
+	}
+
+	cursorDir := workspacePathToCursorDir(workspaceSourcesPath)
+	filePath := fmt.Sprintf(".cursor/projects/%s/.workspace-trusted", cursorDir)
+
+	content := map[string]interface{}{
+		"trustedAt":     time.Now().UTC().Format(time.RFC3339Nano),
+		"workspacePath": workspaceSourcesPath,
+	}
+
+	contentJSON, err := json.MarshalIndent(content, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal cursor workspace-trusted file: %w", err)
+	}
+
+	settings[filePath] = contentJSON
+	return settings, nil
+}
+
+// workspacePathToCursorDir converts a workspace path to the directory name
+// used by Cursor in its projects directory. Cursor replaces '/' with '-'
+// and the resulting string has any leading '-' stripped.
+func workspacePathToCursorDir(workspacePath string) string {
+	dir := strings.ReplaceAll(workspacePath, "/", "-")
+	return strings.TrimLeft(dir, "-")
+}

--- a/pkg/agent/cursor_test.go
+++ b/pkg/agent/cursor_test.go
@@ -1,0 +1,221 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestCursor_Name(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+	if got := agent.Name(); got != "cursor" {
+		t.Errorf("Name() = %q, want %q", got, "cursor")
+	}
+}
+
+func TestCursor_SkipOnboarding_NoExistingSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+	settings := make(map[string][]byte)
+
+	before := time.Now().UTC()
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	after := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("SkipOnboarding() error = %v", err)
+	}
+
+	expectedPath := ".cursor/projects/workspace-sources/.workspace-trusted"
+	trustedFile, exists := result[expectedPath]
+	if !exists {
+		t.Fatalf("Expected %s to be created", expectedPath)
+	}
+
+	var content map[string]interface{}
+	if err := json.Unmarshal(trustedFile, &content); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if content["workspacePath"] != "/workspace/sources" {
+		t.Errorf("workspacePath = %v, want %q", content["workspacePath"], "/workspace/sources")
+	}
+
+	trustedAtStr, ok := content["trustedAt"].(string)
+	if !ok {
+		t.Fatalf("trustedAt is not a string: %v", content["trustedAt"])
+	}
+	trustedAt, err := time.Parse(time.RFC3339Nano, trustedAtStr)
+	if err != nil {
+		t.Fatalf("Failed to parse trustedAt: %v", err)
+	}
+	if trustedAt.Before(before) || trustedAt.After(after) {
+		t.Errorf("trustedAt = %v, expected between %v and %v", trustedAt, before, after)
+	}
+}
+
+func TestCursor_SkipOnboarding_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+
+	result, err := agent.SkipOnboarding(nil, "/workspace/sources")
+	if err != nil {
+		t.Fatalf("SkipOnboarding() error = %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected non-nil result map")
+	}
+
+	expectedPath := ".cursor/projects/workspace-sources/.workspace-trusted"
+	if _, exists := result[expectedPath]; !exists {
+		t.Errorf("Expected %s to be created", expectedPath)
+	}
+}
+
+func TestCursor_SkipOnboarding_DifferentWorkspacePaths(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		workspacePath     string
+		expectedCursorDir string
+	}{
+		{
+			name:              "podman path",
+			workspacePath:     "/workspace/sources",
+			expectedCursorDir: "workspace-sources",
+		},
+		{
+			name:              "fake runtime path",
+			workspacePath:     "/project/sources",
+			expectedCursorDir: "project-sources",
+		},
+		{
+			name:              "custom path",
+			workspacePath:     "/custom/workspace/location",
+			expectedCursorDir: "custom-workspace-location",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			agent := NewCursor()
+			settings := make(map[string][]byte)
+
+			result, err := agent.SkipOnboarding(settings, tc.workspacePath)
+			if err != nil {
+				t.Fatalf("SkipOnboarding() error = %v", err)
+			}
+
+			expectedPath := ".cursor/projects/" + tc.expectedCursorDir + "/.workspace-trusted"
+			trustedFile, exists := result[expectedPath]
+			if !exists {
+				t.Fatalf("Expected %s to be created", expectedPath)
+			}
+
+			var content map[string]interface{}
+			if err := json.Unmarshal(trustedFile, &content); err != nil {
+				t.Fatalf("Failed to parse result JSON: %v", err)
+			}
+
+			if content["workspacePath"] != tc.workspacePath {
+				t.Errorf("workspacePath = %v, want %q", content["workspacePath"], tc.workspacePath)
+			}
+		})
+	}
+}
+
+func TestCursor_SkipOnboarding_PreservesExistingSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+
+	existingSettings := map[string][]byte{
+		"some/other/file": []byte("existing content"),
+	}
+
+	result, err := agent.SkipOnboarding(existingSettings, "/workspace/sources")
+	if err != nil {
+		t.Fatalf("SkipOnboarding() error = %v", err)
+	}
+
+	if string(result["some/other/file"]) != "existing content" {
+		t.Errorf("Existing settings were not preserved")
+	}
+
+	expectedPath := ".cursor/projects/workspace-sources/.workspace-trusted"
+	if _, exists := result[expectedPath]; !exists {
+		t.Errorf("Expected %s to be created", expectedPath)
+	}
+}
+
+func TestWorkspacePathToCursorDir(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard podman path",
+			input:    "/workspace/sources",
+			expected: "workspace-sources",
+		},
+		{
+			name:     "project sources path",
+			input:    "/project/sources",
+			expected: "project-sources",
+		},
+		{
+			name:     "deeply nested path",
+			input:    "/a/b/c/d",
+			expected: "a-b-c-d",
+		},
+		{
+			name:     "single segment path",
+			input:    "/workspace",
+			expected: "workspace",
+		},
+		{
+			name:     "empty path",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := workspacePathToCursorDir(tc.input)
+			if got != tc.expected {
+				t.Errorf("workspacePathToCursorDir(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/agentsetup/register.go
+++ b/pkg/agentsetup/register.go
@@ -38,6 +38,7 @@ type agentFactory func() agent.Agent
 // Add new agents here to make them available for automatic registration.
 var availableAgents = []agentFactory{
 	agent.NewClaude,
+	agent.NewCursor,
 }
 
 // RegisterAll registers all available agent implementations to the given registrar.


### PR DESCRIPTION
Implements the Cursor agent by creating a .workspace-trusted file in ~/.cursor/projects/<workspace-dir>/ to skip Cursor's workspace trust dialog on first launch.

Add a Scenario section in the documentation to describe using Cursor CLI Agent.

Closes #180

Part of #165