### PR TITLE
feat(podman): deploy workspaces as pods with proxy sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 kdn is a command-line interface for launching and managing AI agents in isolated, reproducible workspaces. It creates runtime-based environments (containers, VMs, or other backends) where agents run with your project source code mounted, automatically configured and ready to use — no manual onboarding or setup required.
 
-The architecture is built around pluggable runtimes. The first supported runtime is **Podman**, which creates container-based workspaces using a custom Fedora image. Additional runtimes (e.g., MicroVM, Kubernetes) can be added to support other execution environments.
+The architecture is built around pluggable runtimes. The first supported runtime is **Podman**, which creates pod-based workspaces using a custom Fedora image, with a network-isolating proxy sidecar. Additional runtimes (e.g., MicroVM, Kubernetes) can be added to support other execution environments.
 
 **Supported Agents**
 
@@ -17,6 +17,7 @@ The architecture is built around pluggable runtimes. The first supported runtime
 
 - Isolated workspaces per project, each running in its own runtime instance
 - Pluggable runtime system — Podman is the default, with support for adding other runtimes
+- Network-isolated workspaces — outbound traffic is routed through a Squid proxy sidecar with nftables kernel-level enforcement (Podman runtime)
 - Automatic agent configuration (onboarding flags, trusted directories) on workspace creation
 - Multi-level configuration: workspace, global, project-specific, and agent-specific settings
 - Inject environment variables and mount directories into workspaces at multiple scopes
@@ -1126,7 +1127,12 @@ kdn init /path/to/another-project --runtime podman --agent claude --start
 
 ## Podman Runtime
 
-The Podman runtime provides a container-based development environment for workspaces. It creates an isolated environment with all necessary tools pre-installed and configured.
+The Podman runtime provides a container-based development environment for workspaces. It creates a **Podman pod** containing two containers:
+
+- **Workspace container** (`kdn-<name>-workspace`) — runs the AI agent with your project mounted at `/workspace/sources`
+- **Proxy sidecar** (`kdn-<name>-proxy`) — runs a Squid HTTP/HTTPS proxy that enforces network restrictions via nftables
+
+Both containers share the pod's network namespace. The workspace container routes all outbound traffic through the Squid proxy (port 3128) via injected proxy environment variables (`http_proxy`, `https_proxy`, etc.). The proxy sidecar uses `CAP_NET_ADMIN` to set an nftables OUTPUT policy of `drop`, allowing only traffic from the squid user and established connections — so direct outbound access is blocked at the kernel level even if proxy env vars are unset.
 
 ### Container Image
 
@@ -1214,15 +1220,24 @@ When you register a workspace with the Podman runtime, you'll see progress feedb
 ✓ Containerfile generated
 ⠋ Building container image: kdn-myproject
 ✓ Container image built
-⠋ Creating container: myproject
-✓ Container created
+⠋ Building proxy image: kdn-myproject-proxy
+✓ Proxy image built
+⠋ Creating pod: kdn-myproject
+✓ Pod created
+⠋ Creating proxy container
+✓ Proxy container created
+⠋ Creating workspace container: kdn-myproject-workspace
+✓ Workspace container created
 ```
 
 The `init` command will:
 1. Create a temporary build directory - **with progress spinner**
 2. Generate a Containerfile with the configuration above - **with progress spinner**
-3. Build a custom image (tagged as `kdn-<workspace-name>`) - **with progress spinner**
-4. Create a container with your source code mounted - **with progress spinner**
+3. Build the workspace image (tagged as `kdn-<workspace-name>`) - **with progress spinner**
+4. Build the proxy sidecar image (tagged as `kdn-<workspace-name>-proxy`) - **with progress spinner**
+5. Create a Podman pod (named `kdn-<workspace-name>`) - **with progress spinner**
+6. Create the proxy container inside the pod - **with progress spinner**
+7. Create the workspace container inside the pod with your source code mounted - **with progress spinner**
 
 After registration, you can start the workspace:
 
@@ -2748,6 +2763,7 @@ kdn terminal a1b2c3d4e5f6...
 - You can override the default by providing a custom command (e.g., `bash`, `python`, or any executable available in the container)
 - Use the `--` separator when your command includes flags to prevent kdn from trying to parse them
 - The terminal session is fully interactive with stdin/stdout/stderr connected to your terminal
+- With the Podman runtime, the terminal connects to the **workspace container** (`kdn-<name>-workspace`) inside the pod, not the proxy sidecar
 - The command execution happens inside the workspace's container/runtime environment
 - JSON output is **not supported** for this command as it's inherently interactive
 - Runtime support: The terminal command requires the runtime to implement the Terminal interface. The Podman runtime supports this using `podman exec -it`

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -314,14 +314,14 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	// All steps succeeded — disable cleanup so the deferred call is a no-op.
 	cleanupOnError = func() {}
 
-	// Return RuntimeInfo with the pod name as ID
+	// Return RuntimeInfo with the pod name as ID.
+	// source_path and agent are stored in the instance record by the manager
+	// and are not part of the pod-level runtime info.
 	info := map[string]string{
 		"pod_name":            podN,
 		"workspace_container": wsContainer,
 		"proxy_container":     proxyContainer,
 		"image_name":          imageName,
-		"source_path":         params.SourcePath,
-		"agent":               params.Agent,
 	}
 
 	return runtime.RuntimeInfo{

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -28,6 +28,16 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
+// podName returns the pod name for a given workspace name.
+func podName(workspaceName string) string {
+	return fmt.Sprintf("kdn-%s", workspaceName)
+}
+
+// workspaceContainerName returns the workspace container name for a given pod name.
+func workspaceContainerName(podN string) string {
+	return fmt.Sprintf("%s-workspace", podN)
+}
+
 // validateCreateParams validates the create parameters.
 func (p *podmanRuntime) validateCreateParams(params runtime.CreateParams) error {
 	if params.Name == "" {
@@ -114,9 +124,24 @@ func (p *podmanRuntime) buildImage(ctx context.Context, imageName, instanceDir s
 	return nil
 }
 
-// buildContainerArgs builds the arguments for creating a podman container.
-func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string) ([]string, error) {
-	args := []string{"create", "--name", params.Name}
+// proxyEnvVars are the -e flags injected into the workspace container so that
+// HTTP clients use the Squid sidecar. Unsetting them does not bypass the proxy
+// because nftables enforces the restriction at the kernel level.
+var proxyEnvVars = []string{
+	"-e", "HTTP_PROXY=http://localhost:3128",
+	"-e", "HTTPS_PROXY=http://localhost:3128",
+	"-e", "http_proxy=http://localhost:3128",
+	"-e", "https_proxy=http://localhost:3128",
+	"-e", "NO_PROXY=localhost,127.0.0.1",
+	"-e", "no_proxy=localhost,127.0.0.1",
+}
+
+// buildWorkspaceContainerArgs builds the arguments for creating the workspace container in a pod.
+func (p *podmanRuntime) buildWorkspaceContainerArgs(params runtime.CreateParams, podN, containerName, imageName string) ([]string, error) {
+	args := []string{"create", "--pod", podN, "--name", containerName}
+
+	// Proxy env vars are prepended so they take effect before user-supplied vars.
+	args = append(args, proxyEnvVars...)
 
 	// Add environment variables from workspace config
 	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Environment != nil {
@@ -170,7 +195,16 @@ func (p *podmanRuntime) createContainer(ctx context.Context, args []string) (str
 	return strings.TrimSpace(string(output)), nil
 }
 
-// Create creates a new Podman runtime instance.
+// createPod creates a podman pod with the given name.
+func (p *podmanRuntime) createPod(ctx context.Context, podN string) error {
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "create", "--name", podN); err != nil {
+		return fmt.Errorf("failed to create pod: %w", err)
+	}
+	return nil
+}
+
+// Create creates a new Podman runtime instance as a pod with a workspace and proxy sidecar container.
 func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
@@ -203,45 +237,84 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load agent config: %w", err)
 	}
 
-	// Create Containerfile
+	// Create workspace Containerfile
 	stepLogger.Start("Generating Containerfile", "Containerfile generated")
 	if err := p.createContainerfile(instanceDir, imageConfig, agentConfig, params.AgentSettings); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
-	// Build image
-	imageName := fmt.Sprintf("kdn-%s", params.Name)
+	// Write proxy Containerfile and startup script to the instance directory
+	proxyContainerfileContent := generateProxyContainerfile(imageConfig.Version)
+	proxyContainerfilePath := filepath.Join(instanceDir, "Containerfile.proxy")
+	if err := os.WriteFile(proxyContainerfilePath, []byte(proxyContainerfileContent), 0644); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to write proxy Containerfile: %w", err)
+	}
+
+	proxyStartScriptContent := generateProxyStartScript()
+	proxyStartScriptPath := filepath.Join(instanceDir, "proxy-start.sh")
+	if err := os.WriteFile(proxyStartScriptPath, []byte(proxyStartScriptContent), 0755); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to write proxy start script: %w", err)
+	}
+
+	// Build workspace image
+	podN := podName(params.Name)
+	imageName := podN
 	stepLogger.Start(fmt.Sprintf("Building container image: %s", imageName), "Container image built")
 	if err := p.buildImage(ctx, imageName, instanceDir); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
-	// Build container creation arguments
-	createArgs, err := p.buildContainerArgs(params, imageName)
-	if err != nil {
-		return runtime.RuntimeInfo{}, err
-	}
-
-	// Create container and get its ID directly from podman create output
-	stepLogger.Start(fmt.Sprintf("Creating container: %s", params.Name), "Container created")
-	containerID, err := p.createContainer(ctx, createArgs)
-	if err != nil {
+	// Build proxy image
+	proxyImage := proxyImageName(podN)
+	stepLogger.Start(fmt.Sprintf("Building proxy image: %s", proxyImage), "Proxy image built")
+	if err := p.buildProxyImage(ctx, proxyImage, instanceDir); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
-	// Return RuntimeInfo
+	// Create pod
+	stepLogger.Start(fmt.Sprintf("Creating pod: %s", podN), "Pod created")
+	if err := p.createPod(ctx, podN); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, err
+	}
+
+	// Create proxy container in the pod
+	proxyContainer := proxyContainerName(podN)
+	stepLogger.Start("Creating proxy container", "Proxy container created")
+	proxyArgs := buildProxyContainerArgs(podN, proxyContainer, proxyImage)
+	if _, err := p.createContainer(ctx, proxyArgs); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, err
+	}
+
+	// Create workspace container in the pod
+	wsContainer := workspaceContainerName(podN)
+	stepLogger.Start(fmt.Sprintf("Creating workspace container: %s", wsContainer), "Workspace container created")
+	wsArgs, err := p.buildWorkspaceContainerArgs(params, podN, wsContainer, imageName)
+	if err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, err
+	}
+	if _, err := p.createContainer(ctx, wsArgs); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, err
+	}
+
+	// Return RuntimeInfo with the pod name as ID
 	info := map[string]string{
-		"container_id": containerID,
-		"image_name":   imageName,
-		"source_path":  params.SourcePath,
-		"agent":        params.Agent,
+		"pod_name":            podN,
+		"workspace_container": wsContainer,
+		"proxy_container":     proxyContainer,
+		"image_name":          imageName,
+		"source_path":         params.SourcePath,
+		"agent":               params.Agent,
 	}
 
 	return runtime.RuntimeInfo{
-		ID:    containerID,
+		ID:    podN,
 		State: api.WorkspaceStateStopped,
 		Info:  info,
 	}, nil

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -286,7 +286,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
-	cleanupOnError = func() { _ = p.removeContainer(context.Background(), podN) }
+	cleanupOnError = func() { _ = p.removePod(context.Background(), podN) }
 
 	// Create proxy container in the pod
 	proxyContainer := proxyContainerName(podN)

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -274,12 +274,19 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, err
 	}
 
+	// cleanupOnError is updated at each step to undo any resources created so far.
+	// The deferred call runs it on every return; on the success path it is a no-op.
+	// Use a background context so cleanup still runs if the original context is cancelled.
+	cleanupOnError := func() {}
+	defer func() { cleanupOnError() }()
+
 	// Create pod
 	stepLogger.Start(fmt.Sprintf("Creating pod: %s", podN), "Pod created")
 	if err := p.createPod(ctx, podN); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
+	cleanupOnError = func() { _ = p.removeContainer(context.Background(), podN) }
 
 	// Create proxy container in the pod
 	proxyContainer := proxyContainerName(podN)
@@ -289,6 +296,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
+	// Removing the pod also removes any containers inside it, so cleanupOnError stays the same.
 
 	// Create workspace container in the pod
 	wsContainer := workspaceContainerName(podN)
@@ -302,6 +310,9 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
+
+	// All steps succeeded — disable cleanup so the deferred call is a no-op.
+	cleanupOnError = func() {}
 
 	// Return RuntimeInfo with the pod name as ID
 	info := map[string]string{

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -447,8 +447,11 @@ func TestBuildWorkspaceContainerArgs(t *testing.T) {
 		if !strings.Contains(argsStr, "-w /workspace/sources") {
 			t.Errorf("Expected working directory, got: %s", argsStr)
 		}
-		if !strings.Contains(argsStr, imageName) {
-			t.Errorf("Expected image name %q, got: %s", imageName, argsStr)
+		// args ends with [..., imageName, "sleep", "infinity"]; check the exact position
+		// rather than searching argsStr, because imageName equals podN which also
+		// appears in the --pod flag value.
+		if len(args) < 3 || args[len(args)-3] != imageName {
+			t.Errorf("Expected image name %q at args[%d], got: %s", imageName, len(args)-3, argsStr)
 		}
 		if !strings.Contains(argsStr, "sleep infinity") {
 			t.Errorf("Expected sleep infinity command, got: %s", argsStr)
@@ -667,8 +670,11 @@ func TestBuildWorkspaceContainerArgs(t *testing.T) {
 		if !strings.Contains(argsStr, "-w /workspace/sources") {
 			t.Error("Expected working directory")
 		}
-		if !strings.Contains(argsStr, imageName) {
-			t.Error("Expected image name")
+		// args ends with [..., imageName, "sleep", "infinity"]; check the exact position
+		// rather than searching argsStr, because imageName equals podN which also
+		// appears in the --pod flag value.
+		if len(args) < 3 || args[len(args)-3] != imageName {
+			t.Errorf("Expected image name %q at args[%d], got: %s", imageName, len(args)-3, argsStr)
 		}
 		if !strings.Contains(argsStr, "sleep infinity") {
 			t.Error("Expected sleep infinity command")

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1034,6 +1034,122 @@ func TestCreate_StepLogger_FailOnCreateProxyContainer(t *testing.T) {
 	if fakeLogger.failCalls[0] == nil {
 		t.Error("Expected Fail() to be called with non-nil error")
 	}
+
+	// Verify the pod was cleaned up after the partial failure
+	fakeExec.AssertRunCalledWith(t, "pod", "rm", "kdn-test-workspace")
+}
+
+func TestCreate_CleansUpPodOnPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes pod when proxy container creation fails", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcePath := t.TempDir()
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(ctx context.Context, args ...string) error { return nil }
+		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "create" {
+				return nil, fmt.Errorf("create container failed")
+			}
+			return []byte("output"), nil
+		}
+
+		p := &podmanRuntime{
+			system:     &fakeSystem{},
+			executor:   fakeExec,
+			storageDir: storageDir,
+			config:     &fakeConfig{},
+		}
+
+		_, err := p.Create(context.Background(), runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+		})
+		if err == nil {
+			t.Fatal("Expected Create() to fail, got nil")
+		}
+
+		fakeExec.AssertRunCalledWith(t, "pod", "rm", "kdn-test-workspace")
+	})
+
+	t.Run("removes pod and proxy container when workspace container creation fails", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcePath := t.TempDir()
+
+		proxyCreated := false
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(ctx context.Context, args ...string) error { return nil }
+		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "create" {
+				if !proxyCreated {
+					proxyCreated = true
+					return []byte("proxy-container-id"), nil
+				}
+				return nil, fmt.Errorf("workspace container creation failed")
+			}
+			return []byte("output"), nil
+		}
+
+		p := &podmanRuntime{
+			system:     &fakeSystem{},
+			executor:   fakeExec,
+			storageDir: storageDir,
+			config:     &fakeConfig{},
+		}
+
+		_, err := p.Create(context.Background(), runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+		})
+		if err == nil {
+			t.Fatal("Expected Create() to fail, got nil")
+		}
+
+		// pod rm removes the pod and all containers inside it (including the proxy container)
+		fakeExec.AssertRunCalledWith(t, "pod", "rm", "kdn-test-workspace")
+	})
+
+	t.Run("does not remove pod on successful create", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcePath := t.TempDir()
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(ctx context.Context, args ...string) error { return nil }
+		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+			return []byte("container-id"), nil
+		}
+
+		p := &podmanRuntime{
+			system:     &fakeSystem{},
+			executor:   fakeExec,
+			storageDir: storageDir,
+			config:     &fakeConfig{},
+		}
+
+		_, err := p.Create(context.Background(), runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+		})
+		if err != nil {
+			t.Fatalf("Expected Create() to succeed, got: %v", err)
+		}
+
+		for _, call := range fakeExec.RunCalls {
+			if len(call) >= 2 && call[0] == "pod" && call[1] == "rm" {
+				t.Errorf("Expected pod rm not to be called on success, but got: %v", call)
+			}
+		}
+	})
 }
 
 func TestCreate_CleansUpInstanceDirectory(t *testing.T) {

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -394,45 +394,64 @@ func TestCreateContainerfile(t *testing.T) {
 	})
 }
 
-func TestBuildContainerArgs(t *testing.T) {
+func TestBuildWorkspaceContainerArgs(t *testing.T) {
 	t.Parallel()
 
 	t.Run("basic args without config", func(t *testing.T) {
 		t.Parallel()
 
 		p := &podmanRuntime{}
-		// Use t.TempDir() for cross-platform path handling
 		sourcePath := t.TempDir()
 		params := runtime.CreateParams{
 			Name:       "test-workspace",
 			SourcePath: sourcePath,
 			Agent:      "test_agent",
 		}
-		imageName := "kdn-test-workspace"
+		podN := podName(params.Name)
+		wsContainer := workspaceContainerName(podN)
+		imageName := podN
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildWorkspaceContainerArgs(params, podN, wsContainer, imageName)
 		if err != nil {
-			t.Fatalf("buildContainerArgs() failed: %v", err)
+			t.Fatalf("buildWorkspaceContainerArgs() failed: %v", err)
 		}
 
-		// Verify basic structure
-		expectedArgs := []string{
-			"create",
-			"--name", "test-workspace",
-			"-v", fmt.Sprintf("%s:/workspace/sources:Z", sourcePath),
-			"-w", "/workspace/sources",
-			"kdn-test-workspace",
-			"sleep", "infinity",
+		argsStr := strings.Join(args, " ")
+
+		// Verify pod and container flags
+		if !strings.Contains(argsStr, "--pod kdn-test-workspace") {
+			t.Errorf("Expected --pod flag with pod name, got: %s", argsStr)
+		}
+		if !strings.Contains(argsStr, "--name kdn-test-workspace-workspace") {
+			t.Errorf("Expected --name flag with workspace container name, got: %s", argsStr)
 		}
 
-		if len(args) != len(expectedArgs) {
-			t.Fatalf("Expected %d args, got %d\nExpected: %v\nGot: %v", len(expectedArgs), len(args), expectedArgs, args)
-		}
-
-		for i, expected := range expectedArgs {
-			if args[i] != expected {
-				t.Errorf("Arg %d: expected %q, got %q", i, expected, args[i])
+		// Verify proxy env vars are present
+		for _, envFlag := range []string{
+			"HTTP_PROXY=http://localhost:3128",
+			"HTTPS_PROXY=http://localhost:3128",
+			"http_proxy=http://localhost:3128",
+			"https_proxy=http://localhost:3128",
+			"NO_PROXY=localhost,127.0.0.1",
+			"no_proxy=localhost,127.0.0.1",
+		} {
+			if !strings.Contains(argsStr, envFlag) {
+				t.Errorf("Expected proxy env var %q in args: %s", envFlag, argsStr)
 			}
+		}
+
+		// Verify source mount, working dir, image, and command
+		if !strings.Contains(argsStr, fmt.Sprintf("%s:/workspace/sources:Z", sourcePath)) {
+			t.Errorf("Expected source mount, got: %s", argsStr)
+		}
+		if !strings.Contains(argsStr, "-w /workspace/sources") {
+			t.Errorf("Expected working directory, got: %s", argsStr)
+		}
+		if !strings.Contains(argsStr, imageName) {
+			t.Errorf("Expected image name %q, got: %s", imageName, argsStr)
+		}
+		if !strings.Contains(argsStr, "sleep infinity") {
+			t.Errorf("Expected sleep infinity command, got: %s", argsStr)
 		}
 	})
 
@@ -451,7 +470,6 @@ func TestBuildContainerArgs(t *testing.T) {
 			{Name: "EMPTY", Value: &emptyValue},
 		}
 
-		// Use t.TempDir() for cross-platform path handling
 		sourcePath := t.TempDir()
 		params := runtime.CreateParams{
 			Name:       "test-workspace",
@@ -461,11 +479,12 @@ func TestBuildContainerArgs(t *testing.T) {
 				Environment: &envVars,
 			},
 		}
-		imageName := "kdn-test-workspace"
+		podN := podName(params.Name)
+		wsContainer := workspaceContainerName(podN)
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildWorkspaceContainerArgs(params, podN, wsContainer, podN)
 		if err != nil {
-			t.Fatalf("buildContainerArgs() failed: %v", err)
+			t.Fatalf("buildWorkspaceContainerArgs() failed: %v", err)
 		}
 
 		// Check that environment variables are included
@@ -510,11 +529,12 @@ func TestBuildContainerArgs(t *testing.T) {
 				},
 			},
 		}
-		imageName := "kdn-test-workspace"
+		podN := podName(params.Name)
+		wsContainer := workspaceContainerName(podN)
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildWorkspaceContainerArgs(params, podN, wsContainer, podN)
 		if err != nil {
-			t.Fatalf("buildContainerArgs() failed: %v", err)
+			t.Fatalf("buildWorkspaceContainerArgs() failed: %v", err)
 		}
 
 		argsStr := strings.Join(args, " ")
@@ -547,11 +567,12 @@ func TestBuildContainerArgs(t *testing.T) {
 				},
 			},
 		}
-		imageName := "kdn-test-workspace"
+		podN := podName(params.Name)
+		wsContainer := workspaceContainerName(podN)
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildWorkspaceContainerArgs(params, podN, wsContainer, podN)
 		if err != nil {
-			t.Fatalf("buildContainerArgs() failed: %v", err)
+			t.Fatalf("buildWorkspaceContainerArgs() failed: %v", err)
 		}
 
 		// Get user home directory for verification
@@ -605,22 +626,26 @@ func TestBuildContainerArgs(t *testing.T) {
 				},
 			},
 		}
-		imageName := "kdn-test-workspace"
+		podN := podName(params.Name)
+		wsContainer := workspaceContainerName(podN)
+		imageName := podN
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildWorkspaceContainerArgs(params, podN, wsContainer, imageName)
 		if err != nil {
-			t.Fatalf("buildContainerArgs() failed: %v", err)
+			t.Fatalf("buildWorkspaceContainerArgs() failed: %v", err)
 		}
 
 		// Verify all components are present
 		argsStr := strings.Join(args, " ")
 
-		// Check structure
 		if !strings.Contains(argsStr, "create") {
 			t.Error("Expected 'create' command")
 		}
-		if !strings.Contains(argsStr, "--name test-workspace") {
-			t.Error("Expected container name")
+		if !strings.Contains(argsStr, "--pod kdn-test-workspace") {
+			t.Error("Expected pod name flag")
+		}
+		if !strings.Contains(argsStr, "--name kdn-test-workspace-workspace") {
+			t.Error("Expected workspace container name")
 		}
 		if !strings.Contains(argsStr, "-e DEBUG=true") {
 			t.Error("Expected environment variable")
@@ -696,7 +721,7 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Verify Start was called 4 times with correct messages
+	// Verify Start was called 7 times with correct messages
 	expectedSteps := []stepCall{
 		{
 			inProgress: "Creating temporary build directory",
@@ -711,8 +736,20 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 			completed:  "Container image built",
 		},
 		{
-			inProgress: "Creating container: test-workspace",
-			completed:  "Container created",
+			inProgress: "Building proxy image: kdn-test-workspace-proxy",
+			completed:  "Proxy image built",
+		},
+		{
+			inProgress: "Creating pod: kdn-test-workspace",
+			completed:  "Pod created",
+		},
+		{
+			inProgress: "Creating proxy container",
+			completed:  "Proxy container created",
+		},
+		{
+			inProgress: "Creating workspace container: kdn-test-workspace-workspace",
+			completed:  "Workspace container created",
 		},
 	}
 
@@ -858,7 +895,7 @@ func TestCreate_StepLogger_FailOnBuildImage(t *testing.T) {
 	sourcePath := t.TempDir()
 
 	fakeExec := exec.NewFake()
-	// Make Run fail on build command
+	// Make Run fail on build command (first build = workspace image)
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
 		if len(args) > 0 && args[0] == "build" {
 			return fmt.Errorf("build failed")
@@ -892,7 +929,7 @@ func TestCreate_StepLogger_FailOnBuildImage(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called 3 times (create dir, containerfile, build image)
+	// Verify Start was called 3 times (create dir, containerfile, build workspace image)
 	if len(fakeLogger.startCalls) != 3 {
 		t.Fatalf("Expected 3 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
@@ -919,14 +956,14 @@ func TestCreate_StepLogger_FailOnBuildImage(t *testing.T) {
 	}
 }
 
-func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
+func TestCreate_StepLogger_FailOnCreateProxyContainer(t *testing.T) {
 	t.Parallel()
 
 	storageDir := t.TempDir()
 	sourcePath := t.TempDir()
 
 	fakeExec := exec.NewFake()
-	// Make Run succeed for build, but Output fail for create
+	// Run succeeds for all builds and pod create; Output fails for any container create
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
 		return nil
 	}
@@ -963,16 +1000,18 @@ func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called 4 times (all steps)
-	if len(fakeLogger.startCalls) != 4 {
-		t.Fatalf("Expected 4 Start() calls, got %d", len(fakeLogger.startCalls))
+	// Verify Start was called 6 times (up to and including "Creating proxy container")
+	if len(fakeLogger.startCalls) != 6 {
+		t.Fatalf("Expected 6 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
 		"Creating temporary build directory",
 		"Generating Containerfile",
 		"Building container image: kdn-test-workspace",
-		"Creating container: test-workspace",
+		"Building proxy image: kdn-test-workspace-proxy",
+		"Creating pod: kdn-test-workspace",
+		"Creating proxy container",
 	}
 
 	for i, expected := range expectedSteps {

--- a/pkg/runtime/podman/info.go
+++ b/pkg/runtime/podman/info.go
@@ -77,10 +77,13 @@ func (p *podmanRuntime) getPodInfo(ctx context.Context, id string) (runtime.Runt
 	// Map podman pod state to valid WorkspaceState
 	state := mapPodmanPodState(podmanState)
 
-	// Build the info map
+	// Build the info map with all pod-derivable fields so Info() returns
+	// the same key set as Create().
 	info := map[string]string{
 		"pod_name":            podN,
 		"workspace_container": workspaceContainerName(podN),
+		"proxy_container":     proxyContainerName(podN),
+		"image_name":          podN,
 	}
 
 	return runtime.RuntimeInfo{

--- a/pkg/runtime/podman/info.go
+++ b/pkg/runtime/podman/info.go
@@ -24,15 +24,15 @@ import (
 	"github.com/openkaiden/kdn/pkg/runtime"
 )
 
-// mapPodmanState maps podman container states to valid WorkspaceState values.
-// Podman states: https://docs.podman.io/en/latest/markdown/podman-ps.1.html
-func mapPodmanState(podmanState string) api.WorkspaceState {
+// mapPodmanPodState maps podman pod states to valid WorkspaceState values.
+// Pod states use title case: https://docs.podman.io/en/latest/markdown/podman-pod-inspect.1.html
+func mapPodmanPodState(podmanState string) api.WorkspaceState {
 	switch podmanState {
-	case "running":
+	case "Running":
 		return api.WorkspaceStateRunning
-	case "created", "exited", "stopped", "paused", "removing":
+	case "Created", "Stopped", "Exited":
 		return api.WorkspaceStateStopped
-	case "dead":
+	case "Dead", "Degraded":
 		return api.WorkspaceStateError
 	default:
 		return api.WorkspaceStateUnknown
@@ -43,11 +43,11 @@ func mapPodmanState(podmanState string) api.WorkspaceState {
 func (p *podmanRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
 	// Validate the ID parameter
 	if id == "" {
-		return runtime.RuntimeInfo{}, fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
+		return runtime.RuntimeInfo{}, fmt.Errorf("%w: pod ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Get container information
-	info, err := p.getContainerInfo(ctx, id)
+	// Get pod information
+	info, err := p.getPodInfo(ctx, id)
 	if err != nil {
 		return runtime.RuntimeInfo{}, err
 	}
@@ -55,37 +55,36 @@ func (p *podmanRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInf
 	return info, nil
 }
 
-// getContainerInfo retrieves detailed information about a container.
-func (p *podmanRuntime) getContainerInfo(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
-	// Use podman inspect to get container details in a format we can parse
-	// Format: ID|State|ImageName (custom fields from creation)
+// getPodInfo retrieves detailed information about a pod.
+func (p *podmanRuntime) getPodInfo(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	// Use podman pod inspect to get pod details
+	// Format: Name|State
 	l := logger.FromContext(ctx)
-	output, err := p.executor.Output(ctx, l.Stderr(), "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", id)
+	output, err := p.executor.Output(ctx, l.Stderr(), "pod", "inspect", "--format", "{{.Name}}|{{.State}}", id)
 	if err != nil {
-		return runtime.RuntimeInfo{}, fmt.Errorf("failed to inspect container: %w", err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to inspect pod: %w", err)
 	}
 
 	// Parse the output
 	fields := strings.Split(strings.TrimSpace(string(output)), "|")
-	if len(fields) != 3 {
+	if len(fields) != 2 {
 		return runtime.RuntimeInfo{}, fmt.Errorf("unexpected inspect output format: %s", string(output))
 	}
 
-	containerID := fields[0]
+	podN := fields[0]
 	podmanState := fields[1]
-	imageName := fields[2]
 
-	// Map podman state to valid WorkspaceState
-	state := mapPodmanState(podmanState)
+	// Map podman pod state to valid WorkspaceState
+	state := mapPodmanPodState(podmanState)
 
 	// Build the info map
 	info := map[string]string{
-		"container_id": containerID,
-		"image_name":   imageName,
+		"pod_name":            podN,
+		"workspace_container": workspaceContainerName(podN),
 	}
 
 	return runtime.RuntimeInfo{
-		ID:    containerID,
+		ID:    podN,
 		State: state,
 		Info:  info,
 	}, nil

--- a/pkg/runtime/podman/info_test.go
+++ b/pkg/runtime/podman/info_test.go
@@ -112,6 +112,13 @@ func TestInfo_Success(t *testing.T) {
 			if info.Info["workspace_container"] != expectedWsContainer {
 				t.Errorf("Expected workspace_container %s, got %s", expectedWsContainer, info.Info["workspace_container"])
 			}
+			expectedProxyContainer := proxyContainerName(tt.podID)
+			if info.Info["proxy_container"] != expectedProxyContainer {
+				t.Errorf("Expected proxy_container %s, got %s", expectedProxyContainer, info.Info["proxy_container"])
+			}
+			if info.Info["image_name"] != tt.podID {
+				t.Errorf("Expected image_name %s, got %s", tt.podID, info.Info["image_name"])
+			}
 		})
 	}
 }
@@ -234,6 +241,13 @@ func TestGetPodInfo_ParsesOutput(t *testing.T) {
 			}
 			if info.Info["pod_name"] != tt.podID {
 				t.Errorf("Expected pod_name %s, got %s", tt.podID, info.Info["pod_name"])
+			}
+			expectedProxyContainer := proxyContainerName(tt.podID)
+			if info.Info["proxy_container"] != expectedProxyContainer {
+				t.Errorf("Expected proxy_container %s, got %s", expectedProxyContainer, info.Info["proxy_container"])
+			}
+			if info.Info["image_name"] != tt.podID {
+				t.Errorf("Expected image_name %s, got %s", tt.podID, info.Info["image_name"])
 			}
 		})
 	}

--- a/pkg/runtime/podman/info_test.go
+++ b/pkg/runtime/podman/info_test.go
@@ -49,31 +49,33 @@ func TestInfo_Success(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		containerID   string
+		podID         string
 		output        string
 		expectedState api.WorkspaceState
-		expectedImage string
 	}{
 		{
-			name:          "running container",
-			containerID:   "abc123def456",
-			output:        "abc123def456|running|kdn-test\n",
+			name:          "running pod",
+			podID:         "kdn-test",
+			output:        "kdn-test|Running\n",
 			expectedState: api.WorkspaceStateRunning,
-			expectedImage: "kdn-test",
 		},
 		{
-			name:          "stopped container",
-			containerID:   "xyz789ghi012",
-			output:        "xyz789ghi012|exited|kdn-stopped\n",
+			name:          "stopped pod",
+			podID:         "kdn-stopped",
+			output:        "kdn-stopped|Stopped\n",
 			expectedState: api.WorkspaceStateStopped,
-			expectedImage: "kdn-stopped",
 		},
 		{
-			name:          "created container",
-			containerID:   "def456jkl789",
-			output:        "def456jkl789|created|kdn-new\n",
+			name:          "created pod",
+			podID:         "kdn-new",
+			output:        "kdn-new|Created\n",
 			expectedState: api.WorkspaceStateStopped,
-			expectedImage: "kdn-new",
+		},
+		{
+			name:          "exited pod",
+			podID:         "kdn-exited",
+			output:        "kdn-exited|Exited\n",
+			expectedState: api.WorkspaceStateStopped,
 		},
 	}
 
@@ -88,26 +90,27 @@ func TestInfo_Success(t *testing.T) {
 
 			p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-			info, err := p.Info(context.Background(), tt.containerID)
+			info, err := p.Info(context.Background(), tt.podID)
 			if err != nil {
 				t.Fatalf("Info() failed: %v", err)
 			}
 
-			// Verify Output was called to inspect the container
-			fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", tt.containerID)
+			// Verify Output was called with pod inspect args
+			fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{.Name}}|{{.State}}", tt.podID)
 
 			// Verify returned info
-			if info.ID != tt.containerID {
-				t.Errorf("Expected ID %s, got %s", tt.containerID, info.ID)
+			if info.ID != tt.podID {
+				t.Errorf("Expected ID %s, got %s", tt.podID, info.ID)
 			}
 			if info.State != tt.expectedState {
 				t.Errorf("Expected state %s, got %s", tt.expectedState, info.State)
 			}
-			if info.Info["container_id"] != tt.containerID {
-				t.Errorf("Expected container_id %s, got %s", tt.containerID, info.Info["container_id"])
+			if info.Info["pod_name"] != tt.podID {
+				t.Errorf("Expected pod_name %s, got %s", tt.podID, info.Info["pod_name"])
 			}
-			if info.Info["image_name"] != tt.expectedImage {
-				t.Errorf("Expected image_name %s, got %s", tt.expectedImage, info.Info["image_name"])
+			expectedWsContainer := workspaceContainerName(tt.podID)
+			if info.Info["workspace_container"] != expectedWsContainer {
+				t.Errorf("Expected workspace_container %s, got %s", expectedWsContainer, info.Info["workspace_container"])
 			}
 		})
 	}
@@ -116,77 +119,97 @@ func TestInfo_Success(t *testing.T) {
 func TestInfo_InspectFailure(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up OutputFunc to return an error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		return nil, fmt.Errorf("container not found")
+		return nil, fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	_, err := p.Info(context.Background(), containerID)
+	_, err := p.Info(context.Background(), podID)
 	if err == nil {
 		t.Fatal("Expected error when inspect fails, got nil")
 	}
 
-	// Verify Output was called
-	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
+	// Verify Output was called with pod inspect args
+	fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{.Name}}|{{.State}}", podID)
 }
 
 func TestInfo_MalformedOutput(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return malformed output
+	// Set up OutputFunc to return malformed output (missing pipe separator)
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		return []byte("invalid-output-without-pipes\n"), nil
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	_, err := p.Info(context.Background(), containerID)
+	_, err := p.Info(context.Background(), podID)
 	if err == nil {
 		t.Fatal("Expected error for malformed output, got nil")
 	}
 
-	// Verify Output was called
-	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
+	// Verify Output was called with pod inspect args
+	fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{.Name}}|{{.State}}", podID)
 }
 
-func TestGetContainerInfo_ParsesOutput(t *testing.T) {
+func TestGetPodInfo_ParsesOutput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name          string
-		containerID   string
+		podID         string
 		output        string
 		expectedState api.WorkspaceState
-		expectedImage string
 	}{
 		{
-			name:          "running container",
-			containerID:   "abc123",
-			output:        "abc123def456|running|kdn-test\n",
+			name:          "running pod",
+			podID:         "kdn-test",
+			output:        "kdn-test|Running\n",
 			expectedState: api.WorkspaceStateRunning,
-			expectedImage: "kdn-test",
 		},
 		{
-			name:          "stopped container",
-			containerID:   "xyz789",
-			output:        "xyz789ghi012|exited|kdn-stopped\n",
+			name:          "stopped pod",
+			podID:         "kdn-stopped",
+			output:        "kdn-stopped|Stopped\n",
 			expectedState: api.WorkspaceStateStopped,
-			expectedImage: "kdn-stopped",
 		},
 		{
-			name:          "created container",
-			containerID:   "def456",
-			output:        "def456|created|kdn-new\n",
+			name:          "created pod",
+			podID:         "kdn-new",
+			output:        "kdn-new|Created\n",
 			expectedState: api.WorkspaceStateStopped,
-			expectedImage: "kdn-new",
+		},
+		{
+			name:          "exited pod",
+			podID:         "kdn-exited",
+			output:        "kdn-exited|Exited\n",
+			expectedState: api.WorkspaceStateStopped,
+		},
+		{
+			name:          "dead pod",
+			podID:         "kdn-dead",
+			output:        "kdn-dead|Dead\n",
+			expectedState: api.WorkspaceStateError,
+		},
+		{
+			name:          "degraded pod",
+			podID:         "kdn-degraded",
+			output:        "kdn-degraded|Degraded\n",
+			expectedState: api.WorkspaceStateError,
+		},
+		{
+			name:          "unknown pod state",
+			podID:         "kdn-weird",
+			output:        "kdn-weird|SomeFutureState\n",
+			expectedState: api.WorkspaceStateUnknown,
 		},
 	}
 
@@ -201,22 +224,22 @@ func TestGetContainerInfo_ParsesOutput(t *testing.T) {
 
 			p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-			info, err := p.getContainerInfo(context.Background(), tt.containerID)
+			info, err := p.getPodInfo(context.Background(), tt.podID)
 			if err != nil {
-				t.Fatalf("getContainerInfo() failed: %v", err)
+				t.Fatalf("getPodInfo() failed: %v", err)
 			}
 
 			if info.State != tt.expectedState {
 				t.Errorf("Expected state %s, got %s", tt.expectedState, info.State)
 			}
-			if info.Info["image_name"] != tt.expectedImage {
-				t.Errorf("Expected image_name %s, got %s", tt.expectedImage, info.Info["image_name"])
+			if info.Info["pod_name"] != tt.podID {
+				t.Errorf("Expected pod_name %s, got %s", tt.podID, info.Info["pod_name"])
 			}
 		})
 	}
 }
 
-func TestGetContainerInfo_MalformedOutput(t *testing.T) {
+func TestGetPodInfo_MalformedOutput(t *testing.T) {
 	t.Parallel()
 
 	fakeExec := exec.NewFake()
@@ -226,7 +249,7 @@ func TestGetContainerInfo_MalformedOutput(t *testing.T) {
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	_, err := p.getContainerInfo(context.Background(), "abc123")
+	_, err := p.getPodInfo(context.Background(), "kdn-test")
 	if err == nil {
 		t.Fatal("Expected error for malformed output, got nil")
 	}

--- a/pkg/runtime/podman/proxy.go
+++ b/pkg/runtime/podman/proxy.go
@@ -62,8 +62,10 @@ func generateProxyStartScript() string {
 set -e
 
 # Restrict outbound network in the shared pod network namespace.
-# Delete and recreate the filter table so rules are clean on every start
+# Delete and recreate the filter tables so rules are clean on every start
 # (the pod network namespace persists across stop/start, not just pod rm).
+
+# IPv4 rules
 nft delete table ip filter 2>/dev/null || true
 nft add table ip filter
 nft add chain ip filter output '{ type filter hook output priority 0; policy drop; }'
@@ -73,6 +75,14 @@ nft add rule ip filter output ct state established,related accept
 nft add rule ip filter output oif lo accept
 # Squid's own outbound traffic must reach the internet.
 nft add rule ip filter output meta skuid squid accept
+
+# IPv6 rules (mirror of IPv4 to block direct outbound IPv6 from the workspace).
+nft delete table ip6 filter 2>/dev/null || true
+nft add table ip6 filter
+nft add chain ip6 filter output '{ type filter hook output priority 0; policy drop; }'
+nft add rule ip6 filter output ct state established,related accept
+nft add rule ip6 filter output oif lo accept
+nft add rule ip6 filter output meta skuid squid accept
 
 # Remove a stale PID file if present (left by a previous run after pod stop/start).
 rm -f /run/squid.pid

--- a/pkg/runtime/podman/proxy.go
+++ b/pkg/runtime/podman/proxy.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime/podman/constants"
+)
+
+// proxyImageName returns the proxy image name for a given pod name.
+func proxyImageName(podN string) string {
+	return fmt.Sprintf("%s-proxy", podN)
+}
+
+// proxyContainerName returns the proxy container name for a given pod name.
+func proxyContainerName(podN string) string {
+	return fmt.Sprintf("%s-proxy", podN)
+}
+
+// generateProxyContainerfile generates the Containerfile content for the proxy sidecar image.
+// The proxy runs as root so that nftables setup works; Squid drops privileges to the squid user.
+func generateProxyContainerfile(version string) string {
+	return fmt.Sprintf(`FROM %s:%s
+
+RUN dnf install -y squid nftables
+
+RUN printf 'http_port 3128\nacl all src all\nhttp_access allow all\ncoredump_dir /var/spool/squid\n' \
+    > /etc/squid/squid.conf
+
+COPY proxy-start.sh /usr/local/bin/proxy-start.sh
+RUN chmod +x /usr/local/bin/proxy-start.sh
+
+CMD ["/usr/local/bin/proxy-start.sh"]
+`, constants.BaseImageRegistry, version)
+}
+
+// generateProxyStartScript returns the content of the proxy startup script.
+// The script sets nftables OUTPUT chain rules in the shared pod network namespace,
+// then starts Squid. The chain policy is drop, so only explicitly accepted traffic passes.
+//
+// The table is deleted before recreation so the script is idempotent across pod
+// stop/start cycles: Podman preserves the pod network namespace (and any nftables
+// rules in it) between stop and start, only destroying it on pod removal.
+func generateProxyStartScript() string {
+	return `#!/bin/bash
+set -e
+
+# Restrict outbound network in the shared pod network namespace.
+# Delete and recreate the filter table so rules are clean on every start
+# (the pod network namespace persists across stop/start, not just pod rm).
+nft delete table ip filter 2>/dev/null || true
+nft add table ip filter
+nft add chain ip filter output '{ type filter hook output priority 0; policy drop; }'
+# ESTABLISHED/RELATED allows return packets for squid's own connections.
+nft add rule ip filter output ct state established,related accept
+# Localhost is always allowed (workspace container -> squid on :3128).
+nft add rule ip filter output oif lo accept
+# Squid's own outbound traffic must reach the internet.
+nft add rule ip filter output meta skuid squid accept
+
+# Remove a stale PID file if present (left by a previous run after pod stop/start).
+rm -f /run/squid.pid
+
+exec squid -N -f /etc/squid/squid.conf
+`
+}
+
+// buildProxyContainerArgs builds the podman create arguments for the proxy sidecar container.
+// CAP_NET_ADMIN is required for nft to configure the shared pod network namespace.
+func buildProxyContainerArgs(podN, proxyContainer, proxyImage string) []string {
+	return []string{
+		"create",
+		"--pod", podN,
+		"--name", proxyContainer,
+		"--cap-add", "NET_ADMIN",
+		proxyImage,
+	}
+}
+
+// buildProxyImage builds the proxy sidecar container image.
+// Unlike the workspace image, the proxy image does not need UID/GID build args.
+func (p *podmanRuntime) buildProxyImage(ctx context.Context, imageName, instanceDir string) error {
+	containerfilePath := filepath.Join(instanceDir, "Containerfile.proxy")
+
+	l := logger.FromContext(ctx)
+	args := []string{
+		"build",
+		"-t", imageName,
+		"-f", containerfilePath,
+		instanceDir,
+	}
+
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), args...); err != nil {
+		return fmt.Errorf("failed to build proxy image: %w", err)
+	}
+	return nil
+}

--- a/pkg/runtime/podman/proxy_test.go
+++ b/pkg/runtime/podman/proxy_test.go
@@ -84,13 +84,29 @@ func TestGenerateProxyStartScript(t *testing.T) {
 		}
 	})
 
-	t.Run("is idempotent - deletes table before recreating", func(t *testing.T) {
+	t.Run("is idempotent - deletes tables before recreating", func(t *testing.T) {
 		t.Parallel()
 
 		script := generateProxyStartScript()
 
 		if !strings.Contains(script, "nft delete table ip filter") {
-			t.Error("Expected proxy start script to delete existing filter table for idempotency")
+			t.Error("Expected proxy start script to delete existing ip filter table for idempotency")
+		}
+		if !strings.Contains(script, "nft delete table ip6 filter") {
+			t.Error("Expected proxy start script to delete existing ip6 filter table for idempotency")
+		}
+	})
+
+	t.Run("covers IPv6 traffic", func(t *testing.T) {
+		t.Parallel()
+
+		script := generateProxyStartScript()
+
+		if !strings.Contains(script, "nft add table ip6 filter") {
+			t.Error("Expected proxy start script to create ip6 filter table")
+		}
+		if !strings.Contains(script, "nft add chain ip6 filter output") {
+			t.Error("Expected proxy start script to create ip6 output chain")
 		}
 	})
 

--- a/pkg/runtime/podman/proxy_test.go
+++ b/pkg/runtime/podman/proxy_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateProxyContainerfile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("includes squid and nftables installation", func(t *testing.T) {
+		t.Parallel()
+
+		content := generateProxyContainerfile("42")
+
+		if !strings.Contains(content, "FROM registry.fedoraproject.org/fedora:42") {
+			t.Error("Expected proxy Containerfile to use fedora:42 base image")
+		}
+		if !strings.Contains(content, "squid") {
+			t.Error("Expected proxy Containerfile to install squid")
+		}
+		if !strings.Contains(content, "nftables") {
+			t.Error("Expected proxy Containerfile to install nftables")
+		}
+		if !strings.Contains(content, "proxy-start.sh") {
+			t.Error("Expected proxy Containerfile to reference proxy-start.sh")
+		}
+		if !strings.Contains(content, "/usr/local/bin/proxy-start.sh") {
+			t.Error("Expected proxy Containerfile to install proxy-start.sh to /usr/local/bin")
+		}
+	})
+
+	t.Run("uses provided version", func(t *testing.T) {
+		t.Parallel()
+
+		content := generateProxyContainerfile("latest")
+		if !strings.Contains(content, "fedora:latest") {
+			t.Errorf("Expected proxy Containerfile to use version 'latest', got:\n%s", content)
+		}
+
+		content2 := generateProxyContainerfile("40")
+		if !strings.Contains(content2, "fedora:40") {
+			t.Errorf("Expected proxy Containerfile to use version '40', got:\n%s", content2)
+		}
+	})
+}
+
+func TestGenerateProxyStartScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("contains nftables setup", func(t *testing.T) {
+		t.Parallel()
+
+		script := generateProxyStartScript()
+
+		if !strings.Contains(script, "nft") {
+			t.Error("Expected proxy start script to contain nft commands")
+		}
+		if !strings.Contains(script, "policy drop") {
+			t.Error("Expected proxy start script to set drop policy")
+		}
+		if !strings.Contains(script, "established,related") {
+			t.Error("Expected proxy start script to allow established/related traffic")
+		}
+		if !strings.Contains(script, "oif lo") {
+			t.Error("Expected proxy start script to allow loopback traffic")
+		}
+		if !strings.Contains(script, "skuid squid") {
+			t.Error("Expected proxy start script to allow squid user outbound traffic")
+		}
+	})
+
+	t.Run("is idempotent - deletes table before recreating", func(t *testing.T) {
+		t.Parallel()
+
+		script := generateProxyStartScript()
+
+		if !strings.Contains(script, "nft delete table ip filter") {
+			t.Error("Expected proxy start script to delete existing filter table for idempotency")
+		}
+	})
+
+	t.Run("cleans up stale PID file before starting squid", func(t *testing.T) {
+		t.Parallel()
+
+		script := generateProxyStartScript()
+
+		if !strings.Contains(script, "rm -f /run/squid.pid") {
+			t.Error("Expected proxy start script to remove stale PID file before starting squid")
+		}
+	})
+
+	t.Run("starts squid in foreground", func(t *testing.T) {
+		t.Parallel()
+
+		script := generateProxyStartScript()
+
+		if !strings.Contains(script, "exec squid -N") {
+			t.Error("Expected proxy start script to start squid in foreground with -N flag")
+		}
+	})
+}
+
+func TestBuildProxyContainerArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces correct args with CAP_NET_ADMIN", func(t *testing.T) {
+		t.Parallel()
+
+		args := buildProxyContainerArgs("kdn-myws", "kdn-myws-proxy", "kdn-myws-proxy")
+
+		argsStr := strings.Join(args, " ")
+
+		if !strings.Contains(argsStr, "create") {
+			t.Error("Expected 'create' subcommand")
+		}
+		if !strings.Contains(argsStr, "--pod kdn-myws") {
+			t.Error("Expected --pod flag with pod name")
+		}
+		if !strings.Contains(argsStr, "--name kdn-myws-proxy") {
+			t.Error("Expected --name flag with proxy container name")
+		}
+		if !strings.Contains(argsStr, "--cap-add NET_ADMIN") {
+			t.Error("Expected --cap-add NET_ADMIN for nftables support")
+		}
+		if !strings.Contains(argsStr, "kdn-myws-proxy") {
+			t.Error("Expected proxy image name")
+		}
+	})
+
+	t.Run("does not include sleep infinity", func(t *testing.T) {
+		t.Parallel()
+
+		args := buildProxyContainerArgs("kdn-myws", "kdn-myws-proxy", "kdn-myws-proxy")
+		argsStr := strings.Join(args, " ")
+
+		if strings.Contains(argsStr, "sleep") {
+			t.Error("Proxy container should use its own CMD, not sleep infinity")
+		}
+	})
+}

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -78,12 +78,13 @@ func isNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-	errMsg := err.Error()
-	// Check for podman-specific "not found" error messages
+	errMsg := strings.ToLower(err.Error())
+	// Check for podman-specific "not found" error messages.
+	// Only match concrete not-found variants; do not match generic inspect failures
+	// so that permission or runtime errors are not silently swallowed.
 	return strings.Contains(errMsg, "no such container") ||
 		strings.Contains(errMsg, "no such pod") ||
 		strings.Contains(errMsg, "pod not found") ||
 		strings.Contains(errMsg, "no such object") ||
-		strings.Contains(errMsg, "error getting container") ||
-		strings.Contains(errMsg, "failed to inspect pod")
+		strings.Contains(errMsg, "error getting container")
 }

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -56,7 +56,7 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 
 	// Remove the pod
 	stepLogger.Start(fmt.Sprintf("Removing pod: %s", id), "Pod removed")
-	if err := p.removeContainer(ctx, id); err != nil {
+	if err := p.removePod(ctx, id); err != nil {
 		stepLogger.Fail(err)
 		return err
 	}
@@ -64,8 +64,8 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	return nil
 }
 
-// removeContainer removes a podman pod by ID.
-func (p *podmanRuntime) removeContainer(ctx context.Context, id string) error {
+// removePod removes a podman pod by ID.
+func (p *podmanRuntime) removePod(ctx context.Context, id string) error {
 	l := logger.FromContext(ctx)
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "rm", id); err != nil {
 		return fmt.Errorf("failed to remove pod: %w", err)

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -25,21 +25,21 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-// Remove removes a Podman container and its associated resources.
+// Remove removes a Podman pod and its associated resources.
 func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
 
 	// Validate the ID parameter
 	if id == "" {
-		return fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
+		return fmt.Errorf("%w: pod ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Check if the container exists and get its state
-	stepLogger.Start("Checking container state", "Container state checked")
-	info, err := p.getContainerInfo(ctx, id)
+	// Check if the pod exists and get its state
+	stepLogger.Start("Checking pod state", "Pod state checked")
+	info, err := p.getPodInfo(ctx, id)
 	if err != nil {
-		// If the container doesn't exist, treat it as already removed (idempotent)
+		// If the pod doesn't exist, treat it as already removed (idempotent)
 		if isNotFoundError(err) {
 			return nil
 		}
@@ -47,15 +47,15 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Check if the container is running
+	// Check if the pod is running
 	if info.State == api.WorkspaceStateRunning {
-		err := fmt.Errorf("container %s is still running, stop it first", id)
+		err := fmt.Errorf("pod %s is still running, stop it first", id)
 		stepLogger.Fail(err)
 		return err
 	}
 
-	// Remove the container
-	stepLogger.Start(fmt.Sprintf("Removing container: %s", id), "Container removed")
+	// Remove the pod
+	stepLogger.Start(fmt.Sprintf("Removing pod: %s", id), "Pod removed")
 	if err := p.removeContainer(ctx, id); err != nil {
 		stepLogger.Fail(err)
 		return err
@@ -64,16 +64,16 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	return nil
 }
 
-// removeContainer removes a podman container by ID.
+// removeContainer removes a podman pod by ID.
 func (p *podmanRuntime) removeContainer(ctx context.Context, id string) error {
 	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "rm", id); err != nil {
-		return fmt.Errorf("failed to remove podman container: %w", err)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "rm", id); err != nil {
+		return fmt.Errorf("failed to remove pod: %w", err)
 	}
 	return nil
 }
 
-// isNotFoundError checks if an error indicates that a container was not found.
+// isNotFoundError checks if an error indicates that a pod or container was not found.
 func isNotFoundError(err error) bool {
 	if err == nil {
 		return false
@@ -81,7 +81,9 @@ func isNotFoundError(err error) bool {
 	errMsg := err.Error()
 	// Check for podman-specific "not found" error messages
 	return strings.Contains(errMsg, "no such container") ||
+		strings.Contains(errMsg, "no such pod") ||
+		strings.Contains(errMsg, "pod not found") ||
 		strings.Contains(errMsg, "no such object") ||
 		strings.Contains(errMsg, "error getting container") ||
-		strings.Contains(errMsg, "failed to inspect container")
+		strings.Contains(errMsg, "failed to inspect pod")
 }

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -220,7 +220,7 @@ func TestIsNotFoundError(t *testing.T) {
 		{
 			name:     "failed to inspect pod with other error",
 			err:      fmt.Errorf("failed to inspect pod: permission denied"),
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "other error",

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -47,44 +47,43 @@ func TestRemove_ValidatesID(t *testing.T) {
 func TestRemove_Success(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123def456"
+	podID := "kdn-test-workspace"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info showing stopped state
+	// Set up OutputFunc to return pod info showing stopped state
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		if len(args) >= 1 && args[0] == "inspect" {
-			// Return a stopped container
-			return []byte(fmt.Sprintf("%s|stopped|kdn-test", containerID)), nil
+		if len(args) >= 2 && args[0] == "pod" && args[1] == "inspect" {
+			return []byte(fmt.Sprintf("%s|Stopped", podID)), nil
 		}
 		return nil, fmt.Errorf("unexpected command: %v", args)
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	err := p.Remove(context.Background(), containerID)
+	err := p.Remove(context.Background(), podID)
 	if err != nil {
 		t.Fatalf("Remove() failed: %v", err)
 	}
 
-	// Verify Output was called to inspect the container
+	// Verify Output was called to inspect the pod
 	if len(fakeExec.OutputCalls) == 0 {
-		t.Error("Expected Output to be called to inspect container")
+		t.Error("Expected Output to be called to inspect pod")
 	}
 
-	// Verify Run was called to remove the container
-	fakeExec.AssertRunCalledWith(t, "rm", containerID)
+	// Verify Run was called to remove the pod
+	fakeExec.AssertRunCalledWith(t, "pod", "rm", podID)
 }
 
-func TestRemove_IdempotentWhenContainerNotFound(t *testing.T) {
+func TestRemove_IdempotentWhenPodNotFound(t *testing.T) {
 	t.Parallel()
 
-	containerID := "nonexistent"
+	podID := "kdn-nonexistent"
 	fakeExec := exec.NewFake()
 
 	// Set up OutputFunc to return a "not found" error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		if len(args) >= 1 && args[0] == "inspect" {
-			return nil, fmt.Errorf("failed to inspect container: no such container")
+		if len(args) >= 2 && args[0] == "pod" && args[1] == "inspect" {
+			return nil, fmt.Errorf("failed to inspect pod: no such pod")
 		}
 		return nil, fmt.Errorf("unexpected command: %v", args)
 	}
@@ -92,42 +91,41 @@ func TestRemove_IdempotentWhenContainerNotFound(t *testing.T) {
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
 	// Should succeed without error (idempotent)
-	err := p.Remove(context.Background(), containerID)
+	err := p.Remove(context.Background(), podID)
 	if err != nil {
-		t.Fatalf("Remove() should be idempotent for non-existent containers, got error: %v", err)
+		t.Fatalf("Remove() should be idempotent for non-existent pods, got error: %v", err)
 	}
 
-	// Verify Output was called to check if container exists
+	// Verify Output was called to check if pod exists
 	if len(fakeExec.OutputCalls) == 0 {
-		t.Error("Expected Output to be called to check if container exists")
+		t.Error("Expected Output to be called to check if pod exists")
 	}
 
-	// Run should NOT be called since container doesn't exist
+	// Run should NOT be called since pod doesn't exist
 	if len(fakeExec.RunCalls) > 0 {
-		t.Error("Run should not be called for non-existent container")
+		t.Error("Run should not be called for non-existent pod")
 	}
 }
 
-func TestRemove_RejectsRunningContainer(t *testing.T) {
+func TestRemove_RejectsRunningPod(t *testing.T) {
 	t.Parallel()
 
-	containerID := "running123"
+	podID := "kdn-running"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info showing running state
+	// Set up OutputFunc to return pod info showing running state
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		if len(args) >= 1 && args[0] == "inspect" {
-			// Return a running container
-			return []byte(fmt.Sprintf("%s|running|kdn-test", containerID)), nil
+		if len(args) >= 2 && args[0] == "pod" && args[1] == "inspect" {
+			return []byte(fmt.Sprintf("%s|Running", podID)), nil
 		}
 		return nil, fmt.Errorf("unexpected command: %v", args)
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	err := p.Remove(context.Background(), containerID)
+	err := p.Remove(context.Background(), podID)
 	if err == nil {
-		t.Fatal("Expected error when removing running container, got nil")
+		t.Fatal("Expected error when removing running pod, got nil")
 	}
 
 	expectedMsg := "is still running, stop it first"
@@ -135,27 +133,27 @@ func TestRemove_RejectsRunningContainer(t *testing.T) {
 		t.Errorf("Expected error message to contain %q, got: %v", expectedMsg, err)
 	}
 
-	// Verify Output was called to check container state
+	// Verify Output was called to check pod state
 	if len(fakeExec.OutputCalls) == 0 {
-		t.Error("Expected Output to be called to check container state")
+		t.Error("Expected Output to be called to check pod state")
 	}
 
-	// Run should NOT be called since container is running
+	// Run should NOT be called since pod is running
 	if len(fakeExec.RunCalls) > 0 {
-		t.Error("Run should not be called for running container")
+		t.Error("Run should not be called for running pod")
 	}
 }
 
-func TestRemove_RemoveContainerFailure(t *testing.T) {
+func TestRemove_RemovePodFailure(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info showing stopped state
+	// Set up OutputFunc to return pod info showing stopped state
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		if len(args) >= 1 && args[0] == "inspect" {
-			return []byte(fmt.Sprintf("%s|stopped|kdn-test", containerID)), nil
+		if len(args) >= 2 && args[0] == "pod" && args[1] == "inspect" {
+			return []byte(fmt.Sprintf("%s|Stopped", podID)), nil
 		}
 		return nil, fmt.Errorf("unexpected command: %v", args)
 	}
@@ -167,13 +165,13 @@ func TestRemove_RemoveContainerFailure(t *testing.T) {
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	err := p.Remove(context.Background(), containerID)
+	err := p.Remove(context.Background(), podID)
 	if err == nil {
 		t.Fatal("Expected error when remove fails, got nil")
 	}
 
-	// Verify Run was called
-	fakeExec.AssertRunCalledWith(t, "rm", containerID)
+	// Verify Run was called with pod rm
+	fakeExec.AssertRunCalledWith(t, "pod", "rm", podID)
 }
 
 func TestIsNotFoundError(t *testing.T) {
@@ -195,6 +193,16 @@ func TestIsNotFoundError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "no such pod error",
+			err:      fmt.Errorf("Error: no such pod abc123"),
+			expected: true,
+		},
+		{
+			name:     "pod not found error",
+			err:      fmt.Errorf("pod not found: abc123"),
+			expected: true,
+		},
+		{
 			name:     "no such object error",
 			err:      fmt.Errorf("Error: no such object: abc123"),
 			expected: true,
@@ -205,13 +213,13 @@ func TestIsNotFoundError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "failed to inspect container with not found",
-			err:      fmt.Errorf("failed to inspect container: no such container"),
+			name:     "failed to inspect pod with not found",
+			err:      fmt.Errorf("failed to inspect pod: no such pod"),
 			expected: true,
 		},
 		{
-			name:     "failed to inspect container with other error",
-			err:      fmt.Errorf("failed to inspect container: permission denied"),
+			name:     "failed to inspect pod with other error",
+			err:      fmt.Errorf("failed to inspect pod: permission denied"),
 			expected: true,
 		},
 		{
@@ -250,12 +258,12 @@ func stringContains(s, substr string) bool {
 func TestRemove_StepLogger_Success(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123def456"
+	podID := "kdn-test-workspace"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return stopped container info
+	// Set up OutputFunc to return stopped pod info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		output := fmt.Sprintf("%s|exited|kdn-test\n", containerID)
+		output := fmt.Sprintf("%s|Exited\n", podID)
 		return []byte(output), nil
 	}
 
@@ -264,7 +272,7 @@ func TestRemove_StepLogger_Success(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Remove(ctx, containerID)
+	err := p.Remove(ctx, podID)
 	if err != nil {
 		t.Fatalf("Remove() failed: %v", err)
 	}
@@ -282,12 +290,12 @@ func TestRemove_StepLogger_Success(t *testing.T) {
 	// Verify Start was called 2 times with correct messages
 	expectedSteps := []stepCall{
 		{
-			inProgress: "Checking container state",
-			completed:  "Container state checked",
+			inProgress: "Checking pod state",
+			completed:  "Pod state checked",
 		},
 		{
-			inProgress: "Removing container: abc123def456",
-			completed:  "Container removed",
+			inProgress: "Removing pod: kdn-test-workspace",
+			completed:  "Pod removed",
 		},
 	}
 
@@ -306,15 +314,15 @@ func TestRemove_StepLogger_Success(t *testing.T) {
 	}
 }
 
-func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
+func TestRemove_StepLogger_PodNotFound(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up OutputFunc to return a "not found" error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		return nil, fmt.Errorf("no such container: %s", containerID)
+		return nil, fmt.Errorf("no such pod: %s", podID)
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -322,7 +330,7 @@ func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Remove(ctx, containerID)
+	err := p.Remove(ctx, podID)
 	if err != nil {
 		t.Fatalf("Remove() should be idempotent for not found, got error: %v", err)
 	}
@@ -332,13 +340,13 @@ func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (checking container state)
+	// Verify Start was called once (checking pod state)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Checking container state" {
-		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != "Checking pod state" {
+		t.Errorf("Expected first step to be 'Checking pod state', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
 	// Verify no Fail calls (idempotent operation)
@@ -347,16 +355,16 @@ func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
 	}
 }
 
-func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
+func TestRemove_StepLogger_FailOnGetPodInfo(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up OutputFunc to return malformed output (not an error that matches isNotFoundError)
-	// This will cause getContainerInfo to fail with a parsing error
+	// This will cause getPodInfo to fail with a parsing error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		return []byte("invalid|output"), nil
+		return []byte("invalid|output|extra"), nil
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -364,7 +372,7 @@ func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Remove(ctx, containerID)
+	err := p.Remove(ctx, podID)
 	if err == nil {
 		t.Fatal("Expected Remove() to fail, got nil")
 	}
@@ -374,13 +382,13 @@ func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (checking container state)
+	// Verify Start was called once (checking pod state)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Checking container state" {
-		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != "Checking pod state" {
+		t.Errorf("Expected first step to be 'Checking pod state', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
 	// Verify Fail was called once
@@ -393,15 +401,15 @@ func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 	}
 }
 
-func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
+func TestRemove_StepLogger_FailOnRunningPod(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return a running container
+	// Set up OutputFunc to return a running pod
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		output := fmt.Sprintf("%s|Running\n", podID)
 		return []byte(output), nil
 	}
 
@@ -410,9 +418,9 @@ func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Remove(ctx, containerID)
+	err := p.Remove(ctx, podID)
 	if err == nil {
-		t.Fatal("Expected Remove() to fail for running container, got nil")
+		t.Fatal("Expected Remove() to fail for running pod, got nil")
 	}
 
 	// Verify Complete was called once (deferred call)
@@ -420,13 +428,13 @@ func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (checking container state)
+	// Verify Start was called once (checking pod state)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Checking container state" {
-		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != "Checking pod state" {
+		t.Errorf("Expected first step to be 'Checking pod state', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
 	// Verify Fail was called once
@@ -439,22 +447,22 @@ func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
 	}
 }
 
-func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
+func TestRemove_StepLogger_FailOnRemovePod(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return stopped container info
+	// Set up OutputFunc to return stopped pod info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		output := fmt.Sprintf("%s|exited|kdn-test\n", containerID)
+		output := fmt.Sprintf("%s|Exited\n", podID)
 		return []byte(output), nil
 	}
 
 	// Set up RunFunc to fail on remove
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		if len(args) > 0 && args[0] == "rm" {
-			return fmt.Errorf("failed to remove container")
+		if len(args) >= 2 && args[0] == "pod" && args[1] == "rm" {
+			return fmt.Errorf("failed to remove pod")
 		}
 		return nil
 	}
@@ -464,7 +472,7 @@ func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Remove(ctx, containerID)
+	err := p.Remove(ctx, podID)
 	if err == nil {
 		t.Fatal("Expected Remove() to fail, got nil")
 	}
@@ -474,14 +482,14 @@ func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called twice (checking state, removing container)
+	// Verify Start was called twice (checking state, removing pod)
 	if len(fakeLogger.startCalls) != 2 {
 		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
-		"Checking container state",
-		"Removing container: abc123",
+		"Checking pod state",
+		"Removing pod: kdn-test",
 	}
 
 	for i, expected := range expectedSteps {

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -35,7 +35,7 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 
 	// Start the pod
 	stepLogger.Start(fmt.Sprintf("Starting pod: %s", id), "Pod started")
-	if err := p.startContainer(ctx, id); err != nil {
+	if err := p.startPod(ctx, id); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
@@ -51,8 +51,8 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	return info, nil
 }
 
-// startContainer starts a podman pod by ID.
-func (p *podmanRuntime) startContainer(ctx context.Context, id string) error {
+// startPod starts a podman pod by ID.
+func (p *podmanRuntime) startPod(ctx context.Context, id string) error {
 	l := logger.FromContext(ctx)
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "start", id); err != nil {
 		return fmt.Errorf("failed to start pod: %w", err)

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -23,39 +23,39 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-// Start starts a previously created Podman container.
+// Start starts a previously created Podman pod.
 func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
 
 	// Validate the ID parameter
 	if id == "" {
-		return runtime.RuntimeInfo{}, fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
+		return runtime.RuntimeInfo{}, fmt.Errorf("%w: pod ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Start the container
-	stepLogger.Start(fmt.Sprintf("Starting container: %s", id), "Container started")
+	// Start the pod
+	stepLogger.Start(fmt.Sprintf("Starting pod: %s", id), "Pod started")
 	if err := p.startContainer(ctx, id); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
 
-	// Get updated container information
-	stepLogger.Start("Verifying container status", "Container status verified")
-	info, err := p.getContainerInfo(ctx, id)
+	// Get updated pod information
+	stepLogger.Start("Verifying pod status", "Pod status verified")
+	info, err := p.getPodInfo(ctx, id)
 	if err != nil {
 		stepLogger.Fail(err)
-		return runtime.RuntimeInfo{}, fmt.Errorf("failed to get container info after start: %w", err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to get pod info after start: %w", err)
 	}
 
 	return info, nil
 }
 
-// startContainer starts a podman container by ID.
+// startContainer starts a podman pod by ID.
 func (p *podmanRuntime) startContainer(ctx context.Context, id string) error {
 	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", id); err != nil {
-		return fmt.Errorf("failed to start podman container: %w", err)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "start", id); err != nil {
+		return fmt.Errorf("failed to start pod: %w", err)
 	}
 	return nil
 }

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -47,70 +47,67 @@ func TestStart_ValidatesID(t *testing.T) {
 func TestStart_Success(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123def456"
+	podID := "kdn-test-workspace"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info
+	// Set up OutputFunc to return pod info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		// Simulate podman inspect output
-		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		// Simulate podman pod inspect output
+		output := fmt.Sprintf("%s|Running\n", podID)
 		return []byte(output), nil
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	info, err := p.Start(context.Background(), containerID)
+	info, err := p.Start(context.Background(), podID)
 	if err != nil {
 		t.Fatalf("Start() failed: %v", err)
 	}
 
-	// Verify Run was called to start the container
-	fakeExec.AssertRunCalledWith(t, "start", containerID)
+	// Verify Run was called to start the pod
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podID)
 
-	// Verify Output was called to inspect the container
-	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
+	// Verify Output was called to inspect the pod
+	fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{.Name}}|{{.State}}", podID)
 
 	// Verify returned info
-	if info.ID != containerID {
-		t.Errorf("Expected ID %s, got %s", containerID, info.ID)
+	if info.ID != podID {
+		t.Errorf("Expected ID %s, got %s", podID, info.ID)
 	}
 	if info.State != "running" {
 		t.Errorf("Expected state 'running', got %s", info.State)
 	}
-	if info.Info["container_id"] != containerID {
-		t.Errorf("Expected container_id %s, got %s", containerID, info.Info["container_id"])
-	}
-	if info.Info["image_name"] != "kdn-test" {
-		t.Errorf("Expected image_name 'kdn-test', got %s", info.Info["image_name"])
+	if info.Info["pod_name"] != podID {
+		t.Errorf("Expected pod_name %s, got %s", podID, info.Info["pod_name"])
 	}
 }
 
-func TestStart_StartContainerFailure(t *testing.T) {
+func TestStart_StartPodFailure(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	_, err := p.Start(context.Background(), containerID)
+	_, err := p.Start(context.Background(), podID)
 	if err == nil {
 		t.Fatal("Expected error when start fails, got nil")
 	}
 
-	// Verify Run was called
-	fakeExec.AssertRunCalledWith(t, "start", containerID)
+	// Verify Run was called with pod start
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podID)
 }
 
 func TestStart_InspectFailure(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up OutputFunc to return an error
@@ -120,25 +117,25 @@ func TestStart_InspectFailure(t *testing.T) {
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	_, err := p.Start(context.Background(), containerID)
+	_, err := p.Start(context.Background(), podID)
 	if err == nil {
 		t.Fatal("Expected error when inspect fails, got nil")
 	}
 
 	// Verify both Run and Output were called
-	fakeExec.AssertRunCalledWith(t, "start", containerID)
-	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podID)
+	fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{.Name}}|{{.State}}", podID)
 }
 
 func TestStart_StepLogger_Success(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123def456"
+	podID := "kdn-test-workspace"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info
+	// Set up OutputFunc to return pod info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		output := fmt.Sprintf("%s|Running\n", podID)
 		return []byte(output), nil
 	}
 
@@ -147,7 +144,7 @@ func TestStart_StepLogger_Success(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	_, err := p.Start(ctx, containerID)
+	_, err := p.Start(ctx, podID)
 	if err != nil {
 		t.Fatalf("Start() failed: %v", err)
 	}
@@ -165,12 +162,12 @@ func TestStart_StepLogger_Success(t *testing.T) {
 	// Verify Start was called 2 times with correct messages
 	expectedSteps := []stepCall{
 		{
-			inProgress: "Starting container: abc123def456",
-			completed:  "Container started",
+			inProgress: "Starting pod: kdn-test-workspace",
+			completed:  "Pod started",
 		},
 		{
-			inProgress: "Verifying container status",
-			completed:  "Container status verified",
+			inProgress: "Verifying pod status",
+			completed:  "Pod status verified",
 		},
 	}
 
@@ -189,15 +186,15 @@ func TestStart_StepLogger_Success(t *testing.T) {
 	}
 }
 
-func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
+func TestStart_StepLogger_FailOnStartPod(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -205,7 +202,7 @@ func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	_, err := p.Start(ctx, containerID)
+	_, err := p.Start(ctx, podID)
 	if err == nil {
 		t.Fatal("Expected Start() to fail, got nil")
 	}
@@ -215,13 +212,13 @@ func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (start container step)
+	// Verify Start was called once (start pod step)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Starting container: abc123" {
-		t.Errorf("Expected first step to be 'Starting container: abc123', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != "Starting pod: kdn-test" {
+		t.Errorf("Expected first step to be 'Starting pod: kdn-test', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
 	// Verify Fail was called once
@@ -234,10 +231,10 @@ func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
 	}
 }
 
-func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
+func TestStart_StepLogger_FailOnGetPodInfo(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up RunFunc to succeed, but OutputFunc to fail
@@ -245,7 +242,7 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		return nil
 	}
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		return nil, fmt.Errorf("failed to inspect container")
+		return nil, fmt.Errorf("failed to inspect pod")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -253,7 +250,7 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	_, err := p.Start(ctx, containerID)
+	_, err := p.Start(ctx, podID)
 	if err == nil {
 		t.Fatal("Expected Start() to fail, got nil")
 	}
@@ -263,14 +260,14 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called twice (start container, verify status)
+	// Verify Start was called twice (start pod, verify status)
 	if len(fakeLogger.startCalls) != 2 {
 		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
-		"Starting container: abc123",
-		"Verifying container status",
+		"Starting pod: kdn-test",
+		"Verifying pod status",
 	}
 
 	for i, expected := range expectedSteps {

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -35,7 +35,7 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 
 	// Stop the pod
 	logger.Start(fmt.Sprintf("Stopping pod: %s", id), "Pod stopped")
-	if err := p.stopContainer(ctx, id); err != nil {
+	if err := p.stopPod(ctx, id); err != nil {
 		logger.Fail(err)
 		return err
 	}
@@ -43,8 +43,8 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 	return nil
 }
 
-// stopContainer stops a podman pod by ID.
-func (p *podmanRuntime) stopContainer(ctx context.Context, id string) error {
+// stopPod stops a podman pod by ID.
+func (p *podmanRuntime) stopPod(ctx context.Context, id string) error {
 	l := logger.FromContext(ctx)
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "stop", id); err != nil {
 		return fmt.Errorf("failed to stop pod: %w", err)

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -23,18 +23,18 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-// Stop stops a Podman container.
+// Stop stops a Podman pod.
 func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 	logger := steplogger.FromContext(ctx)
 	defer logger.Complete()
 
 	// Validate the ID parameter
 	if id == "" {
-		return fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
+		return fmt.Errorf("%w: pod ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Stop the container
-	logger.Start(fmt.Sprintf("Stopping container: %s", id), "Container stopped")
+	// Stop the pod
+	logger.Start(fmt.Sprintf("Stopping pod: %s", id), "Pod stopped")
 	if err := p.stopContainer(ctx, id); err != nil {
 		logger.Fail(err)
 		return err
@@ -43,11 +43,11 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 	return nil
 }
 
-// stopContainer stops a podman container by ID.
+// stopContainer stops a podman pod by ID.
 func (p *podmanRuntime) stopContainer(ctx context.Context, id string) error {
 	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "stop", id); err != nil {
-		return fmt.Errorf("failed to stop podman container: %w", err)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "stop", id); err != nil {
+		return fmt.Errorf("failed to stop pod: %w", err)
 	}
 	return nil
 }

--- a/pkg/runtime/podman/stop_test.go
+++ b/pkg/runtime/podman/stop_test.go
@@ -47,46 +47,46 @@ func TestStop_ValidatesID(t *testing.T) {
 func TestStop_Success(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123def456"
+	podID := "kdn-test-workspace"
 	fakeExec := exec.NewFake()
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	err := p.Stop(context.Background(), containerID)
+	err := p.Stop(context.Background(), podID)
 	if err != nil {
 		t.Fatalf("Stop() failed: %v", err)
 	}
 
-	// Verify Run was called to stop the container
-	fakeExec.AssertRunCalledWith(t, "stop", containerID)
+	// Verify Run was called to stop the pod
+	fakeExec.AssertRunCalledWith(t, "pod", "stop", podID)
 }
 
-func TestStop_StopContainerFailure(t *testing.T) {
+func TestStop_StopPodFailure(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	err := p.Stop(context.Background(), containerID)
+	err := p.Stop(context.Background(), podID)
 	if err == nil {
 		t.Fatal("Expected error when stop fails, got nil")
 	}
 
-	// Verify Run was called
-	fakeExec.AssertRunCalledWith(t, "stop", containerID)
+	// Verify Run was called with pod stop
+	fakeExec.AssertRunCalledWith(t, "pod", "stop", podID)
 }
 
 func TestStop_StepLogger_Success(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123def456"
+	podID := "kdn-test-workspace"
 	fakeExec := exec.NewFake()
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -94,7 +94,7 @@ func TestStop_StepLogger_Success(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Stop(ctx, containerID)
+	err := p.Stop(ctx, podID)
 	if err != nil {
 		t.Fatalf("Stop() failed: %v", err)
 	}
@@ -112,8 +112,8 @@ func TestStop_StepLogger_Success(t *testing.T) {
 	// Verify Start was called once with correct messages
 	expectedSteps := []stepCall{
 		{
-			inProgress: "Stopping container: abc123def456",
-			completed:  "Container stopped",
+			inProgress: "Stopping pod: kdn-test-workspace",
+			completed:  "Pod stopped",
 		},
 	}
 
@@ -132,15 +132,15 @@ func TestStop_StepLogger_Success(t *testing.T) {
 	}
 }
 
-func TestStop_StepLogger_FailOnStopContainer(t *testing.T) {
+func TestStop_StepLogger_FailOnStopPod(t *testing.T) {
 	t.Parallel()
 
-	containerID := "abc123"
+	podID := "kdn-test"
 	fakeExec := exec.NewFake()
 
 	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -148,7 +148,7 @@ func TestStop_StepLogger_FailOnStopContainer(t *testing.T) {
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
 
-	err := p.Stop(ctx, containerID)
+	err := p.Stop(ctx, podID)
 	if err == nil {
 		t.Fatal("Expected Stop() to fail, got nil")
 	}
@@ -158,13 +158,13 @@ func TestStop_StepLogger_FailOnStopContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (stop container step)
+	// Verify Start was called once (stop pod step)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Stopping container: abc123" {
-		t.Errorf("Expected first step to be 'Stopping container: abc123', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != "Stopping pod: kdn-test" {
+		t.Errorf("Expected first step to be 'Stopping pod: kdn-test', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
 	// Verify Fail was called once

--- a/pkg/runtime/podman/terminal.go
+++ b/pkg/runtime/podman/terminal.go
@@ -24,7 +24,7 @@ import (
 // Ensure podmanRuntime implements runtime.Terminal at compile time.
 var _ runtime.Terminal = (*podmanRuntime)(nil)
 
-// Terminal starts an interactive terminal session inside a running instance.
+// Terminal starts an interactive terminal session inside the workspace container of a running pod.
 func (p *podmanRuntime) Terminal(ctx context.Context, instanceID string, agent string, command []string) error {
 	if instanceID == "" {
 		return fmt.Errorf("%w: instance ID is required", runtime.ErrInvalidParams)
@@ -50,8 +50,11 @@ func (p *podmanRuntime) Terminal(ctx context.Context, instanceID string, agent s
 		command = agentConfig.TerminalCommand
 	}
 
-	// Build podman exec -it <container> <command...>
-	args := []string{"exec", "-it", instanceID}
+	// The instanceID is the pod name; exec targets the workspace container.
+	wsContainer := workspaceContainerName(instanceID)
+
+	// Build podman exec -it <workspace-container> <command...>
+	args := []string{"exec", "-it", wsContainer}
 	args = append(args, command...)
 
 	return p.executor.RunInteractive(ctx, args...)

--- a/pkg/runtime/podman/terminal_test.go
+++ b/pkg/runtime/podman/terminal_test.go
@@ -26,7 +26,7 @@ import (
 func TestPodmanRuntime_Terminal(t *testing.T) {
 	t.Parallel()
 
-	t.Run("executes podman exec -it with command", func(t *testing.T) {
+	t.Run("executes podman exec -it on workspace container with command", func(t *testing.T) {
 		t.Parallel()
 
 		fakeExec := exec.NewFake()
@@ -35,13 +35,16 @@ func TestPodmanRuntime_Terminal(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := rt.Terminal(ctx, "container123", "test-agent", []string{"bash"})
+		// instanceID is the pod name; terminal should exec into the workspace container
+		podID := "kdn-test-workspace"
+		err := rt.Terminal(ctx, podID, "test-agent", []string{"bash"})
 		if err != nil {
 			t.Fatalf("Terminal() failed: %v", err)
 		}
 
-		// Verify RunInteractive was called with correct arguments
-		expectedArgs := []string{"exec", "-it", "container123", "bash"}
+		// Verify RunInteractive was called targeting the workspace container, not the pod name
+		wsContainer := workspaceContainerName(podID)
+		expectedArgs := []string{"exec", "-it", wsContainer, "bash"}
 		fakeExec.AssertRunInteractiveCalledWith(t, expectedArgs...)
 	})
 
@@ -54,13 +57,15 @@ func TestPodmanRuntime_Terminal(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := rt.Terminal(ctx, "container123", "test-agent", []string{"claude-code", "--debug"})
+		podID := "kdn-test-workspace"
+		err := rt.Terminal(ctx, podID, "test-agent", []string{"claude-code", "--debug"})
 		if err != nil {
 			t.Fatalf("Terminal() failed: %v", err)
 		}
 
-		// Verify RunInteractive was called with correct arguments
-		expectedArgs := []string{"exec", "-it", "container123", "claude-code", "--debug"}
+		// Verify RunInteractive was called targeting the workspace container
+		wsContainer := workspaceContainerName(podID)
+		expectedArgs := []string{"exec", "-it", wsContainer, "claude-code", "--debug"}
 		fakeExec.AssertRunInteractiveCalledWith(t, expectedArgs...)
 	})
 
@@ -93,13 +98,15 @@ func TestPodmanRuntime_Terminal(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := rt.Terminal(ctx, "container123", "test-agent", []string{})
+		podID := "kdn-test-workspace"
+		err := rt.Terminal(ctx, podID, "test-agent", []string{})
 		if err != nil {
 			t.Fatalf("Terminal() failed: %v", err)
 		}
 
-		// Verify RunInteractive was called with agent's terminal command from fakeConfig
-		expectedArgs := []string{"exec", "-it", "container123", "claude"}
+		// Verify RunInteractive was called targeting the workspace container with agent's terminal command
+		wsContainer := workspaceContainerName(podID)
+		expectedArgs := []string{"exec", "-it", wsContainer, "claude"}
 		fakeExec.AssertRunInteractiveCalledWith(t, expectedArgs...)
 	})
 
@@ -112,7 +119,7 @@ func TestPodmanRuntime_Terminal(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := rt.Terminal(ctx, "container123", "", []string{})
+		err := rt.Terminal(ctx, "kdn-test-workspace", "", []string{})
 		if err == nil {
 			t.Fatal("Expected error for empty agent and empty command")
 		}
@@ -136,7 +143,7 @@ func TestPodmanRuntime_Terminal(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := rt.Terminal(ctx, "container123", "test-agent", []string{"bash"})
+		err := rt.Terminal(ctx, "kdn-test-workspace", "test-agent", []string{"bash"})
 		if err == nil {
 			t.Fatal("Expected error to be propagated")
 		}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -123,8 +123,10 @@ type AgentLister interface {
 //	}
 //
 //	func (r *myRuntime) Terminal(ctx context.Context, instanceID string, agent string, command []string) error {
+//	    // Derive the actual exec target from the instance ID (e.g., workspace container inside a pod)
+//	    target := deriveExecTarget(instanceID)
 //	    // Execute command interactively (stdin/stdout/stderr connected)
-//	    return r.exec.RunInteractive(ctx, "exec", "-it", instanceID, command...)
+//	    return r.exec.RunInteractive(ctx, "exec", "-it", target, command...)
 //	}
 type Terminal interface {
 	// Terminal starts an interactive terminal session inside a running instance.

--- a/skills/working-with-runtime-system/SKILL.md
+++ b/skills/working-with-runtime-system/SKILL.md
@@ -171,7 +171,7 @@ The Terminal interface follows the same pattern as `StorageAware` - it's optiona
 
 ```go
 if terminalRuntime, ok := runtime.(Terminal); ok {
-    return terminalRuntime.Terminal(ctx, agent, instanceID, command)
+    return terminalRuntime.Terminal(ctx, instanceID, agent, command)
 }
 return errors.New("runtime does not support terminal sessions")
 ```

--- a/skills/working-with-runtime-system/SKILL.md
+++ b/skills/working-with-runtime-system/SKILL.md
@@ -130,26 +130,35 @@ type Terminal interface {
     // Terminal starts an interactive terminal session inside a running instance.
     // The agent parameter is used to load agent-specific configuration for the terminal session.
     // The command is executed with stdin/stdout/stderr connected directly to the user's terminal.
-    Terminal(ctx context.Context, agent string, instanceID string, command []string) error
+    Terminal(ctx context.Context, instanceID string, agent string, command []string) error
 }
 ```
 
 **Example implementation (Podman runtime):**
 
 ```go
-func (p *podmanRuntime) Terminal(ctx context.Context, agent string, instanceID string, command []string) error {
-    if agent == "" {
-        return fmt.Errorf("%w: agent is required", runtime.ErrInvalidParams)
-    }
+func (p *podmanRuntime) Terminal(ctx context.Context, instanceID string, agent string, command []string) error {
     if instanceID == "" {
         return fmt.Errorf("%w: instance ID is required", runtime.ErrInvalidParams)
     }
+
+    // If no command provided, load it from agent config
     if len(command) == 0 {
-        return fmt.Errorf("%w: command is required", runtime.ErrInvalidParams)
+        if agent == "" {
+            return fmt.Errorf("%w: agent name is required when command is not provided", runtime.ErrInvalidParams)
+        }
+        agentConfig, err := p.config.LoadAgent(agent)
+        if err != nil {
+            return fmt.Errorf("failed to load agent config: %w", err)
+        }
+        command = agentConfig.TerminalCommand
     }
 
-    // Build podman exec -it <container> <command...>
-    args := []string{"exec", "-it", instanceID}
+    // instanceID is the pod name; exec targets the workspace container inside the pod.
+    wsContainer := workspaceContainerName(instanceID)
+
+    // Build podman exec -it <workspace-container> <command...>
+    args := []string{"exec", "-it", wsContainer}
     args = append(args, command...)
 
     return p.executor.RunInteractive(ctx, args...)
@@ -219,13 +228,14 @@ Runtime implementations must map platform-specific states to the four valid stat
 
 ```go
 // In pkg/runtime/podman/info.go
-func mapPodmanState(podmanState string) api.WorkspaceState {
+// Pod states are title-case (see podman-pod-inspect docs).
+func mapPodmanPodState(podmanState string) api.WorkspaceState {
     switch podmanState {
-    case "running":
+    case "Running":
         return api.WorkspaceStateRunning
-    case "created", "exited", "stopped", "paused", "removing":
+    case "Created", "Stopped", "Exited":
         return api.WorkspaceStateStopped
-    case "dead":
+    case "Dead", "Degraded":
         return api.WorkspaceStateError
     default:
         return api.WorkspaceStateUnknown
@@ -233,17 +243,12 @@ func mapPodmanState(podmanState string) api.WorkspaceState {
 }
 
 func (p *podmanRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
-    // Get podman-specific state
-    podmanState := getPodmanContainerState(id)
-    
-    // Map to valid WorkspaceState (no validation needed - manager handles it)
-    state := mapPodmanState(podmanState)
-    
-    return runtime.RuntimeInfo{
-        ID:    id,
-        State: state,
-        Info:  info,
-    }, nil
+    // Get pod information (name|state) via podman pod inspect
+    info, err := p.getPodInfo(ctx, id)
+    if err != nil {
+        return runtime.RuntimeInfo{}, err
+    }
+    return info, nil
 }
 ```
 


### PR DESCRIPTION
Implements #245. Replaces the single-container model with a Podman pod containing two containers: a workspace container (`kdn-<name>-workspace`) and a Squid proxy sidecar (`kdn-<name>-proxy`). The sidecar enforces network isolation by setting an nftables OUTPUT policy of drop with CAP_NET_ADMIN, allowing only loopback and squid-user traffic. The workspace container routes HTTP/HTTPS through the proxy via injected env vars, which cannot be bypassed even if unset.

RuntimeInfo.ID changes from the container ID to the pod name (kdn-<name>). Pod lifecycle (start, stop, rm, inspect) replaces the former container-level commands throughout.


Fixes #245

The proxy container is based on fedora image. This is not optimal, but IMHO make it first work with all features (filtering, secret injection), then find the best image to use

In the proxy container, you can see in `/var/log/squid/access.log` the requests done by the agent.

BREAKING CHANGE: remove all previous workspaces as they won't be correctly supported with this new version 