### PR TITLE
fix(build): add .exe extension to Windows binary

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,7 +47,26 @@ jobs:
       - name: Build binary
         run: make build
 
-      - name: Verify binary
+      - name: Check binary extension (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path ./kdn.exe)) { Write-Error "kdn.exe not found"; exit 1 }
+          if (Test-Path ./kdn) { Write-Error "kdn (without .exe) should not exist on Windows"; exit 1 }
+
+      - name: Check binary extension (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          test -f ./kdn
+          test ! -f ./kdn.exe
+
+      - name: Verify binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./kdn.exe version
+
+      - name: Verify binary (Unix)
+        if: runner.os != 'Windows'
         run: ./kdn version
 
       - name: Generate coverage report

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@
 
 # Binary name
 BINARY_NAME=kdn
+# Add .exe extension on Windows
+ifeq ($(OS),Windows_NT)
+    BINARY_EXT=.exe
+else
+    BINARY_EXT=
+endif
 # Build output directory
 BUILD_DIR=.
 # Go command
@@ -33,8 +39,8 @@ help: ## Display this help message
 
 build: ## Build the kdn binary
 build:
-	@echo "Building $(BINARY_NAME)..."
-	$(GO) build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/kdn
+	@echo "Building $(BINARY_NAME)$(BINARY_EXT)..."
+	$(GO) build -o $(BUILD_DIR)/$(BINARY_NAME)$(BINARY_EXT) ./cmd/kdn
 
 install: ## Install the binary to GOPATH/bin
 	@echo "Installing $(BINARY_NAME)..."
@@ -78,7 +84,7 @@ ci-checks: check-fmt check-vet test ## Run all CI checks
 
 clean: ## Remove build artifacts
 	@echo "Cleaning build artifacts..."
-	@rm -f $(BUILD_DIR)/$(BINARY_NAME)
+	@rm -f $(BUILD_DIR)/$(BINARY_NAME)$(BINARY_EXT)
 	@rm -f coverage.out coverage.html
 	@rm -f *.test
 	@echo "Clean complete."


### PR DESCRIPTION
On Windows, executables require the .exe extension to be runnable. The Makefile now detects Windows via the OS environment variable and appends .exe to the binary name for build and clean targets. The pr-checks workflow is updated to verify the correct extension per platform and invoke the binary accordingly.

Closes #187