### PR TITLE
feat(config): add MCP server configuration support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ type Logger interface {
 
 ### Config System
 
-The config system manages workspace configuration for **injecting environment variables, mounting directories, and providing skills** into workspaces (different from runtime-specific configuration).
+The config system manages workspace configuration for **injecting environment variables, mounting directories, providing skills and configuring MCP servers** into workspaces (different from runtime-specific configuration).
 
 **Multi-Level Configuration:**
 - **Workspace-level** (`.kaiden/workspace.json`) - Project configuration, set via `--workspace-configuration` flag
@@ -220,6 +220,7 @@ A separate mechanism (distinct from env/mount config) allows default dotfiles to
 
 - **Location:** `~/.kdn/config/<agent>/` (e.g., `~/.kdn/config/claude/`)
 - Files are read by `manager.readAgentSettings()` into a `map[string][]byte` and passed to the runtime via `runtime.CreateParams.AgentSettings`
+- After reading, the manager calls `agent.SkipOnboarding()`, `agent.SetModel()` (if a model is set), and `agent.SetMCPServers()` (if MCP is configured) to further modify the settings map
 - The Podman runtime writes these files into the build context as `agent-settings/` and adds `COPY --chown=agent:agent agent-settings/. /home/agent/` to the Containerfile
 - Result: every file under `config/<agent>/` lands at the corresponding path under `/home/agent/` inside the image
 

--- a/README.md
+++ b/README.md
@@ -1429,7 +1429,24 @@ The `workspace.json` file uses a nested JSON structure:
   "skills": [
     "/absolute/path/to/commit-skill",
     "$HOME/review-skill"
-  ]
+  ],
+  "mcp": {
+    "commands": [
+      {
+        "name": "my-local-tool",
+        "command": "python3",
+        "args": ["/workspace/sources/scripts/mcp_server.py"],
+        "env": {"DEBUG": "true"}
+      }
+    ],
+    "servers": [
+      {
+        "name": "remote-api",
+        "url": "https://api.example.com/mcp",
+        "headers": {"Authorization": "Bearer token123"}
+      }
+    ]
+  }
 }
 ```
 
@@ -1548,6 +1565,56 @@ For example, a skills path of `/home/user/commit-skill` is mounted at `~/.claude
 - Each path must be an absolute path or start with `$HOME`
 - `$SOURCES`-based paths are not supported for skills
 
+### MCP Servers
+
+Configure MCP (Model Context Protocol) servers to give the agent access to external tools and data sources. Two types are supported:
+
+- **Commands** — local MCP servers launched by the agent inside the workspace using stdio transport
+- **Servers** — remote MCP servers accessed over SSE (Server-Sent Events)
+
+**Structure:**
+```json
+{
+  "mcp": {
+    "commands": [
+      {
+        "name": "my-tool",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace/sources"],
+        "env": {"NODE_ENV": "production"}
+      }
+    ],
+    "servers": [
+      {
+        "name": "remote-api",
+        "url": "https://api.example.com/mcp",
+        "headers": {"Authorization": "Bearer token123"}
+      }
+    ]
+  }
+}
+```
+
+**Command fields** (`commands[*]`):
+- `name` (required) - Unique name for this MCP server
+- `command` (required) - Executable to run (e.g., `npx`, `python3`, `node`)
+- `args` (optional) - Arguments to pass to the command
+- `env` (optional) - Environment variables to set for the process
+
+**Server fields** (`servers[*]`):
+- `name` (required) - Unique name for this MCP server
+- `url` (required) - SSE endpoint URL of the remote MCP server
+- `headers` (optional) - HTTP headers to include in requests (e.g., `Authorization`)
+
+**Agent support:**
+
+MCP server configuration is applied to agents that support it at workspace registration time. For **Claude Code**, both command-based and URL-based MCP servers are written to `~/.claude.json` under the top-level `mcpServers` key (user scope), so they are available across all projects inside the workspace.
+
+**Validation Rules:**
+- `name` cannot be empty and must be unique across **both** `commands` and `servers` combined — a command and a server cannot share the same name, since all entries map to the same flat `mcpServers` key in the agent settings
+- `command` cannot be empty for command entries
+- `url` cannot be empty for server entries
+
 ### Configuration Validation
 
 When you register a workspace with `kdn init`, the configuration is automatically validated. If `workspace.json` exists and contains invalid data, the registration will fail with a descriptive error message.
@@ -1620,6 +1687,36 @@ mount at index 0 is missing host
 }
 ```
 
+**MCP command server (local tool):**
+```json
+{
+  "mcp": {
+    "commands": [
+      {
+        "name": "filesystem",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace/sources"]
+      }
+    ]
+  }
+}
+```
+
+**MCP remote server with authentication:**
+```json
+{
+  "mcp": {
+    "servers": [
+      {
+        "name": "company-api",
+        "url": "https://mcp.company.com/sse",
+        "headers": {"Authorization": "Bearer mytoken"}
+      }
+    ]
+  }
+}
+```
+
 **Complete configuration:**
 ```json
 {
@@ -1637,7 +1734,22 @@ mount at index 0 is missing host
     {"host": "$SOURCES/../main", "target": "$SOURCES/../main"},
     {"host": "$HOME/.claude", "target": "$HOME/.claude"},
     {"host": "$HOME/.gitconfig", "target": "$HOME/.gitconfig"}
-  ]
+  ],
+  "mcp": {
+    "commands": [
+      {
+        "name": "filesystem",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace/sources"]
+      }
+    ],
+    "servers": [
+      {
+        "name": "remote-api",
+        "url": "https://api.example.com/mcp"
+      }
+    ]
+  }
 }
 ```
 
@@ -1844,6 +1956,11 @@ kdn init --runtime podman --project my-custom-project --agent goose
 - Mounts are deduplicated by `host`+`target` pair (duplicates removed)
 - Order is preserved (first occurrence wins)
 - Example: If workspace has mounts for `.gitconfig` and `.ssh`, and global adds `.ssh` and `.kube`, the result contains `.gitconfig`, `.ssh`, and `.kube`
+
+**MCP Servers:**
+- Commands and servers are each merged by `name`
+- Later configurations override earlier ones with the same name
+- Example: If workspace defines an MCP command named `filesystem` and agent config also defines `filesystem`, the agent config's version is used
 
 ### Configuration Files Don't Exist?
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.1
 require (
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.1.14
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.1.14
+	github.com/openkaiden/kdn-api/cli/go v0.2.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.2.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/openkaiden/kdn-api/cli/go v0.1.14 h1:HK1V8pOGU9VBxeT3by0qhzYhZ+ndgbQEIka8wEDueDE=
-github.com/openkaiden/kdn-api/cli/go v0.1.14/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.1.14 h1:/QVij8HkLk5NRRAYyK1r5hf7FT9D8H1yYFsx44yY9+w=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.1.14/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.2.0 h1:/zHLdzxz07uNLpkJonMBaO9Vb7Ho+tTcFN6JZAWdUHo=
+github.com/openkaiden/kdn-api/cli/go v0.2.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.2.0 h1:W4z3v0G28UIWVWGluVTNKy0lgJSAEb8bNJJKDT4O7vM=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.2.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -18,6 +18,10 @@
 
 package agent
 
+import (
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
 // Agent is an interface for agent-specific configuration and setup operations.
 type Agent interface {
 	// Name returns the agent name (e.g., "claude", "goose").
@@ -38,4 +42,11 @@ type Agent interface {
 	// directories should be mounted (e.g., "$HOME/.claude/skills" for Claude Code).
 	// Returns "" if the agent does not support skills mounting.
 	SkillsDir() string
+	// SetMCPServers configures MCP servers in the agent settings.
+	// It takes the current agent settings map (path -> content) and the MCP configuration,
+	// and returns the modified settings with MCP servers configured.
+	// If the agent does not support MCP configuration, settings are returned unchanged.
+	// If mcp is nil, settings are returned unchanged.
+	// Returns the modified settings map, or an error if modification fails.
+	SetMCPServers(settings map[string][]byte, mcp *workspace.McpConfiguration) (map[string][]byte, error)
 }

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -21,6 +21,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 const (
@@ -111,6 +113,85 @@ func (c *claudeAgent) SkipOnboarding(settings map[string][]byte, workspaceSource
 // SkillsDir returns the container path under which skill directories are mounted for Claude Code.
 func (c *claudeAgent) SkillsDir() string {
 	return "$HOME/.claude/skills"
+}
+
+// SetMCPServers configures MCP servers in Claude settings.
+// It writes MCP server entries into .claude.json under the top-level "mcpServers" key.
+// Command-based servers use type "stdio" with {command, args, env}.
+// URL-based servers use type "sse" with {url, headers}.
+// All other fields in the settings file are preserved.
+// If mcp is nil, settings are returned unchanged.
+func (c *claudeAgent) SetMCPServers(settings map[string][]byte, mcp *workspace.McpConfiguration) (map[string][]byte, error) {
+	if mcp == nil {
+		return settings, nil
+	}
+	if settings == nil {
+		settings = make(map[string][]byte)
+	}
+
+	var existingContent []byte
+	var exists bool
+	if existingContent, exists = settings[ClaudeJSONPath]; !exists {
+		existingContent = []byte("{}")
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(existingContent, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing %s: %w", ClaudeJSONPath, err)
+	}
+
+	// Get or create the mcpServers map
+	mcpServers := make(map[string]interface{})
+	if raw, ok := config["mcpServers"]; ok {
+		if m, ok := raw.(map[string]interface{}); ok {
+			mcpServers = m
+		}
+	}
+
+	// Add command-based MCP servers (stdio type)
+	if mcp.Commands != nil {
+		for _, cmd := range *mcp.Commands {
+			entry := map[string]interface{}{
+				"type":    "stdio",
+				"command": cmd.Command,
+				"args":    []string{},
+				"env":     map[string]string{},
+			}
+			if cmd.Args != nil {
+				entry["args"] = *cmd.Args
+			}
+			if cmd.Env != nil {
+				entry["env"] = *cmd.Env
+			}
+			mcpServers[cmd.Name] = entry
+		}
+	}
+
+	// Add URL-based MCP servers (sse type)
+	if mcp.Servers != nil {
+		for _, srv := range *mcp.Servers {
+			entry := map[string]interface{}{
+				"type": "sse",
+				"url":  srv.Url,
+			}
+			if srv.Headers != nil {
+				entry["headers"] = *srv.Headers
+			}
+			mcpServers[srv.Name] = entry
+		}
+	}
+
+	if len(mcpServers) > 0 {
+		config["mcpServers"] = mcpServers
+	}
+
+	modifiedContent, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified %s: %w", ClaudeJSONPath, err)
+	}
+
+	settings[ClaudeJSONPath] = modifiedContent
+	return settings, nil
 }
 
 // SetModel configures the model ID in Claude settings.

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -21,6 +21,8 @@ package agent
 import (
 	"encoding/json"
 	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 func TestClaude_Name(t *testing.T) {
@@ -500,5 +502,352 @@ func TestClaude_SkillsDir(t *testing.T) {
 	agent := NewClaude()
 	if got := agent.SkillsDir(); got != "$HOME/.claude/skills" {
 		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.claude/skills")
+	}
+}
+
+func TestClaude_SetMCPServers_NilMCP(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	settings := map[string][]byte{
+		ClaudeJSONPath: []byte(`{"hasCompletedOnboarding": true}`),
+	}
+
+	result, err := agent.SetMCPServers(settings, nil)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	// Settings should be returned unchanged
+	if string(result[ClaudeJSONPath]) != `{"hasCompletedOnboarding": true}` {
+		t.Errorf("SetMCPServers() with nil MCP modified settings unexpectedly: %s", result[ClaudeJSONPath])
+	}
+}
+
+func TestClaude_SetMCPServers_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	args := []string{"-y", "@modelcontextprotocol/server-filesystem"}
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "filesystem", Command: "npx", Args: &args},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected non-nil result map")
+	}
+	if _, exists := result[ClaudeJSONPath]; !exists {
+		t.Errorf("Expected %s to be created", ClaudeJSONPath)
+	}
+}
+
+func TestClaude_SetMCPServers_CommandBased(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	args := []string{"-y", "@modelcontextprotocol/server-filesystem", "/workspace"}
+	env := map[string]string{"NODE_ENV": "production"}
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "filesystem", Command: "npx", Args: &args, Env: &env},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpServers, ok := config["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers is not a map: %v", config["mcpServers"])
+	}
+
+	fsServer, ok := mcpServers["filesystem"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("filesystem server not found or wrong type")
+	}
+
+	if fsServer["type"] != "stdio" {
+		t.Errorf("type = %v, want %q", fsServer["type"], "stdio")
+	}
+	if fsServer["command"] != "npx" {
+		t.Errorf("command = %v, want %q", fsServer["command"], "npx")
+	}
+
+	gotArgs, ok := fsServer["args"].([]interface{})
+	if !ok {
+		t.Fatalf("args is not a slice: %v", fsServer["args"])
+	}
+	if len(gotArgs) != 3 || gotArgs[0] != "-y" {
+		t.Errorf("args = %v, want %v", gotArgs, args)
+	}
+
+	gotEnv, ok := fsServer["env"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("env is not a map: %v", fsServer["env"])
+	}
+	if gotEnv["NODE_ENV"] != "production" {
+		t.Errorf("env.NODE_ENV = %v, want %q", gotEnv["NODE_ENV"], "production")
+	}
+}
+
+func TestClaude_SetMCPServers_URLBased(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	headers := map[string]string{"Authorization": "Bearer token123"}
+	mcp := &workspace.McpConfiguration{
+		Servers: &[]workspace.McpServer{
+			{Name: "remote", Url: "https://example.com/sse", Headers: &headers},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpServers, ok := config["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers is not a map: %v", config["mcpServers"])
+	}
+
+	remoteServer, ok := mcpServers["remote"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("remote server not found or wrong type")
+	}
+
+	if remoteServer["type"] != "sse" {
+		t.Errorf("type = %v, want %q", remoteServer["type"], "sse")
+	}
+	if remoteServer["url"] != "https://example.com/sse" {
+		t.Errorf("url = %v, want %q", remoteServer["url"], "https://example.com/sse")
+	}
+
+	gotHeaders, ok := remoteServer["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers is not a map: %v", remoteServer["headers"])
+	}
+	if gotHeaders["Authorization"] != "Bearer token123" {
+		t.Errorf("headers.Authorization = %v, want %q", gotHeaders["Authorization"], "Bearer token123")
+	}
+}
+
+func TestClaude_SetMCPServers_URLBased_NoHeaders(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	mcp := &workspace.McpConfiguration{
+		Servers: &[]workspace.McpServer{
+			{Name: "simple", Url: "https://example.com/sse"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpServers := config["mcpServers"].(map[string]interface{})
+	server := mcpServers["simple"].(map[string]interface{})
+
+	if _, hasHeaders := server["headers"]; hasHeaders {
+		t.Errorf("Expected no headers field when Headers is nil, got: %v", server["headers"])
+	}
+}
+
+func TestClaude_SetMCPServers_Mixed(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "local-tool", Command: "python3", Args: &[]string{"/scripts/mcp.py"}},
+		},
+		Servers: &[]workspace.McpServer{
+			{Name: "remote-api", Url: "https://api.example.com/mcp"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpServers, ok := config["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers is not a map")
+	}
+	if _, ok := mcpServers["local-tool"]; !ok {
+		t.Error("Expected local-tool server to be present")
+	}
+	if _, ok := mcpServers["remote-api"]; !ok {
+		t.Error("Expected remote-api server to be present")
+	}
+}
+
+func TestClaude_SetMCPServers_PreservesExistingMCPServers(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+
+	// Start with an existing mcpServers entry in .claude.json
+	existing := map[string]interface{}{
+		"hasCompletedOnboarding": true,
+		"mcpServers": map[string]interface{}{
+			"existing-server": map[string]interface{}{
+				"type":    "stdio",
+				"command": "existing-cmd",
+				"args":    []interface{}{},
+				"env":     map[string]interface{}{},
+			},
+		},
+	}
+	existingJSON, _ := json.Marshal(existing)
+
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "new-tool", Command: "new-cmd"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(map[string][]byte{ClaudeJSONPath: existingJSON}, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpServers, ok := config["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers is not a map")
+	}
+
+	// Both old and new servers should be present
+	if _, ok := mcpServers["existing-server"]; !ok {
+		t.Error("existing-server was not preserved")
+	}
+	if _, ok := mcpServers["new-tool"]; !ok {
+		t.Error("new-tool was not added")
+	}
+	if config["hasCompletedOnboarding"] != true {
+		t.Error("hasCompletedOnboarding was not preserved")
+	}
+}
+
+func TestClaude_SetMCPServers_PreservesOtherFields(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	existing := map[string]interface{}{
+		"model":                  "claude-opus-4-6",
+		"hasCompletedOnboarding": true,
+	}
+	existingJSON, _ := json.Marshal(existing)
+
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "tool", Command: "mytool"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(map[string][]byte{ClaudeJSONPath: existingJSON}, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if config["model"] != "claude-opus-4-6" {
+		t.Errorf("model field was not preserved: %v", config["model"])
+	}
+	if config["hasCompletedOnboarding"] != true {
+		t.Errorf("hasCompletedOnboarding was not preserved: %v", config["hasCompletedOnboarding"])
+	}
+	if _, ok := config["mcpServers"]; !ok {
+		t.Error("mcpServers was not added")
+	}
+}
+
+func TestClaude_SetMCPServers_CommandNoArgs(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "tool", Command: "mytool"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpServers := config["mcpServers"].(map[string]interface{})
+	server := mcpServers["tool"].(map[string]interface{})
+
+	// Args should default to empty slice, env to empty map
+	args, ok := server["args"].([]interface{})
+	if !ok || len(args) != 0 {
+		t.Errorf("args = %v, want empty slice", server["args"])
+	}
+	envMap, ok := server["env"].(map[string]interface{})
+	if !ok || len(envMap) != 0 {
+		t.Errorf("env = %v, want empty map", server["env"])
+	}
+}
+
+func TestClaude_SetMCPServers_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "tool", Command: "mytool"},
+		},
+	}
+
+	_, err := agent.SetMCPServers(map[string][]byte{ClaudeJSONPath: []byte("invalid json {{{")}, mcp)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
 	}
 }

--- a/pkg/agent/cursor.go
+++ b/pkg/agent/cursor.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 // CursorCLIConfigPath is the path to Cursor's CLI configuration file.
@@ -72,6 +74,12 @@ func (c *cursorAgent) SkipOnboarding(settings map[string][]byte, workspaceSource
 // SkillsDir returns the container path under which skill directories are mounted for Cursor.
 func (c *cursorAgent) SkillsDir() string {
 	return "$HOME/.cursor/skills"
+}
+
+// SetMCPServers returns the settings unchanged, as Cursor does not support MCP configuration
+// through agent settings files.
+func (c *cursorAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	return settings, nil
 }
 
 // SetModel configures the model ID in Cursor settings.

--- a/pkg/agent/goose.go
+++ b/pkg/agent/goose.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 const (
@@ -84,6 +85,12 @@ func (g *gooseAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[s
 // SkillsDir returns the container path under which skill directories are mounted for Goose.
 func (g *gooseAgent) SkillsDir() string {
 	return "$HOME/.agents/skills"
+}
+
+// SetMCPServers returns the settings unchanged, as Goose does not support MCP configuration
+// through agent settings files.
+func (g *gooseAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	return settings, nil
 }
 
 // SetModel configures the model ID in Goose settings.

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -21,6 +21,8 @@ package agent
 import (
 	"errors"
 	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 // fakeAgent is a test implementation of the Agent interface
@@ -42,6 +44,10 @@ func (f *fakeAgent) SetModel(settings map[string][]byte, _ string) (map[string][
 
 func (f *fakeAgent) SkillsDir() string {
 	return ""
+}
+
+func (f *fakeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	return settings, nil
 }
 
 func TestNewRegistry(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,6 +159,41 @@ func (c *config) validate(cfg *workspace.WorkspaceConfiguration) error {
 		}
 	}
 
+	// Validate MCP configuration
+	if cfg.Mcp != nil {
+		// Names must be unique across both commands and servers, since all entries
+		// are written to a single flat map (e.g., Claude's mcpServers).
+		seenMCP := make(map[string]string) // name -> "command" or "server"
+		if cfg.Mcp.Commands != nil {
+			for i, cmd := range *cfg.Mcp.Commands {
+				if cmd.Name == "" {
+					return fmt.Errorf("%w: MCP command at index %d has empty name", ErrInvalidConfig, i)
+				}
+				if kind, exists := seenMCP[cmd.Name]; exists {
+					return fmt.Errorf("%w: MCP command %q (index %d) duplicates a %s with the same name", ErrInvalidConfig, cmd.Name, i, kind)
+				}
+				seenMCP[cmd.Name] = "command"
+				if cmd.Command == "" {
+					return fmt.Errorf("%w: MCP command %q (index %d) has empty command", ErrInvalidConfig, cmd.Name, i)
+				}
+			}
+		}
+		if cfg.Mcp.Servers != nil {
+			for i, srv := range *cfg.Mcp.Servers {
+				if srv.Name == "" {
+					return fmt.Errorf("%w: MCP server at index %d has empty name", ErrInvalidConfig, i)
+				}
+				if kind, exists := seenMCP[srv.Name]; exists {
+					return fmt.Errorf("%w: MCP server %q (index %d) duplicates a %s with the same name", ErrInvalidConfig, srv.Name, i, kind)
+				}
+				seenMCP[srv.Name] = "server"
+				if srv.Url == "" {
+					return fmt.Errorf("%w: MCP server %q (index %d) has empty url", ErrInvalidConfig, srv.Name, i)
+				}
+			}
+		}
+	}
+
 	// Validate mounts
 	if cfg.Mounts != nil {
 		for i, m := range *cfg.Mounts {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1212,3 +1212,119 @@ func TestConfig_Load(t *testing.T) {
 		}
 	})
 }
+
+func TestConfig_Load_MCP_Valid(t *testing.T) {
+	t.Parallel()
+
+	configDir := t.TempDir()
+	workspaceJSON := `{
+  "mcp": {
+    "commands": [
+      {"name": "my-tool", "command": "npx", "args": ["-y", "my-pkg"]},
+      {"name": "another-tool", "command": "python3"}
+    ],
+    "servers": [
+      {"name": "remote-srv", "url": "https://example.com/sse"},
+      {"name": "auth-srv", "url": "https://api.example.com/mcp", "headers": {"Authorization": "Bearer token"}}
+    ]
+  }
+}`
+	err := os.WriteFile(filepath.Join(configDir, WorkspaceConfigFile), []byte(workspaceJSON), 0644)
+	if err != nil {
+		t.Fatalf("os.WriteFile() failed: %v", err)
+	}
+
+	cfg, err := NewConfig(configDir)
+	if err != nil {
+		t.Fatalf("NewConfig() failed: %v", err)
+	}
+
+	workspaceCfg, err := cfg.Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if workspaceCfg.Mcp == nil {
+		t.Fatal("Expected non-nil Mcp")
+	}
+	if workspaceCfg.Mcp.Commands == nil || len(*workspaceCfg.Mcp.Commands) != 2 {
+		t.Errorf("Expected 2 commands, got %v", workspaceCfg.Mcp.Commands)
+	}
+	if workspaceCfg.Mcp.Servers == nil || len(*workspaceCfg.Mcp.Servers) != 2 {
+		t.Errorf("Expected 2 servers, got %v", workspaceCfg.Mcp.Servers)
+	}
+}
+
+func TestConfig_Load_MCP_Invalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		json       string
+		wantErrMsg string
+	}{
+		{
+			name:       "command with empty name",
+			json:       `{"mcp": {"commands": [{"name": "", "command": "npx"}]}}`,
+			wantErrMsg: "MCP command at index 0 has empty name",
+		},
+		{
+			name:       "command with empty command field",
+			json:       `{"mcp": {"commands": [{"name": "tool", "command": ""}]}}`,
+			wantErrMsg: "MCP command \"tool\" (index 0) has empty command",
+		},
+		{
+			name:       "duplicate command names",
+			json:       `{"mcp": {"commands": [{"name": "tool", "command": "cmd1"}, {"name": "tool", "command": "cmd2"}]}}`,
+			wantErrMsg: "MCP command \"tool\" (index 1) duplicates a command with the same name",
+		},
+		{
+			name:       "server with empty name",
+			json:       `{"mcp": {"servers": [{"name": "", "url": "https://example.com"}]}}`,
+			wantErrMsg: "MCP server at index 0 has empty name",
+		},
+		{
+			name:       "server with empty url",
+			json:       `{"mcp": {"servers": [{"name": "srv", "url": ""}]}}`,
+			wantErrMsg: "MCP server \"srv\" (index 0) has empty url",
+		},
+		{
+			name:       "duplicate server names",
+			json:       `{"mcp": {"servers": [{"name": "srv", "url": "https://a.example.com"}, {"name": "srv", "url": "https://b.example.com"}]}}`,
+			wantErrMsg: "MCP server \"srv\" (index 1) duplicates a server with the same name",
+		},
+		{
+			name:       "command and server share the same name",
+			json:       `{"mcp": {"commands": [{"name": "tool", "command": "cmd"}], "servers": [{"name": "tool", "url": "https://example.com"}]}}`,
+			wantErrMsg: "MCP server \"tool\" (index 0) duplicates a command with the same name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			configDir := t.TempDir()
+			err := os.WriteFile(filepath.Join(configDir, WorkspaceConfigFile), []byte(tt.json), 0644)
+			if err != nil {
+				t.Fatalf("os.WriteFile() failed: %v", err)
+			}
+
+			cfg, err := NewConfig(configDir)
+			if err != nil {
+				t.Fatalf("NewConfig() failed: %v", err)
+			}
+
+			_, err = cfg.Load()
+			if err == nil {
+				t.Fatalf("Expected error containing %q, got nil", tt.wantErrMsg)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("Error %q does not contain %q", err.Error(), tt.wantErrMsg)
+			}
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Errorf("Expected ErrInvalidConfig, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -69,6 +69,9 @@ func (m *merger) Merge(base, override *workspace.WorkspaceConfiguration) *worksp
 	// Merge skills
 	result.Skills = mergeSkills(base.Skills, override.Skills)
 
+	// Merge MCP configuration
+	result.Mcp = mergeMCP(base.Mcp, override.Mcp)
+
 	return result
 }
 
@@ -166,7 +169,6 @@ func mergeSkills(base, override *[]string) *[]string {
 	if base == nil && override == nil {
 		return nil
 	}
-
 	seen := make(map[string]bool)
 	var result []string
 
@@ -186,6 +188,119 @@ func mergeSkills(base, override *[]string) *[]string {
 		return nil
 	}
 	return &result
+}
+
+// mergeMCP merges two McpConfiguration objects, with override taking precedence by name.
+// Commands and servers from base are included first; override entries replace base entries
+// with the same name.
+func mergeMCP(base, override *workspace.McpConfiguration) *workspace.McpConfiguration {
+	if base == nil && override == nil {
+		return nil
+	}
+	if base == nil {
+		return copyMCP(override)
+	}
+	if override == nil {
+		return copyMCP(base)
+	}
+
+	result := &workspace.McpConfiguration{}
+	result.Commands = mergeMCPCommands(base.Commands, override.Commands)
+	result.Servers = mergeMCPServers(base.Servers, override.Servers)
+
+	if result.Commands == nil && result.Servers == nil {
+		return nil
+	}
+	return result
+}
+
+// mergeMCPCommands merges command slices, deduplicating by name (override wins).
+func mergeMCPCommands(base, override *[]workspace.McpCommand) *[]workspace.McpCommand {
+	if base == nil && override == nil {
+		return nil
+	}
+
+	cmdMap := make(map[string]workspace.McpCommand)
+	var order []string
+
+	if base != nil {
+		for _, cmd := range *base {
+			cmdMap[cmd.Name] = cmd
+			order = append(order, cmd.Name)
+		}
+	}
+	if override != nil {
+		for _, cmd := range *override {
+			if _, exists := cmdMap[cmd.Name]; !exists {
+				order = append(order, cmd.Name)
+			}
+			cmdMap[cmd.Name] = cmd
+		}
+	}
+
+	if len(cmdMap) == 0 {
+		return nil
+	}
+
+	result := make([]workspace.McpCommand, 0, len(order))
+	for _, name := range order {
+		result = append(result, cmdMap[name])
+	}
+	return &result
+}
+
+// mergeMCPServers merges server slices, deduplicating by name (override wins).
+func mergeMCPServers(base, override *[]workspace.McpServer) *[]workspace.McpServer {
+	if base == nil && override == nil {
+		return nil
+	}
+
+	srvMap := make(map[string]workspace.McpServer)
+	var order []string
+
+	if base != nil {
+		for _, srv := range *base {
+			srvMap[srv.Name] = srv
+			order = append(order, srv.Name)
+		}
+	}
+	if override != nil {
+		for _, srv := range *override {
+			if _, exists := srvMap[srv.Name]; !exists {
+				order = append(order, srv.Name)
+			}
+			srvMap[srv.Name] = srv
+		}
+	}
+
+	if len(srvMap) == 0 {
+		return nil
+	}
+
+	result := make([]workspace.McpServer, 0, len(order))
+	for _, name := range order {
+		result = append(result, srvMap[name])
+	}
+	return &result
+}
+
+// copyMCP creates a deep copy of an McpConfiguration.
+func copyMCP(mcp *workspace.McpConfiguration) *workspace.McpConfiguration {
+	if mcp == nil {
+		return nil
+	}
+	result := &workspace.McpConfiguration{}
+	if mcp.Commands != nil {
+		cmdsCopy := make([]workspace.McpCommand, len(*mcp.Commands))
+		copy(cmdsCopy, *mcp.Commands)
+		result.Commands = &cmdsCopy
+	}
+	if mcp.Servers != nil {
+		srvsCopy := make([]workspace.McpServer, len(*mcp.Servers))
+		copy(srvsCopy, *mcp.Servers)
+		result.Servers = &srvsCopy
+	}
+	return result
 }
 
 // copyConfig creates a deep copy of a WorkspaceConfiguration
@@ -218,6 +333,9 @@ func copyConfig(cfg *workspace.WorkspaceConfiguration) *workspace.WorkspaceConfi
 		copy(skillsCopy, *cfg.Skills)
 		result.Skills = &skillsCopy
 	}
+
+	// Copy MCP configuration
+	result.Mcp = copyMCP(cfg.Mcp)
 
 	return result
 }

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -375,14 +375,21 @@ func copyMCP(mcp *workspace.McpConfiguration) *workspace.McpConfiguration {
 		for i, cmd := range *mcp.Commands {
 			cmdsCopy[i] = deepCopyMcpCommand(cmd)
 		}
-		result.Commands = &cmdsCopy
+		if len(cmdsCopy) > 0 {
+			result.Commands = &cmdsCopy
+		}
 	}
 	if mcp.Servers != nil {
 		srvsCopy := make([]workspace.McpServer, len(*mcp.Servers))
 		for i, srv := range *mcp.Servers {
 			srvsCopy[i] = deepCopyMcpServer(srv)
 		}
-		result.Servers = &srvsCopy
+		if len(srvsCopy) > 0 {
+			result.Servers = &srvsCopy
+		}
+	}
+	if result.Commands == nil && result.Servers == nil {
+		return nil
 	}
 	return result
 }

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -193,6 +193,11 @@ func mergeSkills(base, override *[]string) *[]string {
 // mergeMCP merges two McpConfiguration objects, with override taking precedence by name.
 // Commands and servers from base are included first; override entries replace base entries
 // with the same name.
+//
+// Cross-type collisions are resolved in favour of the override side: if override defines
+// a command named "foo", any base server named "foo" is dropped, and vice-versa. This
+// prevents the lower-precedence type from silently overwriting the higher-precedence one
+// when an agent flattens both lists into a single mcpServers map.
 func mergeMCP(base, override *workspace.McpConfiguration) *workspace.McpConfiguration {
 	if base == nil && override == nil {
 		return nil
@@ -204,14 +209,89 @@ func mergeMCP(base, override *workspace.McpConfiguration) *workspace.McpConfigur
 		return copyMCP(base)
 	}
 
+	// Build sets of names claimed by each override list so we can resolve cross-type
+	// collisions (e.g. base.Servers["foo"] must lose to override.Commands["foo"]).
+	overrideCmdNames := make(map[string]bool)
+	if override.Commands != nil {
+		for _, cmd := range *override.Commands {
+			overrideCmdNames[cmd.Name] = true
+		}
+	}
+	overrideSrvNames := make(map[string]bool)
+	if override.Servers != nil {
+		for _, srv := range *override.Servers {
+			overrideSrvNames[srv.Name] = true
+		}
+	}
+
 	result := &workspace.McpConfiguration{}
 	result.Commands = mergeMCPCommands(base.Commands, override.Commands)
 	result.Servers = mergeMCPServers(base.Servers, override.Servers)
+
+	// Drop any command whose name was claimed by override.Servers, and any server
+	// whose name was claimed by override.Commands.
+	if result.Commands != nil && len(overrideSrvNames) > 0 {
+		filtered := (*result.Commands)[:0:0]
+		for _, cmd := range *result.Commands {
+			if !overrideSrvNames[cmd.Name] {
+				filtered = append(filtered, cmd)
+			}
+		}
+		if len(filtered) == 0 {
+			result.Commands = nil
+		} else {
+			result.Commands = &filtered
+		}
+	}
+	if result.Servers != nil && len(overrideCmdNames) > 0 {
+		filtered := (*result.Servers)[:0:0]
+		for _, srv := range *result.Servers {
+			if !overrideCmdNames[srv.Name] {
+				filtered = append(filtered, srv)
+			}
+		}
+		if len(filtered) == 0 {
+			result.Servers = nil
+		} else {
+			result.Servers = &filtered
+		}
+	}
 
 	if result.Commands == nil && result.Servers == nil {
 		return nil
 	}
 	return result
+}
+
+// deepCopyMcpCommand returns a deep copy of cmd so that its Args and Env
+// pointer fields do not alias the original.
+func deepCopyMcpCommand(cmd workspace.McpCommand) workspace.McpCommand {
+	if cmd.Args != nil {
+		argsCopy := make([]string, len(*cmd.Args))
+		copy(argsCopy, *cmd.Args)
+		cmd.Args = &argsCopy
+	}
+	if cmd.Env != nil {
+		envCopy := make(map[string]string, len(*cmd.Env))
+		for k, v := range *cmd.Env {
+			envCopy[k] = v
+		}
+		cmd.Env = &envCopy
+	}
+	return cmd
+}
+
+// deepCopyMcpServer returns a deep copy of srv so that its Headers pointer
+// field does not alias the original.
+func deepCopyMcpServer(srv workspace.McpServer) workspace.McpServer {
+	if srv.Headers != nil {
+		hdrs := make(map[string]string, len(*srv.Headers))
+		for k, v := range *srv.Headers {
+			hdrs[k] = v
+		}
+		srv.Headers = &hdrs
+	}
+	return srv
 }
 
 // mergeMCPCommands merges command slices, deduplicating by name (override wins).
@@ -244,7 +324,7 @@ func mergeMCPCommands(base, override *[]workspace.McpCommand) *[]workspace.McpCo
 
 	result := make([]workspace.McpCommand, 0, len(order))
 	for _, name := range order {
-		result = append(result, cmdMap[name])
+		result = append(result, deepCopyMcpCommand(cmdMap[name]))
 	}
 	return &result
 }
@@ -279,7 +359,7 @@ func mergeMCPServers(base, override *[]workspace.McpServer) *[]workspace.McpServ
 
 	result := make([]workspace.McpServer, 0, len(order))
 	for _, name := range order {
-		result = append(result, srvMap[name])
+		result = append(result, deepCopyMcpServer(srvMap[name]))
 	}
 	return &result
 }
@@ -292,12 +372,16 @@ func copyMCP(mcp *workspace.McpConfiguration) *workspace.McpConfiguration {
 	result := &workspace.McpConfiguration{}
 	if mcp.Commands != nil {
 		cmdsCopy := make([]workspace.McpCommand, len(*mcp.Commands))
-		copy(cmdsCopy, *mcp.Commands)
+		for i, cmd := range *mcp.Commands {
+			cmdsCopy[i] = deepCopyMcpCommand(cmd)
+		}
 		result.Commands = &cmdsCopy
 	}
 	if mcp.Servers != nil {
 		srvsCopy := make([]workspace.McpServer, len(*mcp.Servers))
-		copy(srvsCopy, *mcp.Servers)
+		for i, srv := range *mcp.Servers {
+			srvsCopy[i] = deepCopyMcpServer(srv)
+		}
 		result.Servers = &srvsCopy
 	}
 	return result

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -616,3 +616,204 @@ func TestMergeSkills(t *testing.T) {
 		}
 	})
 }
+
+func TestMerger_Merge_MCP_BothNil(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+	base := &workspace.WorkspaceConfiguration{}
+	override := &workspace.WorkspaceConfiguration{}
+
+	result := merger.Merge(base, override)
+	if result.Mcp != nil {
+		t.Error("Expected Mcp to be nil when both have no MCP config")
+	}
+}
+
+func TestMerger_Merge_MCP_BaseOnly(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+	base := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "tool-a", Command: "cmd-a"},
+			},
+			Servers: &[]workspace.McpServer{
+				{Name: "srv-a", Url: "https://a.example.com"},
+			},
+		},
+	}
+	override := &workspace.WorkspaceConfiguration{}
+
+	result := merger.Merge(base, override)
+	if result.Mcp == nil {
+		t.Fatal("Expected non-nil Mcp")
+	}
+	if result.Mcp.Commands == nil || len(*result.Mcp.Commands) != 1 {
+		t.Errorf("Expected 1 command, got %v", result.Mcp.Commands)
+	}
+	if (*result.Mcp.Commands)[0].Name != "tool-a" {
+		t.Errorf("Expected command name %q, got %q", "tool-a", (*result.Mcp.Commands)[0].Name)
+	}
+	if result.Mcp.Servers == nil || len(*result.Mcp.Servers) != 1 {
+		t.Errorf("Expected 1 server, got %v", result.Mcp.Servers)
+	}
+}
+
+func TestMerger_Merge_MCP_OverrideOnly(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+	base := &workspace.WorkspaceConfiguration{}
+	override := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "tool-b", Command: "cmd-b"},
+			},
+		},
+	}
+
+	result := merger.Merge(base, override)
+	if result.Mcp == nil {
+		t.Fatal("Expected non-nil Mcp")
+	}
+	if result.Mcp.Commands == nil || len(*result.Mcp.Commands) != 1 {
+		t.Errorf("Expected 1 command, got %v", result.Mcp.Commands)
+	}
+	if (*result.Mcp.Commands)[0].Name != "tool-b" {
+		t.Errorf("Expected command name %q, got %q", "tool-b", (*result.Mcp.Commands)[0].Name)
+	}
+}
+
+func TestMerger_Merge_MCP_CommandsMergedByName(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+	base := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "tool-a", Command: "cmd-a"},
+				{Name: "tool-b", Command: "cmd-b-base"},
+			},
+		},
+	}
+	override := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "tool-b", Command: "cmd-b-override"},
+				{Name: "tool-c", Command: "cmd-c"},
+			},
+		},
+	}
+
+	result := merger.Merge(base, override)
+	if result.Mcp == nil || result.Mcp.Commands == nil {
+		t.Fatal("Expected non-nil Mcp.Commands")
+	}
+
+	cmds := *result.Mcp.Commands
+	if len(cmds) != 3 {
+		t.Fatalf("Expected 3 commands, got %d: %v", len(cmds), cmds)
+	}
+
+	cmdMap := make(map[string]string)
+	for _, cmd := range cmds {
+		cmdMap[cmd.Name] = cmd.Command
+	}
+
+	if cmdMap["tool-a"] != "cmd-a" {
+		t.Errorf("tool-a command = %q, want %q", cmdMap["tool-a"], "cmd-a")
+	}
+	if cmdMap["tool-b"] != "cmd-b-override" {
+		t.Errorf("tool-b should be overridden: got %q, want %q", cmdMap["tool-b"], "cmd-b-override")
+	}
+	if cmdMap["tool-c"] != "cmd-c" {
+		t.Errorf("tool-c command = %q, want %q", cmdMap["tool-c"], "cmd-c")
+	}
+}
+
+func TestMerger_Merge_MCP_ServersMergedByName(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+	base := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Servers: &[]workspace.McpServer{
+				{Name: "srv-a", Url: "https://a.example.com"},
+				{Name: "srv-b", Url: "https://b-base.example.com"},
+			},
+		},
+	}
+	override := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Servers: &[]workspace.McpServer{
+				{Name: "srv-b", Url: "https://b-override.example.com"},
+				{Name: "srv-c", Url: "https://c.example.com"},
+			},
+		},
+	}
+
+	result := merger.Merge(base, override)
+	if result.Mcp == nil || result.Mcp.Servers == nil {
+		t.Fatal("Expected non-nil Mcp.Servers")
+	}
+
+	srvs := *result.Mcp.Servers
+	if len(srvs) != 3 {
+		t.Fatalf("Expected 3 servers, got %d: %v", len(srvs), srvs)
+	}
+
+	srvMap := make(map[string]string)
+	for _, srv := range srvs {
+		srvMap[srv.Name] = srv.Url
+	}
+
+	if srvMap["srv-a"] != "https://a.example.com" {
+		t.Errorf("srv-a url = %q, want %q", srvMap["srv-a"], "https://a.example.com")
+	}
+	if srvMap["srv-b"] != "https://b-override.example.com" {
+		t.Errorf("srv-b should be overridden: got %q, want %q", srvMap["srv-b"], "https://b-override.example.com")
+	}
+	if srvMap["srv-c"] != "https://c.example.com" {
+		t.Errorf("srv-c url = %q, want %q", srvMap["srv-c"], "https://c.example.com")
+	}
+}
+
+func TestMerger_Merge_MCP_PreservesOtherFields(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+	base := &workspace.WorkspaceConfiguration{
+		Environment: &[]workspace.EnvironmentVariable{
+			{Name: "FOO", Value: strPtr("bar")},
+		},
+		Mcp: &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "tool-a", Command: "cmd-a"},
+			},
+		},
+	}
+	override := &workspace.WorkspaceConfiguration{
+		Mcp: &workspace.McpConfiguration{
+			Servers: &[]workspace.McpServer{
+				{Name: "srv-a", Url: "https://a.example.com"},
+			},
+		},
+	}
+
+	result := merger.Merge(base, override)
+
+	if result.Environment == nil || len(*result.Environment) != 1 {
+		t.Error("Environment was not preserved during MCP merge")
+	}
+	if result.Mcp == nil {
+		t.Fatal("Expected non-nil Mcp")
+	}
+	if result.Mcp.Commands == nil || len(*result.Mcp.Commands) != 1 {
+		t.Error("Commands from base were not preserved")
+	}
+	if result.Mcp.Servers == nil || len(*result.Mcp.Servers) != 1 {
+		t.Error("Servers from override were not added")
+	}
+}

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -780,6 +780,228 @@ func TestMerger_Merge_MCP_ServersMergedByName(t *testing.T) {
 	}
 }
 
+func TestMerger_Merge_MCP_DeepCopy(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+
+	t.Run("mutating merged command Args does not affect base", func(t *testing.T) {
+		t.Parallel()
+
+		args := []string{"--verbose"}
+		base := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "tool-a", Command: "cmd-a", Args: &args},
+				},
+			},
+		}
+
+		result := merger.Merge(base, nil)
+
+		// Mutate the result's Args slice
+		(*result.Mcp.Commands)[0].Args = &[]string{"--other"}
+
+		// Base must be unaffected
+		if (*(*base.Mcp.Commands)[0].Args)[0] != "--verbose" {
+			t.Error("Mutating merged command Args affected the base input")
+		}
+	})
+
+	t.Run("mutating merged command Env does not affect base", func(t *testing.T) {
+		t.Parallel()
+
+		env := map[string]string{"KEY": "original"}
+		base := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "tool-a", Command: "cmd-a", Env: &env},
+				},
+			},
+		}
+
+		result := merger.Merge(base, nil)
+
+		// Mutate the result's Env map
+		(*(*result.Mcp.Commands)[0].Env)["KEY"] = "mutated"
+
+		// Base must be unaffected
+		if env["KEY"] != "original" {
+			t.Error("Mutating merged command Env affected the base input")
+		}
+	})
+
+	t.Run("mutating merged server Headers does not affect base", func(t *testing.T) {
+		t.Parallel()
+
+		headers := map[string]string{"Authorization": "Bearer token"}
+		base := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Servers: &[]workspace.McpServer{
+					{Name: "srv-a", Url: "https://a.example.com", Headers: &headers},
+				},
+			},
+		}
+
+		result := merger.Merge(base, nil)
+
+		// Mutate the result's Headers map
+		(*(*result.Mcp.Servers)[0].Headers)["Authorization"] = "Bearer other"
+
+		// Base must be unaffected
+		if headers["Authorization"] != "Bearer token" {
+			t.Error("Mutating merged server Headers affected the base input")
+		}
+	})
+
+	t.Run("override command Args is independent of override input", func(t *testing.T) {
+		t.Parallel()
+
+		args := []string{"--flag"}
+		override := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "tool-a", Command: "cmd-a", Args: &args},
+				},
+			},
+		}
+
+		result := merger.Merge(nil, override)
+
+		// Mutate the result's Args slice
+		(*result.Mcp.Commands)[0].Args = &[]string{"--other"}
+
+		// Override must be unaffected
+		if (*(*override.Mcp.Commands)[0].Args)[0] != "--flag" {
+			t.Error("Mutating merged command Args affected the override input")
+		}
+	})
+}
+
+func TestMerger_Merge_MCP_CrossTypeCollision(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+
+	t.Run("override command wins over base server with same name", func(t *testing.T) {
+		t.Parallel()
+
+		// base has a server named "foo"; override promotes it to a command – the
+		// command (higher-precedence type) must win and the base server must be gone.
+		base := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Servers: &[]workspace.McpServer{
+					{Name: "foo", Url: "https://base.example.com"},
+					{Name: "bar", Url: "https://bar.example.com"},
+				},
+			},
+		}
+		override := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "foo", Command: "foo-cmd"},
+				},
+			},
+		}
+
+		result := merger.Merge(base, override)
+		if result.Mcp == nil {
+			t.Fatal("Expected non-nil Mcp")
+		}
+
+		// "foo" command from override must be present
+		if result.Mcp.Commands == nil || len(*result.Mcp.Commands) != 1 {
+			t.Fatalf("Expected 1 command, got %v", result.Mcp.Commands)
+		}
+		if (*result.Mcp.Commands)[0].Name != "foo" {
+			t.Errorf("Expected command name %q, got %q", "foo", (*result.Mcp.Commands)[0].Name)
+		}
+
+		// "foo" server from base must have been removed; only "bar" should remain
+		if result.Mcp.Servers == nil || len(*result.Mcp.Servers) != 1 {
+			t.Fatalf("Expected 1 server (bar), got %v", result.Mcp.Servers)
+		}
+		if (*result.Mcp.Servers)[0].Name != "bar" {
+			t.Errorf("Expected server name %q, got %q", "bar", (*result.Mcp.Servers)[0].Name)
+		}
+	})
+
+	t.Run("override server wins over base command with same name", func(t *testing.T) {
+		t.Parallel()
+
+		// base has a command named "foo"; override promotes it to a server – the
+		// server (higher-precedence type) must win and the base command must be gone.
+		base := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "foo", Command: "foo-cmd-base"},
+					{Name: "bar", Command: "bar-cmd"},
+				},
+			},
+		}
+		override := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Servers: &[]workspace.McpServer{
+					{Name: "foo", Url: "https://override.example.com"},
+				},
+			},
+		}
+
+		result := merger.Merge(base, override)
+		if result.Mcp == nil {
+			t.Fatal("Expected non-nil Mcp")
+		}
+
+		// "foo" server from override must be present
+		if result.Mcp.Servers == nil || len(*result.Mcp.Servers) != 1 {
+			t.Fatalf("Expected 1 server, got %v", result.Mcp.Servers)
+		}
+		if (*result.Mcp.Servers)[0].Name != "foo" {
+			t.Errorf("Expected server name %q, got %q", "foo", (*result.Mcp.Servers)[0].Name)
+		}
+
+		// "foo" command from base must have been removed; only "bar" should remain
+		if result.Mcp.Commands == nil || len(*result.Mcp.Commands) != 1 {
+			t.Fatalf("Expected 1 command (bar), got %v", result.Mcp.Commands)
+		}
+		if (*result.Mcp.Commands)[0].Name != "bar" {
+			t.Errorf("Expected command name %q, got %q", "bar", (*result.Mcp.Commands)[0].Name)
+		}
+	})
+
+	t.Run("collision removes all base entries of losing type", func(t *testing.T) {
+		t.Parallel()
+
+		// When the override claims all server names as commands, the servers list
+		// should become nil rather than an empty slice.
+		base := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Servers: &[]workspace.McpServer{
+					{Name: "foo", Url: "https://a.example.com"},
+				},
+			},
+		}
+		override := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "foo", Command: "foo-cmd"},
+				},
+			},
+		}
+
+		result := merger.Merge(base, override)
+		if result.Mcp == nil {
+			t.Fatal("Expected non-nil Mcp")
+		}
+		if result.Mcp.Servers != nil {
+			t.Errorf("Expected Servers to be nil after all entries were displaced, got %v", result.Mcp.Servers)
+		}
+		if result.Mcp.Commands == nil || len(*result.Mcp.Commands) != 1 {
+			t.Fatalf("Expected 1 command, got %v", result.Mcp.Commands)
+		}
+	})
+}
+
 func TestMerger_Merge_MCP_PreservesOtherFields(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -266,6 +266,13 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 					}
 				}
 			}
+			// Configure MCP servers if specified in workspace config
+			if mergedConfig != nil && mergedConfig.Mcp != nil {
+				agentSettings, err = agentImpl.SetMCPServers(agentSettings, mergedConfig.Mcp)
+				if err != nil {
+					return nil, fmt.Errorf("failed to apply agent MCP server settings: %w", err)
+				}
+			}
 		}
 		// If agent not found in registry, use settings as-is (not all agents may be implemented)
 	}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -211,6 +211,7 @@ type trackingAgent struct {
 	setModelCalled         bool
 	setModelSettings       map[string][]byte
 	setModelID             string
+	setMCPServersCalled    bool
 	mu                     sync.Mutex
 }
 
@@ -265,6 +266,22 @@ func (t *trackingAgent) GetSetModelID() string {
 	return t.setModelID
 }
 
+func (t *trackingAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.setMCPServersCalled = true
+	if settings == nil {
+		settings = make(map[string][]byte)
+	}
+	return settings, nil
+}
+
+func (t *trackingAgent) WasSetMCPServersCalled() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.setMCPServersCalled
+}
+
 func (t *trackingAgent) WasSkipOnboardingCalled() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -304,6 +321,10 @@ func (e *erroringSetModelAgent) SetModel(_ map[string][]byte, _ string) (map[str
 
 func (e *erroringSetModelAgent) SkillsDir() string {
 	return ""
+}
+
+func (e *erroringSetModelAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	return settings, nil
 }
 
 // newTestRegistry creates a runtime registry with a fake runtime for testing
@@ -3768,6 +3789,125 @@ func TestManager_Add_ConvertsSkillsToMounts(t *testing.T) {
 		params := spy.LastCreateParams()
 		if params.WorkspaceConfig != nil && params.WorkspaceConfig.Mounts != nil {
 			t.Errorf("Expected no mounts when agent has empty SkillsDir, got %v", *params.WorkspaceConfig.Mounts)
+		}
+	})
+}
+
+func TestManager_Add_AppliesAgentMCPServers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("calls SetMCPServers when workspace config has MCP", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		manager, err := NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		trackingAgent := newTrackingAgent("test-agent")
+		if err := manager.RegisterAgent("test-agent", trackingAgent); err != nil {
+			t.Fatalf("Failed to register tracking agent: %v", err)
+		}
+
+		instanceTmpDir := t.TempDir()
+		sourceDir := filepath.Join(instanceTmpDir, "source")
+		configDir := filepath.Join(instanceTmpDir, "config")
+		if err := os.MkdirAll(sourceDir, 0755); err != nil {
+			t.Fatalf("Failed to create source directory: %v", err)
+		}
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config directory: %v", err)
+		}
+
+		inst, err := NewInstance(NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: configDir,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		mcp := &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "my-tool", Command: "mytool"},
+			},
+		}
+
+		added, err := manager.Add(context.Background(), AddOptions{
+			Instance:    inst,
+			RuntimeType: "fake",
+			Agent:       "test-agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Mcp: mcp,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+		if added == nil {
+			t.Fatal("Add() returned nil instance")
+		}
+
+		if !trackingAgent.WasSetMCPServersCalled() {
+			t.Error("SetMCPServers() was not called")
+		}
+	})
+
+	t.Run("does not call SetMCPServers when workspace config has no MCP", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		manager, err := NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		trackingAgent := newTrackingAgent("test-agent")
+		if err := manager.RegisterAgent("test-agent", trackingAgent); err != nil {
+			t.Fatalf("Failed to register tracking agent: %v", err)
+		}
+
+		instanceTmpDir := t.TempDir()
+		sourceDir := filepath.Join(instanceTmpDir, "source")
+		configDir := filepath.Join(instanceTmpDir, "config")
+		if err := os.MkdirAll(sourceDir, 0755); err != nil {
+			t.Fatalf("Failed to create source directory: %v", err)
+		}
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config directory: %v", err)
+		}
+
+		inst, err := NewInstance(NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: configDir,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		added, err := manager.Add(context.Background(), AddOptions{
+			Instance:    inst,
+			RuntimeType: "fake",
+			Agent:       "test-agent",
+		})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+		if added == nil {
+			t.Fatal("Add() returned nil instance")
+		}
+
+		if trackingAgent.WasSetMCPServersCalled() {
+			t.Error("SetMCPServers() should not be called when no MCP config is provided")
 		}
 	})
 }

--- a/skills/working-with-config-system/SKILL.md
+++ b/skills/working-with-config-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: working-with-config-system
-description: Guide to workspace configuration for environment variables, mount points, and skills at multiple levels
+description: Guide to workspace configuration for environment variables, mount points, skills and MCP servers at multiple levels
 argument-hint: ""
 ---
 
@@ -12,6 +12,7 @@ The config system manages **workspace configuration** for injecting environment 
 - Environment variables to inject into workspace containers/VMs
 - Additional directories to mount, with explicit host and container paths
 - Skills directories to provide to agents inside the workspace
+- MCP servers to configure in the agent (command-based and URL-based)
 
 **What this does NOT control:**
 - Runtime-specific settings (e.g., Podman container image, packages to install)
@@ -69,7 +70,17 @@ When the `--model` flag is provided during `init`, kdn does two things with the 
 
 The `--model` flag takes precedence over any model already defined in the settings files. If no model is specified, `GetModel()` returns an empty string and the `model` field is omitted from JSON output.
 
-**Implementation:** `manager.readAgentSettings(storageDir, agentName)` in `pkg/instances/manager.go` walks this directory and returns a `map[string][]byte` (relative forward-slash path → content). If the agent is registered in the agent registry, the manager calls the agent's `SkipOnboarding()` method to modify the settings. If a model ID is provided, the manager then calls the agent's `SetModel()` method to configure the model in the appropriate settings file. The final map is passed to the runtime via `runtime.CreateParams.AgentSettings`. The Podman runtime writes the files into the build context and adds a `COPY --chown=agent:agent agent-settings/. /home/agent/` instruction to the Containerfile. The model is also stored directly in the `instance` struct and persisted in `instances.json` via `InstanceData.Model`.
+**MCP Server Configuration:**
+
+When the merged workspace configuration contains an `mcp` field, the manager calls the agent's `SetMCPServers()` method to write the MCP servers into the agent settings:
+- Claude: writes `mcpServers` entries into `.claude.json` at the top-level (user scope)
+  - Command-based servers use `type: "stdio"` with `command`, `args`, and `env`
+  - URL-based servers use `type: "sse"` with `url` and optional `headers`
+- Goose and Cursor: no-op (MCP configuration through settings files not supported)
+
+MCP servers from all configuration levels are merged before being passed to the agent, with higher-precedence levels overriding lower ones by server `name`.
+
+**Implementation:** `manager.readAgentSettings(storageDir, agentName)` in `pkg/instances/manager.go` walks this directory and returns a `map[string][]byte` (relative forward-slash path → content). If the agent is registered in the agent registry, the manager calls the agent's `SkipOnboarding()` method to modify the settings. If a model ID is provided, the manager then calls the agent's `SetModel()` method. If the merged config contains MCP servers, the manager calls the agent's `SetMCPServers()` method. The final map is passed to the runtime via `runtime.CreateParams.AgentSettings`. The Podman runtime writes the files into the build context and adds a `COPY --chown=agent:agent agent-settings/. /home/agent/` instruction to the Containerfile. The model is also stored directly in the `instance` struct and persisted in `instances.json` via `InstanceData.Model`.
 
 ## Key Components
 
@@ -124,7 +135,24 @@ The `workspace.json` file controls what gets injected into the workspace:
   "skills": [
     "/absolute/path/to/commit-skill",
     "$HOME/review-skill"
-  ]
+  ],
+  "mcp": {
+    "commands": [
+      {
+        "name": "my-tool",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace/sources"],
+        "env": {"NODE_ENV": "production"}
+      }
+    ],
+    "servers": [
+      {
+        "name": "remote-api",
+        "url": "https://api.example.com/mcp",
+        "headers": {"Authorization": "Bearer token123"}
+      }
+    ]
+  }
 }
 ```
 
@@ -155,6 +183,16 @@ kdn init /path/to/workspace --workspace-configuration /path/to/config-dir
   - Paths must be absolute or start with `$HOME` (`$SOURCES` is not supported)
   - Each directory is mounted read-only into the agent's skills directory using the directory's basename as the skill name
   - The target path is agent-specific (e.g., `$HOME/.claude/skills/<basename>/` for Claude Code)
+- `mcp` - MCP server configuration to inject into the agent's settings (optional)
+  - `commands` - List of local command-based MCP servers (stdio transport)
+    - `name` - Unique server name (required, must be unique within commands)
+    - `command` - Executable to launch (required, e.g., `npx`, `python3`)
+    - `args` - Arguments to pass to the command (optional)
+    - `env` - Environment variables for the process (optional)
+  - `servers` - List of remote URL-based MCP servers (SSE transport)
+    - `name` - Unique server name (required, must be unique within servers)
+    - `url` - SSE endpoint URL (required)
+    - `headers` - HTTP headers to send with requests, e.g., for auth (optional)
 
 ### Agent Configuration (`agents.json`)
 
@@ -303,6 +341,8 @@ The Manager's `Add()` method:
   - If the same variable appears in multiple configs, the one from the higher-precedence config wins
 - **Mounts**: Deduplicated by `host`+`target` pair (preserves order, removes duplicates)
 - **Skills**: Deduplicated by path value (preserves order, base skills first then override)
+- **MCP servers**: Merged separately for commands and servers, each deduplicated by `name`
+  - Higher-precedence configs override lower ones when the same name appears in both
 
 **Example Merge Flow:**
 
@@ -358,6 +398,14 @@ The `Load()` method automatically validates the configuration and returns `ErrIn
 - Each entry cannot be empty
 - Each path must be an absolute path or start with `$HOME` (`$SOURCES` is not supported)
 - Duplicate paths (within or across config levels) are deduplicated by the merger
+
+### MCP Servers
+
+- Command `name` cannot be empty
+- Command `command` field cannot be empty
+- Server `name` cannot be empty
+- Server `url` field cannot be empty
+- Names must be unique across **both** `commands` and `servers` combined — a command and a server cannot share the same name, since all entries map to the same flat `mcpServers` key in the agent settings
 
 ## Error Handling
 

--- a/skills/working-with-config-system/SKILL.md
+++ b/skills/working-with-config-system/SKILL.md
@@ -185,14 +185,15 @@ kdn init /path/to/workspace --workspace-configuration /path/to/config-dir
   - The target path is agent-specific (e.g., `$HOME/.claude/skills/<basename>/` for Claude Code)
 - `mcp` - MCP server configuration to inject into the agent's settings (optional)
   - `commands` - List of local command-based MCP servers (stdio transport)
-    - `name` - Unique server name (required, must be unique within commands)
+    - `name` - Unique server name (required, must be unique across both `commands` and `servers`)
     - `command` - Executable to launch (required, e.g., `npx`, `python3`)
     - `args` - Arguments to pass to the command (optional)
     - `env` - Environment variables for the process (optional)
   - `servers` - List of remote URL-based MCP servers (SSE transport)
-    - `name` - Unique server name (required, must be unique within servers)
+    - `name` - Unique server name (required, must be unique across both `commands` and `servers`)
     - `url` - SSE endpoint URL (required)
     - `headers` - HTTP headers to send with requests, e.g., for auth (optional)
+  - Names must be globally unique across both `commands` and `servers` because agents flatten both lists into a single `mcpServers` map
 
 ### Agent Configuration (`agents.json`)
 

--- a/skills/working-with-instances-manager/SKILL.md
+++ b/skills/working-with-instances-manager/SKILL.md
@@ -67,7 +67,8 @@ The `Add()` method:
 5. Reads agent settings files from `<storage-dir>/config/<agent>/` into `map[string][]byte`
 6. Calls agent's `SkipOnboarding()` method if agent is registered (e.g., Claude agent automatically sets onboarding flags)
 7. Calls agent's `SetModel()` method if model is specified (takes precedence over model in settings files)
-8. Passes merged config and modified agent settings to runtime for injection into workspace
+8. Calls agent's `SetMCPServers()` method if the merged config contains MCP servers (writes them into agent settings)
+9. Passes merged config and modified agent settings to runtime for injection into workspace
 
 ### List - Get All Instances
 
@@ -310,6 +311,8 @@ For the Claude agent, `SkipOnboarding()` automatically:
 - Sets `hasCompletedOnboarding: true` to skip the first-run wizard
 - Adds `hasTrustDialogAccepted: true` for the workspace sources directory
 - Preserves any custom settings you've configured (theme, preferences, etc.)
+
+`SetMCPServers()` writes MCP server entries into `.claude.json` at the top-level `mcpServers` key (user scope). Command-based servers use `type: "stdio"`, URL-based servers use `type: "sse"`. Existing MCP server entries in the file are preserved.
 
 **Graceful Fallback:**
 


### PR DESCRIPTION
Allows users to configure MCP servers (command-based and URL-based) in workspace.json and in the multi-level config system (projects.json, agents.json). The manager calls SetMCPServers() on the registered agent after SetModel(), writing the merged MCP config into agent settings.

- Upgrade kdn-api/workspace-configuration/go to v0.2.0 which adds McpConfiguration, McpCommand, and McpServer types
- Add SetMCPServers() to the Agent interface; Claude writes command servers as type "stdio" and URL servers as type "sse" into the top-level mcpServers key of .claude.json (user scope); Goose and Cursor are no-ops
- Add MCP merge logic to ConfigMerger (merge by name, override wins)
- Add MCP validation: non-empty name/command/url required; names must be unique across both commands and servers combined since they are written to a single flat mcpServers map
- Wire SetMCPServers() into manager.Add() after SetModel()
- Add tests for all new functionality
- Update README.md, CLAUDE.md, and skills documentation

Implementation for Claude agent only.

Closes #210