### PR TITLE
feat(config): add skills support to workspace configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ type Logger interface {
 
 ### Config System
 
-The config system manages workspace configuration for **injecting environment variables and mounting directories** into workspaces (different from runtime-specific configuration).
+The config system manages workspace configuration for **injecting environment variables, mounting directories, and providing skills** into workspaces (different from runtime-specific configuration).
 
 **Multi-Level Configuration:**
 - **Workspace-level** (`.kaiden/workspace.json`) - Project configuration, set via `--workspace-configuration` flag
@@ -239,13 +239,25 @@ The Podman runtime supports runtime-specific configuration for **building and co
 **For Podman runtime configuration details, use:** `/working-with-podman-runtime-config`
 
 ### Skills System
+
 Skills are reusable capabilities that can be discovered and executed by AI agents:
+
 - **Location**: `skills/<skill-name>/SKILL.md`
 - **Claude support**: Skills are symlinked in `.claude/skills/` for Claude Code
 - **Format**: Each SKILL.md contains:
   - YAML frontmatter with `name`, `description`, `argument-hint`
   - Detailed instructions for execution
   - Usage examples
+
+Skills can be provided to workspaces via the `skills` field in `workspace.json` (or any other config level). Each entry is the path to a single skill directory on the host. kdn mounts it read-only into the agent's skills directory inside the container using the directory's basename as the skill name:
+
+| Agent | Container skills directory |
+|-------|--------------------------|
+| Claude Code | `$HOME/.claude/skills/` |
+| Goose | `$HOME/.agents/skills/` |
+| Cursor | `$HOME/.cursor/skills/` |
+
+The `Agent` interface (`pkg/agent/agent.go`) exposes `SkillsDir() string` which returns the container path (using the `$HOME` variable) where skill directories should be mounted. The manager calls this during `Add()` to convert `WorkspaceConfig.Skills` entries into `workspace.Mount` entries before passing the config to the runtime.
 
 ### Adding a New Skill
 1. Create directory: `skills/<skill-name>/`

--- a/README.md
+++ b/README.md
@@ -1394,7 +1394,7 @@ Configuration changes take effect when you **register a new workspace with `init
 
 ## Workspace Configuration
 
-Each workspace can optionally include a configuration file that customizes the environment and mount behavior for that specific workspace. The configuration is stored in a `workspace.json` file within the workspace's configuration directory (typically `.kaiden` in the sources directory).
+Each workspace can optionally include a configuration file that customizes the environment, mount, and skills behavior for that specific workspace. The configuration is stored in a `workspace.json` file within the workspace's configuration directory (typically `.kaiden` in the sources directory).
 
 ### Configuration File Location
 
@@ -1425,6 +1425,10 @@ The `workspace.json` file uses a nested JSON structure:
     {"host": "$SOURCES/../main", "target": "$SOURCES/../main"},
     {"host": "$HOME/.ssh", "target": "$HOME/.ssh"},
     {"host": "/absolute/path/to/data", "target": "/workspace/data"}
+  ],
+  "skills": [
+    "/absolute/path/to/commit-skill",
+    "$HOME/review-skill"
   ]
 }
 ```
@@ -1500,6 +1504,49 @@ Paths can also be absolute (e.g., `/absolute/path`).
 - Each path must be absolute or start with `$SOURCES` or `$HOME`
 - `$SOURCES`-based container targets must not escape above `/workspace`
 - `$HOME`-based container targets must not escape above `/home/agent`
+
+### Skills
+
+Configure skill directories to make available to the agent inside the workspace.
+
+Each entry is a path to a directory on the host that contains a single skill — a `SKILL.md` file and any related files. The directory is mounted read-only inside the agent's skills directory using the directory's basename as the skill name, allowing the agent to discover and use it.
+
+**Structure:**
+```json
+{
+  "skills": [
+    "/absolute/path/to/commit-skill",
+    "$HOME/review-skill"
+  ]
+}
+```
+
+**Fields:**
+- Each entry is a path to a host directory containing a single skill (`SKILL.md` and related files)
+
+**Path Variables:**
+
+Skills paths support the following variables:
+- `$HOME` - Expands to the user's home directory on the host
+
+Paths can also be absolute (e.g., `/absolute/path/to/commit-skill`).
+
+**Mount targets per agent:**
+
+Each skill directory is mounted read-only under the agent's skills directory inside the container. The subdirectory name matches the basename of the host path:
+
+| Agent | Mount target |
+|-------|-------------|
+| Claude Code | `~/.claude/skills/<basename>/` |
+| Goose | `~/.agents/skills/<basename>/` |
+| Cursor | `~/.cursor/skills/<basename>/` |
+
+For example, a skills path of `/home/user/commit-skill` is mounted at `~/.claude/skills/commit-skill/` for Claude Code, making the skill discoverable by the agent.
+
+**Validation Rules:**
+- Each path cannot be empty
+- Each path must be an absolute path or start with `$HOME`
+- `$SOURCES`-based paths are not supported for skills
 
 ### Configuration Validation
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -34,4 +34,8 @@ type Agent interface {
 	// If the agent does not support model configuration, settings are returned unchanged.
 	// Returns the modified settings map, or an error if modification fails.
 	SetModel(settings map[string][]byte, modelID string) (map[string][]byte, error)
+	// SkillsDir returns the container path (using $HOME variable) under which skill
+	// directories should be mounted (e.g., "$HOME/.claude/skills" for Claude Code).
+	// Returns "" if the agent does not support skills mounting.
+	SkillsDir() string
 }

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -108,6 +108,11 @@ func (c *claudeAgent) SkipOnboarding(settings map[string][]byte, workspaceSource
 	return settings, nil
 }
 
+// SkillsDir returns the container path under which skill directories are mounted for Claude Code.
+func (c *claudeAgent) SkillsDir() string {
+	return "$HOME/.claude/skills"
+}
+
 // SetModel configures the model ID in Claude settings.
 // It sets the model field in .claude/settings.json.
 // All other fields in the settings file are preserved.

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -493,3 +493,12 @@ func TestClaude_SetModel_OverwritesExistingModel(t *testing.T) {
 		t.Errorf("otherField = %v, want true", config["otherField"])
 	}
 }
+
+func TestClaude_SkillsDir(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	if got := agent.SkillsDir(); got != "$HOME/.claude/skills" {
+		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.claude/skills")
+	}
+}

--- a/pkg/agent/cursor.go
+++ b/pkg/agent/cursor.go
@@ -69,6 +69,11 @@ func (c *cursorAgent) SkipOnboarding(settings map[string][]byte, workspaceSource
 	return settings, nil
 }
 
+// SkillsDir returns the container path under which skill directories are mounted for Cursor.
+func (c *cursorAgent) SkillsDir() string {
+	return "$HOME/.cursor/skills"
+}
+
 // SetModel configures the model ID in Cursor settings.
 // It sets the model object in cli-config.json with the specified model ID.
 // All other fields in the settings file are preserved.

--- a/pkg/agent/cursor_test.go
+++ b/pkg/agent/cursor_test.go
@@ -411,3 +411,12 @@ func TestCursor_SetModel_InvalidJSON(t *testing.T) {
 		t.Fatal("Expected error for invalid JSON")
 	}
 }
+
+func TestCursor_SkillsDir(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+	if got := agent.SkillsDir(); got != "$HOME/.cursor/skills" {
+		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.cursor/skills")
+	}
+}

--- a/pkg/agent/goose.go
+++ b/pkg/agent/goose.go
@@ -81,6 +81,11 @@ func (g *gooseAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[s
 	return settings, nil
 }
 
+// SkillsDir returns the container path under which skill directories are mounted for Goose.
+func (g *gooseAgent) SkillsDir() string {
+	return "$HOME/.agents/skills"
+}
+
 // SetModel configures the model ID in Goose settings.
 // It sets the GOOSE_MODEL key in the config file.
 // All other fields in the settings file are preserved.

--- a/pkg/agent/goose_test.go
+++ b/pkg/agent/goose_test.go
@@ -309,3 +309,12 @@ func TestGoose_SetModel_OverwritesExistingModel(t *testing.T) {
 		t.Errorf("%s = %v, want false", gooseTelemetryKey, val)
 	}
 }
+
+func TestGoose_SkillsDir(t *testing.T) {
+	t.Parallel()
+
+	agent := NewGoose()
+	if got := agent.SkillsDir(); got != "$HOME/.agents/skills" {
+		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.agents/skills")
+	}
+}

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -40,6 +40,10 @@ func (f *fakeAgent) SetModel(settings map[string][]byte, _ string) (map[string][
 	return settings, nil
 }
 
+func (f *fakeAgent) SkillsDir() string {
+	return ""
+}
+
 func TestNewRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,11 +66,20 @@ type config struct {
 // Compile-time check to ensure config implements Config interface
 var _ Config = (*config)(nil)
 
-// isValidHostPath returns true if the host path is a native OS absolute path or starts with $SOURCES or $HOME.
-// Uses filepath.IsAbs so that only paths valid on the current OS are accepted
-// (e.g. "C:\foo" on Windows, "/foo" on Unix).
-func isValidHostPath(p string) bool {
-	return filepath.IsAbs(p) || strings.HasPrefix(p, "$SOURCES") || strings.HasPrefix(p, "$HOME")
+// isValidHostPath returns true if the host path is a native OS absolute path or starts with
+// one of the allowed variable prefixes. Variables should be provided without the leading "$"
+// (e.g. "HOME", "SOURCES"). Uses filepath.IsAbs so that only paths valid on the current OS
+// are accepted (e.g. "C:\foo" on Windows, "/foo" on Unix).
+func isValidHostPath(p string, variables []string) bool {
+	if filepath.IsAbs(p) {
+		return true
+	}
+	for _, v := range variables {
+		if strings.HasPrefix(p, "$"+v) {
+			return true
+		}
+	}
+	return false
 }
 
 // isValidTargetPath returns true if the container target path is a Unix absolute path or starts with $SOURCES or $HOME.
@@ -159,7 +168,7 @@ func (c *config) validate(cfg *workspace.WorkspaceConfiguration) error {
 			if m.Target == "" {
 				return fmt.Errorf("%w: mount at index %d is missing target", ErrInvalidConfig, i)
 			}
-			if !isValidHostPath(m.Host) {
+			if !isValidHostPath(m.Host, []string{"SOURCES", "HOME"}) {
 				return fmt.Errorf("%w: mount host %q (index %d) must be a native absolute path or start with $SOURCES or $HOME", ErrInvalidConfig, m.Host, i)
 			}
 			if !isValidTargetPath(m.Target) {
@@ -167,6 +176,18 @@ func (c *config) validate(cfg *workspace.WorkspaceConfiguration) error {
 			}
 			if err := checkTargetEscape(m.Target); err != nil {
 				return fmt.Errorf("%w: %s (index %d)", ErrInvalidConfig, err, i)
+			}
+		}
+	}
+
+	// Validate skills
+	if cfg.Skills != nil {
+		for i, s := range *cfg.Skills {
+			if s == "" {
+				return fmt.Errorf("%w: skills path at index %d is empty", ErrInvalidConfig, i)
+			}
+			if !isValidHostPath(s, []string{"HOME"}) {
+				return fmt.Errorf("%w: skills path %q (index %d) must be a native absolute path or start with $HOME", ErrInvalidConfig, s, i)
 			}
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1071,4 +1071,144 @@ func TestConfig_Load(t *testing.T) {
 			t.Errorf("Expected 3 mounts, got %d", len(*workspaceCfg.Mounts))
 		}
 	})
+
+	t.Run("rejects skills path that is empty", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configDir := filepath.Join(tempDir, ".kaiden")
+
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			t.Fatalf("os.MkdirAll() failed: %v", err)
+		}
+
+		workspaceJSON := `{
+  "skills": [""]
+}`
+		workspacePath := filepath.Join(configDir, WorkspaceConfigFile)
+		err = os.WriteFile(workspacePath, []byte(workspaceJSON), 0644)
+		if err != nil {
+			t.Fatalf("os.WriteFile() failed: %v", err)
+		}
+
+		cfg, err := NewConfig(configDir)
+		if err != nil {
+			t.Fatalf("NewConfig() failed: %v", err)
+		}
+
+		_, err = cfg.Load()
+		if err == nil {
+			t.Fatal("Expected error for empty skills path, got nil")
+		}
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Expected ErrInvalidConfig, got %v", err)
+		}
+	})
+
+	t.Run("rejects skills path that is relative", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configDir := filepath.Join(tempDir, ".kaiden")
+
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			t.Fatalf("os.MkdirAll() failed: %v", err)
+		}
+
+		workspaceJSON := `{
+  "skills": ["relative/path/to/skills"]
+}`
+		workspacePath := filepath.Join(configDir, WorkspaceConfigFile)
+		err = os.WriteFile(workspacePath, []byte(workspaceJSON), 0644)
+		if err != nil {
+			t.Fatalf("os.WriteFile() failed: %v", err)
+		}
+
+		cfg, err := NewConfig(configDir)
+		if err != nil {
+			t.Fatalf("NewConfig() failed: %v", err)
+		}
+
+		_, err = cfg.Load()
+		if err == nil {
+			t.Fatal("Expected error for relative skills path, got nil")
+		}
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Expected ErrInvalidConfig, got %v", err)
+		}
+	})
+
+	t.Run("rejects skills path starting with $SOURCES", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configDir := filepath.Join(tempDir, ".kaiden")
+
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			t.Fatalf("os.MkdirAll() failed: %v", err)
+		}
+
+		workspaceJSON := `{
+  "skills": ["$SOURCES/skills"]
+}`
+		workspacePath := filepath.Join(configDir, WorkspaceConfigFile)
+		err = os.WriteFile(workspacePath, []byte(workspaceJSON), 0644)
+		if err != nil {
+			t.Fatalf("os.WriteFile() failed: %v", err)
+		}
+
+		cfg, err := NewConfig(configDir)
+		if err != nil {
+			t.Fatalf("NewConfig() failed: %v", err)
+		}
+
+		_, err = cfg.Load()
+		if err == nil {
+			t.Fatal("Expected error for $SOURCES skills path, got nil")
+		}
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Expected ErrInvalidConfig, got %v", err)
+		}
+	})
+
+	t.Run("accepts valid skills paths", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configDir := filepath.Join(tempDir, ".kaiden")
+
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			t.Fatalf("os.MkdirAll() failed: %v", err)
+		}
+
+		workspaceJSON := fmt.Sprintf(`{
+  "skills": ["%s", "$HOME/my-skills"]
+}`, filepath.ToSlash(tempDir))
+		workspacePath := filepath.Join(configDir, WorkspaceConfigFile)
+		err = os.WriteFile(workspacePath, []byte(workspaceJSON), 0644)
+		if err != nil {
+			t.Fatalf("os.WriteFile() failed: %v", err)
+		}
+
+		cfg, err := NewConfig(configDir)
+		if err != nil {
+			t.Fatalf("NewConfig() failed: %v", err)
+		}
+
+		workspaceCfg, err := cfg.Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+
+		if workspaceCfg.Skills == nil {
+			t.Fatal("Expected skills to be non-nil")
+		}
+		if len(*workspaceCfg.Skills) != 2 {
+			t.Errorf("Expected 2 skills, got %d", len(*workspaceCfg.Skills))
+		}
+	})
 }

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -66,6 +66,9 @@ func (m *merger) Merge(base, override *workspace.WorkspaceConfiguration) *worksp
 	// Merge mounts
 	result.Mounts = mergeMounts(base.Mounts, override.Mounts)
 
+	// Merge skills
+	result.Skills = mergeSkills(base.Skills, override.Skills)
+
 	return result
 }
 
@@ -157,6 +160,34 @@ func mergeMounts(base, override *[]workspace.Mount) *[]workspace.Mount {
 	return &result
 }
 
+// mergeSkills merges skills slices, deduplicating by path value.
+// Skills from base come first; skills from override are appended if not already present.
+func mergeSkills(base, override *[]string) *[]string {
+	if base == nil && override == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var result []string
+
+	for _, slice := range []*[]string{base, override} {
+		if slice == nil {
+			continue
+		}
+		for _, s := range *slice {
+			if !seen[s] {
+				seen[s] = true
+				result = append(result, s)
+			}
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return &result
+}
+
 // copyConfig creates a deep copy of a WorkspaceConfiguration
 func copyConfig(cfg *workspace.WorkspaceConfiguration) *workspace.WorkspaceConfiguration {
 	if cfg == nil {
@@ -179,6 +210,13 @@ func copyConfig(cfg *workspace.WorkspaceConfiguration) *workspace.WorkspaceConfi
 			mountsCopy[i] = deepCopyMount(m)
 		}
 		result.Mounts = &mountsCopy
+	}
+
+	// Copy skills
+	if cfg.Skills != nil {
+		skillsCopy := make([]string, len(*cfg.Skills))
+		copy(skillsCopy, *cfg.Skills)
+		result.Skills = &skillsCopy
 	}
 
 	return result

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -540,3 +540,79 @@ func TestMerger_Merge_EmptyConfigurations(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+func TestMergeSkills(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both nil returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		result := mergeSkills(nil, nil)
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("base nil returns copy of override", func(t *testing.T) {
+		t.Parallel()
+
+		override := &[]string{"/path/a", "/path/b"}
+		result := mergeSkills(nil, override)
+		if result == nil {
+			t.Fatal("Expected non-nil result")
+		}
+		if len(*result) != 2 {
+			t.Errorf("Expected 2 skills, got %d", len(*result))
+		}
+		if (*result)[0] != "/path/a" || (*result)[1] != "/path/b" {
+			t.Errorf("Unexpected skills: %v", *result)
+		}
+	})
+
+	t.Run("override nil returns copy of base", func(t *testing.T) {
+		t.Parallel()
+
+		base := &[]string{"/path/a", "/path/b"}
+		result := mergeSkills(base, nil)
+		if result == nil {
+			t.Fatal("Expected non-nil result")
+		}
+		if len(*result) != 2 {
+			t.Errorf("Expected 2 skills, got %d", len(*result))
+		}
+	})
+
+	t.Run("no overlap combines all", func(t *testing.T) {
+		t.Parallel()
+
+		base := &[]string{"/path/a"}
+		override := &[]string{"/path/b"}
+		result := mergeSkills(base, override)
+		if result == nil {
+			t.Fatal("Expected non-nil result")
+		}
+		if len(*result) != 2 {
+			t.Errorf("Expected 2 skills, got %d", len(*result))
+		}
+		if (*result)[0] != "/path/a" || (*result)[1] != "/path/b" {
+			t.Errorf("Unexpected skills order: %v", *result)
+		}
+	})
+
+	t.Run("duplicates are deduplicated", func(t *testing.T) {
+		t.Parallel()
+
+		base := &[]string{"/path/a", "/path/b"}
+		override := &[]string{"/path/b", "/path/c"}
+		result := mergeSkills(base, override)
+		if result == nil {
+			t.Fatal("Expected non-nil result")
+		}
+		if len(*result) != 3 {
+			t.Errorf("Expected 3 skills, got %d: %v", len(*result), *result)
+		}
+		if (*result)[0] != "/path/a" || (*result)[1] != "/path/b" || (*result)[2] != "/path/c" {
+			t.Errorf("Unexpected skills: %v", *result)
+		}
+	})
+}

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -246,10 +246,16 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 			// Convert skills directories to mounts using the agent's skills directory
 			if skillsDir := agentImpl.SkillsDir(); skillsDir != "" && mergedConfig != nil && mergedConfig.Skills != nil {
 				roTrue := true
+				seenTargets := make(map[string]string)
 				for _, skillsPath := range *mergedConfig.Skills {
+					target := path.Join(skillsDir, filepath.Base(skillsPath))
+					if existing, ok := seenTargets[target]; ok {
+						return nil, fmt.Errorf("skills %q and %q have the same target directory %q", existing, skillsPath, target)
+					}
+					seenTargets[target] = skillsPath
 					mount := workspace.Mount{
 						Host:   skillsPath,
-						Target: path.Join(skillsDir, filepath.Base(skillsPath)),
+						Target: target,
 						Ro:     &roTrue,
 					}
 					if mergedConfig.Mounts == nil {

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -239,6 +240,24 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 				agentSettings, err = agentImpl.SetModel(agentSettings, opts.Model)
 				if err != nil {
 					return nil, fmt.Errorf("failed to apply agent model settings: %w", err)
+				}
+			}
+
+			// Convert skills directories to mounts using the agent's skills directory
+			if skillsDir := agentImpl.SkillsDir(); skillsDir != "" && mergedConfig != nil && mergedConfig.Skills != nil {
+				roTrue := true
+				for _, skillsPath := range *mergedConfig.Skills {
+					mount := workspace.Mount{
+						Host:   skillsPath,
+						Target: path.Join(skillsDir, filepath.Base(skillsPath)),
+						Ro:     &roTrue,
+					}
+					if mergedConfig.Mounts == nil {
+						mounts := []workspace.Mount{mount}
+						mergedConfig.Mounts = &mounts
+					} else {
+						*mergedConfig.Mounts = append(*mergedConfig.Mounts, mount)
+					}
 				}
 			}
 		}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -3662,6 +3662,58 @@ func TestManager_Add_ConvertsSkillsToMounts(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate skill basenames produce an error", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		manager, err := NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		spy := newSpyRuntime(fake.New())
+		if err := manager.RegisterRuntime(spy); err != nil {
+			t.Fatalf("Failed to register spy runtime: %v", err)
+		}
+
+		trackingAgent := newTrackingAgentWithSkillsDir("test-agent", "$HOME/.claude/skills")
+		if err := manager.RegisterAgent("test-agent", trackingAgent); err != nil {
+			t.Fatalf("Failed to register tracking agent: %v", err)
+		}
+
+		instanceTmpDir := t.TempDir()
+		sourceDir := filepath.Join(instanceTmpDir, "source")
+		configDir := filepath.Join(instanceTmpDir, "config")
+		if err := os.MkdirAll(sourceDir, 0755); err != nil {
+			t.Fatalf("Failed to create source directory: %v", err)
+		}
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config directory: %v", err)
+		}
+
+		inst, err := NewInstance(NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: configDir,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		workspaceCfg := &workspace.WorkspaceConfiguration{
+			Skills: &[]string{"/path/one/my-skill", "/path/two/my-skill"},
+		}
+
+		_, err = manager.Add(context.Background(), AddOptions{
+			Instance:        inst,
+			RuntimeType:     "fake",
+			Agent:           "test-agent",
+			WorkspaceConfig: workspaceCfg,
+		})
+		if err == nil {
+			t.Fatal("Expected Add() to return an error for duplicate skill targets, got nil")
+		}
+	})
+
 	t.Run("skills are not converted when agent has no SkillsDir", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -204,6 +204,7 @@ func (g *fakeSequentialGenerator) Generate() string {
 // trackingAgent is a test double for the Agent interface that tracks method calls
 type trackingAgent struct {
 	name                   string
+	skillsDir              string
 	skipOnboardingCalled   bool
 	skipOnboardingSettings map[string][]byte
 	skipOnboardingPath     string
@@ -218,6 +219,10 @@ var _ agent.Agent = (*trackingAgent)(nil)
 
 func newTrackingAgent(name string) *trackingAgent {
 	return &trackingAgent{name: name}
+}
+
+func newTrackingAgentWithSkillsDir(name, skillsDir string) *trackingAgent {
+	return &trackingAgent{name: name, skillsDir: skillsDir}
 }
 
 func (t *trackingAgent) Name() string {
@@ -266,6 +271,10 @@ func (t *trackingAgent) WasSkipOnboardingCalled() bool {
 	return t.skipOnboardingCalled
 }
 
+func (t *trackingAgent) SkillsDir() string {
+	return t.skillsDir
+}
+
 // erroringSetModelAgent is a test double that returns an error from SetModel
 type erroringSetModelAgent struct {
 	name string
@@ -291,6 +300,10 @@ func (e *erroringSetModelAgent) SkipOnboarding(settings map[string][]byte, _ str
 
 func (e *erroringSetModelAgent) SetModel(_ map[string][]byte, _ string) (map[string][]byte, error) {
 	return nil, errors.New("simulated SetModel error")
+}
+
+func (e *erroringSetModelAgent) SkillsDir() string {
+	return ""
 }
 
 // newTestRegistry creates a runtime registry with a fake runtime for testing
@@ -3526,4 +3539,183 @@ func TestManager_Stop_RejectsInvalidState(t *testing.T) {
 			}
 		})
 	}
+}
+
+// spyRuntime is a test double for runtime.Runtime that captures the params passed to Create.
+type spyRuntime struct {
+	wrapped          runtime.Runtime
+	lastCreateParams runtime.CreateParams
+	mu               sync.Mutex
+}
+
+var _ runtime.Runtime = (*spyRuntime)(nil)
+
+func newSpyRuntime(wrapped runtime.Runtime) *spyRuntime {
+	return &spyRuntime{wrapped: wrapped}
+}
+
+func (s *spyRuntime) Type() string { return s.wrapped.Type() }
+
+func (s *spyRuntime) WorkspaceSourcesPath() string { return s.wrapped.WorkspaceSourcesPath() }
+
+func (s *spyRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+	s.mu.Lock()
+	s.lastCreateParams = params
+	s.mu.Unlock()
+	return s.wrapped.Create(ctx, params)
+}
+
+func (s *spyRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	return s.wrapped.Start(ctx, id)
+}
+
+func (s *spyRuntime) Stop(ctx context.Context, id string) error { return s.wrapped.Stop(ctx, id) }
+
+func (s *spyRuntime) Remove(ctx context.Context, id string) error {
+	return s.wrapped.Remove(ctx, id)
+}
+
+func (s *spyRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	return s.wrapped.Info(ctx, id)
+}
+
+func (s *spyRuntime) LastCreateParams() runtime.CreateParams {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastCreateParams
+}
+
+func TestManager_Add_ConvertsSkillsToMounts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skills are converted to mounts using agent SkillsDir", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		manager, err := NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		spy := newSpyRuntime(fake.New())
+		if err := manager.RegisterRuntime(spy); err != nil {
+			t.Fatalf("Failed to register spy runtime: %v", err)
+		}
+
+		trackingAgent := newTrackingAgentWithSkillsDir("test-agent", "$HOME/.claude/skills")
+		if err := manager.RegisterAgent("test-agent", trackingAgent); err != nil {
+			t.Fatalf("Failed to register tracking agent: %v", err)
+		}
+
+		instanceTmpDir := t.TempDir()
+		sourceDir := filepath.Join(instanceTmpDir, "source")
+		configDir := filepath.Join(instanceTmpDir, "config")
+		if err := os.MkdirAll(sourceDir, 0755); err != nil {
+			t.Fatalf("Failed to create source directory: %v", err)
+		}
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config directory: %v", err)
+		}
+
+		inst, err := NewInstance(NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: configDir,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		skillsPath := "/absolute/path/to/skills"
+		workspaceCfg := &workspace.WorkspaceConfiguration{
+			Skills: &[]string{skillsPath},
+		}
+
+		_, err = manager.Add(context.Background(), AddOptions{
+			Instance:        inst,
+			RuntimeType:     "fake",
+			Agent:           "test-agent",
+			WorkspaceConfig: workspaceCfg,
+		})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		params := spy.LastCreateParams()
+		if params.WorkspaceConfig == nil || params.WorkspaceConfig.Mounts == nil {
+			t.Fatal("Expected mounts to be set in CreateParams")
+		}
+
+		mounts := *params.WorkspaceConfig.Mounts
+		if len(mounts) != 1 {
+			t.Fatalf("Expected 1 mount, got %d: %v", len(mounts), mounts)
+		}
+
+		if mounts[0].Host != skillsPath {
+			t.Errorf("Mount host = %q, want %q", mounts[0].Host, skillsPath)
+		}
+		wantTarget := "$HOME/.claude/skills/skills"
+		if mounts[0].Target != wantTarget {
+			t.Errorf("Mount target = %q, want %q", mounts[0].Target, wantTarget)
+		}
+		if mounts[0].Ro == nil || !*mounts[0].Ro {
+			t.Error("Expected mount to be read-only")
+		}
+	})
+
+	t.Run("skills are not converted when agent has no SkillsDir", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		manager, err := NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		spy := newSpyRuntime(fake.New())
+		if err := manager.RegisterRuntime(spy); err != nil {
+			t.Fatalf("Failed to register spy runtime: %v", err)
+		}
+
+		trackingAgent := newTrackingAgentWithSkillsDir("test-agent", "")
+		if err := manager.RegisterAgent("test-agent", trackingAgent); err != nil {
+			t.Fatalf("Failed to register tracking agent: %v", err)
+		}
+
+		instanceTmpDir := t.TempDir()
+		sourceDir := filepath.Join(instanceTmpDir, "source")
+		configDir := filepath.Join(instanceTmpDir, "config")
+		if err := os.MkdirAll(sourceDir, 0755); err != nil {
+			t.Fatalf("Failed to create source directory: %v", err)
+		}
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config directory: %v", err)
+		}
+
+		inst, err := NewInstance(NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: configDir,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		workspaceCfg := &workspace.WorkspaceConfiguration{
+			Skills: &[]string{"/some/skills"},
+		}
+
+		_, err = manager.Add(context.Background(), AddOptions{
+			Instance:        inst,
+			RuntimeType:     "fake",
+			Agent:           "test-agent",
+			WorkspaceConfig: workspaceCfg,
+		})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		params := spy.LastCreateParams()
+		if params.WorkspaceConfig != nil && params.WorkspaceConfig.Mounts != nil {
+			t.Errorf("Expected no mounts when agent has empty SkillsDir, got %v", *params.WorkspaceConfig.Mounts)
+		}
+	})
 }

--- a/skills/working-with-config-system/SKILL.md
+++ b/skills/working-with-config-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: working-with-config-system
-description: Guide to workspace configuration for environment variables and mount points at multiple levels
+description: Guide to workspace configuration for environment variables, mount points, and skills at multiple levels
 argument-hint: ""
 ---
 
@@ -11,6 +11,7 @@ The config system manages **workspace configuration** for injecting environment 
 **What this config system controls:**
 - Environment variables to inject into workspace containers/VMs
 - Additional directories to mount, with explicit host and container paths
+- Skills directories to provide to agents inside the workspace
 
 **What this does NOT control:**
 - Runtime-specific settings (e.g., Podman container image, packages to install)
@@ -119,6 +120,10 @@ The `workspace.json` file controls what gets injected into the workspace:
     {"host": "$HOME/.ssh", "target": "$HOME/.ssh", "ro": true},
     {"host": "$HOME/.gitconfig", "target": "$HOME/.gitconfig", "ro": true},
     {"host": "/absolute/path/to/data", "target": "/workspace/data", "ro": true}
+  ],
+  "skills": [
+    "/absolute/path/to/commit-skill",
+    "$HOME/review-skill"
   ]
 }
 ```
@@ -145,6 +150,11 @@ kdn init /path/to/workspace --workspace-configuration /path/to/config-dir
   - `ro` - If `true`, mount is read-only (optional, defaults to read-write)
   - `$SOURCES` expands to the workspace sources directory on host, `/workspace/sources` in container
   - `$HOME` expands to the user's home directory on host, `/home/<container-user>` in container
+- `skills` - List of skill directories to provide to the agent (optional)
+  - Each entry is a path to a single skill directory on the host (containing a `SKILL.md` and related files)
+  - Paths must be absolute or start with `$HOME` (`$SOURCES` is not supported)
+  - Each directory is mounted read-only into the agent's skills directory using the directory's basename as the skill name
+  - The target path is agent-specific (e.g., `$HOME/.claude/skills/<basename>/` for Claude Code)
 
 ### Agent Configuration (`agents.json`)
 
@@ -253,6 +263,12 @@ if workspaceCfg.Mounts != nil {
         // Use m.Host, m.Target, m.Ro
     }
 }
+
+if workspaceCfg.Skills != nil {
+    for _, s := range *workspaceCfg.Skills {
+        // Use s (host path to skill directory)
+    }
+}
 ```
 
 ## Using the Multi-Level Config System
@@ -278,13 +294,15 @@ The Manager's `Add()` method:
 4. Merges configs: workspace → global → project → agent
 5. Calls agent's `SkipOnboarding()` if agent is registered
 6. Calls agent's `SetModel()` if model is specified (takes precedence over settings)
-7. Passes merged config to runtime for injection into workspace
+7. Converts `Skills` entries into `Mounts` using the agent's `SkillsDir()` (agent-specific target path)
+8. Passes merged config to runtime for injection into workspace
 
 ## Merging Behavior
 
 - **Environment variables**: Later configs override earlier ones by name
   - If the same variable appears in multiple configs, the one from the higher-precedence config wins
 - **Mounts**: Deduplicated by `host`+`target` pair (preserves order, removes duplicates)
+- **Skills**: Deduplicated by path value (preserves order, base skills first then override)
 
 **Example Merge Flow:**
 
@@ -334,6 +352,12 @@ The `Load()` method automatically validates the configuration and returns `ErrIn
 - Relative paths (e.g., `../foo`) are not allowed
 - `$SOURCES`-based container targets must not escape above `/workspace`
 - `$HOME`-based container targets must not escape above `/home/<container-user>`
+
+### Skills
+
+- Each entry cannot be empty
+- Each path must be an absolute path or start with `$HOME` (`$SOURCES` is not supported)
+- Duplicate paths (within or across config levels) are deduplicated by the merger
 
 ## Error Handling
 


### PR DESCRIPTION
Users can now specify a list of skill directories in workspace.json (or any config level). The manager converts each entry into a read-only mount using the agent's SkillsDir() — Claude Code mounts under $HOME/.claude/skills/, Goose under $HOME/.agents/skills/, and Cursor under $HOME/.cursor/skills/.

Closes #211