### PR TITLE
feat(agent): add OpenCode agent with Podman runtime support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-kdn is a command-line interface for launching and managing AI agents (Claude Code, Goose, Cursor) with custom configurations. It provides a unified way to start different agents with specific settings including skills, MCP server connections, and LLM integrations.
+kdn is a command-line interface for launching and managing AI agents (Claude Code, Goose, Cursor, OpenCode) with custom configurations. It provides a unified way to start different agents with specific settings including skills, MCP server connections, and LLM integrations.
 
 ## Build and Test Commands
 
@@ -236,6 +236,7 @@ The Podman runtime supports runtime-specific configuration for **building and co
 - `<storage-dir>/runtimes/podman/config/image.json` - Base image configuration
 - `<storage-dir>/runtimes/podman/config/claude.json` - Claude agent configuration
 - `<storage-dir>/runtimes/podman/config/goose.json` - Goose agent configuration
+- `<storage-dir>/runtimes/podman/config/opencode.json` - OpenCode agent configuration
 
 **For Podman runtime configuration details, use:** `/working-with-podman-runtime-config`
 
@@ -257,6 +258,7 @@ Skills can be provided to workspaces via the `skills` field in `workspace.json` 
 | Claude Code | `$HOME/.claude/skills/` |
 | Goose | `$HOME/.agents/skills/` |
 | Cursor | `$HOME/.cursor/skills/` |
+| OpenCode | `$HOME/.opencode/skills/` |
 
 The `Agent` interface (`pkg/agent/agent.go`) exposes `SkillsDir() string` which returns the container path (using the `$HOME` variable) where skill directories should be mounted. The manager calls this during `Add()` to convert `WorkspaceConfig.Skills` entries into `workspace.Mount` entries before passing the config to the runtime.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The architecture is built around pluggable runtimes. The first supported runtime
 - **Claude Code** - Anthropic's official CLI for Claude
 - **Goose** - AI agent for development tasks
 - **Cursor** - AI-powered code editor agent
+- **OpenCode** - Open-source AI coding agent
 
 **Key Features**
 
@@ -69,7 +70,7 @@ make test-coverage
 ## Glossary
 
 ### Agent
-An AI assistant that can perform tasks autonomously. In kdn, agents are the different AI tools (Claude Code, Goose, Cursor) that can be launched and configured.
+An AI assistant that can perform tasks autonomously. In kdn, agents are the different AI tools (Claude Code, Goose, Cursor, OpenCode) that can be launched and configured.
 
 ### LLM (Large Language Model)
 The underlying AI model that powers the agents. Examples include Claude (by Anthropic), GPT (by OpenAI), and other language models.
@@ -1190,6 +1191,14 @@ The Podman runtime includes default configurations for the following AI agents:
 - Task automation and code assistance
 - Configurable development workflows
 
+**Cursor** - Installed using the official installer from `cursor.com/install`:
+- AI-powered code editor agent
+- Configurable development workflows
+
+**OpenCode** - Installed using the official installer from `opencode.ai/install`:
+- Open-source AI coding agent
+- The installer places the binary in `~/.opencode/bin/`, which is symlinked into `~/.local/bin/` for PATH access
+
 The agent runs within the container environment and has access to the mounted workspace sources and dependencies.
 
 ### Working Directory
@@ -1241,9 +1250,10 @@ The Podman runtime is fully configurable through JSON files. When you first use 
 
 ```text
 $HOME/.kdn/runtimes/podman/config/
-├── image.json    # Base image configuration
-├── claude.json   # Claude agent configuration
-└── goose.json    # Goose agent configuration
+├── image.json      # Base image configuration
+├── claude.json     # Claude agent configuration
+├── goose.json      # Goose agent configuration
+└── opencode.json   # OpenCode agent configuration
 ```
 
 Or if using a custom storage directory:
@@ -1307,7 +1317,7 @@ Controls the container's base image, packages, and sudo permissions.
 
 #### Agent Configuration
 
-Controls agent-specific packages and installation steps. The Podman runtime provides default configurations for Claude Code (`claude.json`) and Goose (`goose.json`).
+Controls agent-specific packages and installation steps. The Podman runtime provides default configurations for Claude Code (`claude.json`), Goose (`goose.json`), Cursor (`cursor.json`), and OpenCode (`opencode.json`).
 
 **Structure (claude.json):**
 
@@ -1334,6 +1344,22 @@ Controls agent-specific packages and installation steps. The Podman runtime prov
   ],
   "terminal_command": [
     "goose"
+  ]
+}
+```
+
+**Structure (opencode.json):**
+
+```json
+{
+  "packages": [],
+  "run_commands": [
+    "cd /tmp && curl -fsSL https://opencode.ai/install | bash",
+    "mkdir -p /home/agent/.local/bin && ln -sf /home/agent/.opencode/bin/opencode /home/agent/.local/bin/opencode",
+    "mkdir -p /home/agent/.config/opencode"
+  ],
+  "terminal_command": [
+    "opencode"
   ]
 }
 ```
@@ -1557,6 +1583,7 @@ Each skill directory is mounted read-only under the agent's skills directory ins
 | Claude Code | `~/.claude/skills/<basename>/` |
 | Goose | `~/.agents/skills/<basename>/` |
 | Cursor | `~/.cursor/skills/<basename>/` |
+| OpenCode | `~/.opencode/skills/<basename>/` |
 
 For example, a skills path of `/home/user/commit-skill` is mounted at `~/.claude/skills/commit-skill/` for Claude Code, making the skill discoverable by the agent.
 
@@ -2342,7 +2369,7 @@ kdn init /tmp/workspace --runtime podman --agent claude
 
 - **Runtime is required**: You must specify a runtime using either the `--runtime` flag or the `KDN_DEFAULT_RUNTIME` environment variable
 - **Agent is required**: You must specify an agent using either the `--agent` flag or the `KDN_DEFAULT_AGENT` environment variable
-- **Model is optional**: Use `--model` to specify a model ID for the agent. The flag takes precedence over any model defined in the agent's default settings files (`~/.kdn/config/<agent>/`). If not provided, the agent uses its default model or the one configured in settings. All agents support model configuration: Claude (via `.claude/settings.json`), Goose (via `config.yaml`), and Cursor (via `.cursor/cli-config.json`)
+- **Model is optional**: Use `--model` to specify a model ID for the agent. The flag takes precedence over any model defined in the agent's default settings files (`~/.kdn/config/<agent>/`). If not provided, the agent uses its default model or the one configured in settings. All agents support model configuration: Claude (via `.claude/settings.json`), Goose (via `config.yaml`), Cursor (via `.cursor/cli-config.json`), and OpenCode (via `.config/opencode/opencode.json`)
 - **Project auto-detection**: The project identifier is automatically detected from git repository information or source directory path. Use `--project` flag to override with a custom identifier
 - **Auto-start**: Use the `--start` flag or set `KDN_INIT_AUTO_START=1` to automatically start the workspace after registration, combining `init` and `start` into a single operation
 - All directory paths are converted to absolute paths for consistency

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -21,6 +21,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 const (
@@ -90,4 +92,10 @@ func (o *openCodeAgent) SetModel(settings map[string][]byte, modelID string) (ma
 // SkillsDir returns the container path under which skill directories are mounted for OpenCode.
 func (o *openCodeAgent) SkillsDir() string {
 	return "$HOME/.opencode/skills"
+}
+
+// SetMCPServers returns the settings unchanged, as OpenCode does not support MCP configuration
+// through agent settings files.
+func (o *openCodeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	return settings, nil
 }

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	// OpenCodeConfigPath is the relative path to the OpenCode configuration file.
+	OpenCodeConfigPath = ".config/opencode/opencode.json"
+)
+
+// openCodeAgent is the implementation of Agent for OpenCode.
+type openCodeAgent struct{}
+
+// Compile-time check to ensure openCodeAgent implements Agent interface
+var _ Agent = (*openCodeAgent)(nil)
+
+// NewOpenCode creates a new OpenCode agent implementation.
+func NewOpenCode() Agent {
+	return &openCodeAgent{}
+}
+
+// Name returns the agent name.
+func (o *openCodeAgent) Name() string {
+	return "opencode"
+}
+
+// SkipOnboarding returns the settings unchanged since OpenCode does not
+// require onboarding configuration.
+func (o *openCodeAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[string][]byte, error) {
+	if settings == nil {
+		settings = make(map[string][]byte)
+	}
+	return settings, nil
+}
+
+// SetModel configures the model ID in OpenCode settings.
+// It sets the model field in .config/opencode/opencode.json.
+// All other fields in the settings file are preserved.
+func (o *openCodeAgent) SetModel(settings map[string][]byte, modelID string) (map[string][]byte, error) {
+	if settings == nil {
+		settings = make(map[string][]byte)
+	}
+
+	var existingContent []byte
+	var exists bool
+	if existingContent, exists = settings[OpenCodeConfigPath]; !exists {
+		existingContent = []byte("{}")
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(existingContent, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing %s: %w", OpenCodeConfigPath, err)
+	}
+
+	if config == nil {
+		config = make(map[string]interface{})
+	}
+
+	config["model"] = modelID
+
+	modifiedContent, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified %s: %w", OpenCodeConfigPath, err)
+	}
+
+	settings[OpenCodeConfigPath] = modifiedContent
+	return settings, nil
+}
+
+// SkillsDir returns the container path under which skill directories are mounted for OpenCode.
+func (o *openCodeAgent) SkillsDir() string {
+	return "$HOME/.opencode/skills"
+}

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -21,6 +21,8 @@ package agent
 import (
 	"encoding/json"
 	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 func TestOpenCode_Name(t *testing.T) {
@@ -249,4 +251,73 @@ func TestOpenCode_SkillsDir(t *testing.T) {
 	if got := agent.SkillsDir(); got != "$HOME/.opencode/skills" {
 		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.opencode/skills")
 	}
+}
+
+func TestOpenCode_SetMCPServers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil MCP returns settings unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := map[string][]byte{
+			OpenCodeConfigPath: []byte(`{"model":"some-model"}`),
+		}
+
+		result, err := agent.SetMCPServers(settings, nil)
+		if err != nil {
+			t.Fatalf("SetMCPServers() error = %v", err)
+		}
+
+		if string(result[OpenCodeConfigPath]) != `{"model":"some-model"}` {
+			t.Errorf("SetMCPServers() with nil MCP modified settings unexpectedly: %s", result[OpenCodeConfigPath])
+		}
+	})
+
+	t.Run("nil settings returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		mcp := &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "test", Command: "npx", Args: &[]string{"-y", "test-server"}},
+			},
+		}
+
+		result, err := agent.SetMCPServers(nil, mcp)
+		if err != nil {
+			t.Fatalf("SetMCPServers() error = %v", err)
+		}
+
+		if result != nil {
+			t.Errorf("SetMCPServers() with nil settings should return nil, got %v", result)
+		}
+	})
+
+	t.Run("non-nil MCP returns settings unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := map[string][]byte{
+			OpenCodeConfigPath: []byte(`{"model":"some-model"}`),
+			"some/other/file":  []byte("existing content"),
+		}
+		mcp := &workspace.McpConfiguration{
+			Commands: &[]workspace.McpCommand{
+				{Name: "test", Command: "npx", Args: &[]string{"-y", "test-server"}},
+			},
+		}
+
+		result, err := agent.SetMCPServers(settings, mcp)
+		if err != nil {
+			t.Fatalf("SetMCPServers() error = %v", err)
+		}
+
+		if string(result[OpenCodeConfigPath]) != `{"model":"some-model"}` {
+			t.Errorf("SetMCPServers() modified config unexpectedly: %s", result[OpenCodeConfigPath])
+		}
+		if string(result["some/other/file"]) != "existing content" {
+			t.Errorf("SetMCPServers() modified other settings unexpectedly")
+		}
+	})
 }

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -1,0 +1,252 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOpenCode_Name(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenCode()
+	if got := agent.Name(); got != "opencode" {
+		t.Errorf("Name() = %q, want %q", got, "opencode")
+	}
+}
+
+func TestOpenCode_SkipOnboarding(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no existing settings", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+		if err != nil {
+			t.Fatalf("SkipOnboarding() error = %v", err)
+		}
+
+		if result == nil {
+			t.Fatal("Expected non-nil result map")
+		}
+	})
+
+	t.Run("nil settings", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		result, err := agent.SkipOnboarding(nil, "/workspace/sources")
+		if err != nil {
+			t.Fatalf("SkipOnboarding() error = %v", err)
+		}
+
+		if result == nil {
+			t.Fatal("Expected non-nil result map")
+		}
+	})
+
+	t.Run("preserves existing settings", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		existingSettings := map[string][]byte{
+			"some/other/file": []byte("existing content"),
+		}
+
+		result, err := agent.SkipOnboarding(existingSettings, "/workspace/sources")
+		if err != nil {
+			t.Fatalf("SkipOnboarding() error = %v", err)
+		}
+
+		if string(result["some/other/file"]) != "existing content" {
+			t.Errorf("Existing settings were not preserved")
+		}
+	})
+}
+
+func TestOpenCode_SetModel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no existing settings", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "anthropic/claude-sonnet-4-5")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		if result == nil {
+			t.Fatal("Expected non-nil result map")
+		}
+
+		configJSON, exists := result[OpenCodeConfigPath]
+		if !exists {
+			t.Fatalf("Expected %s to be created", OpenCodeConfigPath)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(configJSON, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "anthropic/claude-sonnet-4-5" {
+			t.Errorf("model = %v, want %q", config["model"], "anthropic/claude-sonnet-4-5")
+		}
+	})
+
+	t.Run("nil settings", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		result, err := agent.SetModel(nil, "some-model-id")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		if result == nil {
+			t.Fatal("Expected non-nil result map")
+		}
+
+		if _, exists := result[OpenCodeConfigPath]; !exists {
+			t.Errorf("Expected %s to be created", OpenCodeConfigPath)
+		}
+	})
+
+	t.Run("preserves existing settings", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		existingSettings := map[string][]byte{
+			"some/other/file": []byte("existing content"),
+		}
+
+		result, err := agent.SetModel(existingSettings, "some-model-id")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		if string(result["some/other/file"]) != "existing content" {
+			t.Errorf("Existing settings were not preserved")
+		}
+
+		if _, exists := result[OpenCodeConfigPath]; !exists {
+			t.Errorf("Expected %s to be created", OpenCodeConfigPath)
+		}
+	})
+
+	t.Run("preserves existing config fields", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		existingConfig := map[string]interface{}{
+			"someOtherField": "some-value",
+			"anotherField":   123,
+		}
+		existingJSON, _ := json.Marshal(existingConfig)
+
+		settings := map[string][]byte{
+			OpenCodeConfigPath: existingJSON,
+		}
+
+		result, err := agent.SetModel(settings, "new-model-id")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["someOtherField"] != "some-value" {
+			t.Errorf("someOtherField = %v, want %q", config["someOtherField"], "some-value")
+		}
+		if config["anotherField"] != float64(123) {
+			t.Errorf("anotherField = %v, want 123", config["anotherField"])
+		}
+		if config["model"] != "new-model-id" {
+			t.Errorf("model = %v, want %q", config["model"], "new-model-id")
+		}
+	})
+
+	t.Run("overwrites existing model", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		existingConfig := map[string]interface{}{
+			"model": "old-model",
+		}
+		existingJSON, _ := json.Marshal(existingConfig)
+
+		settings := map[string][]byte{
+			OpenCodeConfigPath: existingJSON,
+		}
+
+		result, err := agent.SetModel(settings, "new-model-id")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "new-model-id" {
+			t.Errorf("model = %v, want %q (should overwrite existing)", config["model"], "new-model-id")
+		}
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+
+		settings := map[string][]byte{
+			OpenCodeConfigPath: []byte("invalid json"),
+		}
+
+		_, err := agent.SetModel(settings, "some-model-id")
+		if err == nil {
+			t.Fatal("Expected error for invalid JSON")
+		}
+	})
+}
+
+func TestOpenCode_SkillsDir(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenCode()
+	if got := agent.SkillsDir(); got != "$HOME/.opencode/skills" {
+		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.opencode/skills")
+	}
+}

--- a/pkg/agentsetup/register.go
+++ b/pkg/agentsetup/register.go
@@ -40,6 +40,7 @@ var availableAgents = []agentFactory{
 	agent.NewClaude,
 	agent.NewCursor,
 	agent.NewGoose,
+	agent.NewOpenCode,
 }
 
 // RegisterAll registers all available agent implementations to the given registrar.

--- a/pkg/cmd/info_test.go
+++ b/pkg/cmd/info_test.go
@@ -217,7 +217,7 @@ func TestInfoCmd_E2E(t *testing.T) {
 			t.Fatalf("Failed to parse JSON: %v", err)
 		}
 
-		expected := []string{"claude", "cursor", "goose"}
+		expected := []string{"claude", "cursor", "goose", "opencode"}
 		if !slices.Equal(response.Agents, expected) {
 			t.Errorf("Expected agents %v, got: %v", expected, response.Agents)
 		}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -317,6 +317,9 @@ kdn init --runtime podman --agent claude --name my-project
 # Register with custom project identifier
 kdn init --runtime podman --agent goose --project my-custom-project
 
+# Register with OpenCode agent
+kdn init --runtime podman --agent opencode
+
 # Register with a specific model
 kdn init --runtime podman --agent claude --model claude-sonnet-4-20250514
 

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -2484,7 +2484,7 @@ func TestInitCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 8
+	expectedCount := 9
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/runtime/podman/config/config.go
+++ b/pkg/runtime/podman/config/config.go
@@ -198,10 +198,11 @@ func (c *config) GenerateDefaults() error {
 
 	// Generate default configurations
 	configs := map[string]interface{}{
-		ImageConfigFileName:  defaultImageConfig(),
-		ClaudeConfigFileName: defaultClaudeConfig(),
-		GooseConfigFileName:  defaultGooseConfig(),
-		CursorConfigFileName: defaultCursorConfig(),
+		ImageConfigFileName:    defaultImageConfig(),
+		ClaudeConfigFileName:   defaultClaudeConfig(),
+		GooseConfigFileName:    defaultGooseConfig(),
+		CursorConfigFileName:   defaultCursorConfig(),
+		OpenCodeConfigFileName: defaultOpenCodeConfig(),
 	}
 
 	for filename, config := range configs {

--- a/pkg/runtime/podman/config/config_test.go
+++ b/pkg/runtime/podman/config/config_test.go
@@ -254,6 +254,47 @@ func TestGenerateDefaults(t *testing.T) {
 		}
 	})
 
+	t.Run("creates default opencode config", func(t *testing.T) {
+		t.Parallel()
+
+		configDir := t.TempDir()
+
+		cfg, err := NewConfig(configDir)
+		if err != nil {
+			t.Fatalf("NewConfig() failed: %v", err)
+		}
+
+		err = cfg.GenerateDefaults()
+		if err != nil {
+			t.Fatalf("GenerateDefaults() failed: %v", err)
+		}
+
+		// Verify opencode.json exists
+		openCodeConfigPath := filepath.Join(configDir, OpenCodeConfigFileName)
+		if _, err := os.Stat(openCodeConfigPath); os.IsNotExist(err) {
+			t.Error("opencode.json was not created")
+		}
+
+		// Verify content is valid JSON
+		data, err := os.ReadFile(openCodeConfigPath)
+		if err != nil {
+			t.Fatalf("Failed to read opencode config: %v", err)
+		}
+
+		var agentConfig AgentConfig
+		if err := json.Unmarshal(data, &agentConfig); err != nil {
+			t.Fatalf("Failed to parse opencode config: %v", err)
+		}
+
+		// Verify terminal command is set
+		if len(agentConfig.TerminalCommand) == 0 {
+			t.Error("Expected terminal command to be set")
+		}
+		if agentConfig.TerminalCommand[0] != "opencode" {
+			t.Errorf("Expected terminal command to be 'opencode', got: %s", agentConfig.TerminalCommand[0])
+		}
+	})
+
 	t.Run("does not overwrite existing configs", func(t *testing.T) {
 		t.Parallel()
 
@@ -413,6 +454,36 @@ func TestGenerateDefaults(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), cursorConfigPath) {
 			t.Errorf("Expected error to contain path %s, got: %v", cursorConfigPath, err)
+		}
+	})
+
+	t.Run("returns error when opencode config path is a directory", func(t *testing.T) {
+		t.Parallel()
+
+		configDir := t.TempDir()
+
+		cfg, err := NewConfig(configDir)
+		if err != nil {
+			t.Fatalf("NewConfig() failed: %v", err)
+		}
+
+		// Create opencode.json as a directory instead of a file
+		openCodeConfigPath := filepath.Join(configDir, OpenCodeConfigFileName)
+		if err := os.MkdirAll(openCodeConfigPath, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		// Call GenerateDefaults - should fail
+		err = cfg.GenerateDefaults()
+		if err == nil {
+			t.Fatal("Expected error when opencode config path is a directory")
+		}
+
+		if !strings.Contains(err.Error(), "expected file but found directory") {
+			t.Errorf("Expected 'expected file but found directory' error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), openCodeConfigPath) {
+			t.Errorf("Expected error to contain path %s, got: %v", openCodeConfigPath, err)
 		}
 	})
 }
@@ -786,7 +857,7 @@ func TestListAgents(t *testing.T) {
 		}
 
 		// GenerateDefaults creates configs for all default agents
-		expected := []string{"claude", "cursor", "goose"}
+		expected := []string{"claude", "cursor", "goose", "opencode"}
 		if !slices.Equal(agents, expected) {
 			t.Errorf("Expected %v, got: %v", expected, agents)
 		}

--- a/pkg/runtime/podman/config/defaults.go
+++ b/pkg/runtime/podman/config/defaults.go
@@ -35,6 +35,9 @@ const (
 
 	// CursorConfigFileName is the filename for Cursor agent configuration
 	CursorConfigFileName = "cursor.json"
+
+	// OpenCodeConfigFileName is the filename for OpenCode agent configuration
+	OpenCodeConfigFileName = "opencode.json"
 )
 
 // defaultImageConfig returns the default base image configuration.
@@ -96,5 +99,20 @@ func defaultCursorConfig() *AgentConfig {
 			"curl https://cursor.com/install -fsS | bash",
 		},
 		TerminalCommand: []string{"agent"},
+	}
+}
+
+// defaultOpenCodeConfig returns the default OpenCode agent configuration.
+// The installer places the binary in ~/.opencode/bin/ which is not in the
+// container's ENV PATH, so we symlink it into ~/.local/bin/.
+func defaultOpenCodeConfig() *AgentConfig {
+	return &AgentConfig{
+		Packages: []string{},
+		RunCommands: []string{
+			"cd /tmp && curl -fsSL https://opencode.ai/install | bash",
+			fmt.Sprintf("mkdir -p /home/%s/.local/bin && ln -sf /home/%s/.opencode/bin/opencode /home/%s/.local/bin/opencode", constants.ContainerUser, constants.ContainerUser, constants.ContainerUser),
+			fmt.Sprintf("mkdir -p /home/%s/.config/opencode", constants.ContainerUser),
+		},
+		TerminalCommand: []string{"opencode"},
 	}
 }

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -255,7 +255,7 @@ func TestPodmanRuntime_ListAgents(t *testing.T) {
 		}
 
 		// Default initialization creates config files for all default agents
-		expected := []string{"claude", "cursor", "goose"}
+		expected := []string{"claude", "cursor", "goose", "opencode"}
 		if !slices.Equal(agents, expected) {
 			t.Errorf("Expected %v, got: %v", expected, agents)
 		}

--- a/skills/working-with-config-system/SKILL.md
+++ b/skills/working-with-config-system/SKILL.md
@@ -67,6 +67,7 @@ When the `--model` flag is provided during `init`, kdn does two things with the 
    - Claude: `model` field in `.claude/settings.json`
    - Goose: `GOOSE_MODEL` field in `.config/goose/config.yaml`
    - Cursor: `model` object in `.cursor/cli-config.json`
+   - OpenCode: `model` field in `.config/opencode/opencode.json`
 
 The `--model` flag takes precedence over any model already defined in the settings files. If no model is specified, `GetModel()` returns an empty string and the `model` field is omitted from JSON output.
 
@@ -76,7 +77,7 @@ When the merged workspace configuration contains an `mcp` field, the manager cal
 - Claude: writes `mcpServers` entries into `.claude.json` at the top-level (user scope)
   - Command-based servers use `type: "stdio"` with `command`, `args`, and `env`
   - URL-based servers use `type: "sse"` with `url` and optional `headers`
-- Goose and Cursor: no-op (MCP configuration through settings files not supported)
+- Goose, Cursor, and OpenCode: no-op (MCP configuration through settings files not supported)
 
 MCP servers from all configuration levels are merged before being passed to the agent, with higher-precedence levels overriding lower ones by server `name`.
 

--- a/skills/working-with-podman-runtime-config/SKILL.md
+++ b/skills/working-with-podman-runtime-config/SKILL.md
@@ -29,7 +29,7 @@ The Podman runtime configuration allows customization of the base image, install
 - **Config Interface** (`pkg/runtime/podman/config/config.go`): Interface for managing Podman runtime configuration
 - **ImageConfig** (`pkg/runtime/podman/config/types.go`): Base image configuration (Fedora version, packages, sudo binaries, custom RUN commands)
 - **AgentConfig** (`pkg/runtime/podman/config/types.go`): Agent-specific configuration (packages, RUN commands, terminal command)
-- **Defaults** (`pkg/runtime/podman/config/defaults.go`): Default configurations for image and agents (Claude, Goose)
+- **Defaults** (`pkg/runtime/podman/config/defaults.go`): Default configurations for image and agents (Claude, Goose, Cursor, OpenCode)
 
 ## Configuration Storage
 
@@ -37,9 +37,10 @@ Configuration files are stored in the runtime's storage directory:
 
 ```text
 <storage-dir>/runtimes/podman/config/
-├── image.json    # Base image configuration
-├── claude.json   # Claude agent configuration
-└── goose.json    # Goose agent configuration
+├── image.json      # Base image configuration
+├── claude.json     # Claude agent configuration
+├── goose.json      # Goose agent configuration
+└── opencode.json   # OpenCode agent configuration
 ```
 
 ## Configuration Files
@@ -63,7 +64,7 @@ Configuration files are stored in the runtime's storage directory:
 
 ### Agent-Specific Configuration
 
-Agent configurations are named `<agent-name>.json`. The Podman runtime provides default configurations for Claude Code and Goose.
+Agent configurations are named `<agent-name>.json`. The Podman runtime provides default configurations for Claude Code, Goose, Cursor, and OpenCode.
 
 **claude.json - Claude Code Agent:**
 
@@ -87,6 +88,20 @@ Agent configurations are named `<agent-name>.json`. The Podman runtime provides 
     "cd /tmp && curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"
   ],
   "terminal_command": ["goose"]
+}
+```
+
+**opencode.json - OpenCode Agent:**
+
+```json
+{
+  "packages": [],
+  "run_commands": [
+    "cd /tmp && curl -fsSL https://opencode.ai/install | bash",
+    "mkdir -p /home/agent/.local/bin && ln -sf /home/agent/.opencode/bin/opencode /home/agent/.local/bin/opencode",
+    "mkdir -p /home/agent/.config/opencode"
+  ],
+  "terminal_command": ["opencode"]
 }
 ```
 
@@ -141,6 +156,7 @@ The config system validates:
 - Default agent configs are provided for:
   - **Claude Code** - Installs from the official install script at `claude.ai/install.sh`
   - **Goose** - Installs from the official installer at `github.com/block/goose`
+  - **OpenCode** - Installs from the official installer at `opencode.ai/install`
 
 ## Containerfile Generation
 


### PR DESCRIPTION
Add OpenCode as a supported AI agent with default Podman runtime configuration, automatic onboarding (SkipOnboarding, SetModel), and agent registration. The installer places the binary in ~/.opencode/bin/ which is outside the container's ENV PATH, so the default config symlinks it into ~/.local/bin/.

Test steps:
## Manual Testing Instructions
### Prerequisites
- Podman installed and running
- A local project directory to use as workspace sources
### Steps
#### 1. Build the CLI

```
bash
cd kdn
make build
```

2. Verify OpenCode is listed as an available agent
```
./kdn info
```

Expected: opencode appears in the Agents: line.

3. Initialize a workspace with the OpenCode agent
```
./kdn init /path/to/your/project --runtime podman --agent opencode
```
Expected: all four steps succeed:

✓ Temporary build directory created
✓ Containerfile generated
✓ Container image built
✓ Container created

4. Start the workspace
```
./kdn start <workspace-name>
```
5. Open the OpenCode terminal
```
./kdn workspace terminal <workspace-name>
```
Expected: OpenCode launches inside the container without "command not found" errors. On first run you may see a database migration message.

6. Clean up
```
./kdn stop <workspace-name>
./kdn remove <workspace-na
```

### Model selection test
7. Initialize a workspace specifying a model
Use a free model to verify the --model flag flows through to the OpenCode configuration:
````
./kdn init /path/to/your/project --runtime podman --agent opencode --model opencode/nemotron-3-super-free
````

8. Start and verify the config file
````
./kdn start <workspace-name>
podman exec -it <container-id> bash -c 'cat ~/.config/opencode/opencode.json'
````

Expected: the config file contains the specified model:

````
{
  "model": "opencode/nemotron-3-super-free"
}
````

9. Open the terminal and verify the model is active

```./kdn workspace terminal <workspace-name>```

Expected: the OpenCode TUI status bar shows Nemotron 3 Super Free as the active model. Prompting a question should use this model instead of the default (Big Pickle).

10. Clean up
````
./kdn stop <workspace-name>
./kdn remove <workspace-name>
````


Closes #213