### PR TITLE
feat(agent): add provider auto-config via model ID encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2261,7 +2261,7 @@ kdn init [sources-directory] [flags]
 
 - `--runtime, -r <type>` - Runtime to use for the workspace (required if `KDN_DEFAULT_RUNTIME` is not set)
 - `--agent, -a <name>` - Agent to use for the workspace (required if `KDN_DEFAULT_AGENT` is not set)
-- `--model, -m <id>` - Model ID to configure for the agent (optional, uses agent's default if not specified)
+- `--model, -m <id>` - Model ID to configure for the agent. Supports three formats: `model`, `provider::model` (auto-configures provider with default base URL), or `provider::model::baseURL` (auto-configures provider with custom endpoint). Localhost aliases in base URLs are auto-converted to `host.containers.internal` for container access
 - `--workspace-configuration <path>` - Directory for workspace configuration files (default: `<sources-directory>/.kaiden`)
 - `--name, -n <name>` - Human-readable name for the workspace (default: generated from sources directory)
 - `--project, -p <identifier>` - Custom project identifier to override auto-detection (default: auto-detected from git repository or source directory)
@@ -2349,6 +2349,16 @@ Registered workspace:
   Sources directory: /absolute/path/to/myproject
   Configuration directory: /absolute/path/to/myproject/.kaiden
   State: stopped
+```
+
+**Register with a model provider (default endpoint):**
+```bash
+kdn init --runtime podman --agent opencode --model ollama::gemma4:26b
+```
+
+**Register with a model provider and custom endpoint:**
+```bash
+kdn init --runtime podman --agent opencode --model ollama::gemma4:26b::http://192.168.1.50:11434/v1
 ```
 
 **JSON output (default - ID only):**
@@ -2507,6 +2517,7 @@ kdn init /tmp/workspace --runtime podman --agent claude
 - **Runtime is required**: You must specify a runtime using either the `--runtime` flag or the `KDN_DEFAULT_RUNTIME` environment variable
 - **Agent is required**: You must specify an agent using either the `--agent` flag or the `KDN_DEFAULT_AGENT` environment variable
 - **Model is optional**: Use `--model` to specify a model ID for the agent. The flag takes precedence over any model defined in the agent's default settings files (`~/.kdn/config/<agent>/`). If not provided, the agent uses its default model or the one configured in settings. All agents support model configuration: Claude (via `.claude/settings.json`), Goose (via `config.yaml`), Cursor (via `.cursor/cli-config.json`), and OpenCode (via `.config/opencode/opencode.json`)
+- **Provider configuration**: The `--model` flag supports a `provider::model` format (e.g. `ollama::gemma4:26b`) that auto-configures the provider endpoint and stores the model ID as `provider/model`. Known providers (`ollama`, `ramalama`) have default base URLs pointing to `host.containers.internal`; unknown providers require the full format `provider::model::baseURL`. Localhost aliases (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) in base URLs are automatically converted to `host.containers.internal` for container accessibility
 - **Project auto-detection**: The project identifier is automatically detected from git repository information or source directory path. Use `--project` flag to override with a custom identifier
 - **Auto-start**: Use the `--start` flag or set `KDN_INIT_AUTO_START=1` to automatically start the workspace after registration, combining `init` and `start` into a single operation
 - All directory paths are converted to absolute paths for consistency
@@ -2543,12 +2554,12 @@ kdn workspace list
 ```
 Output:
 ```text
-NAME             SHORT ID      PROJECT                              SOURCES                              AGENT/MODEL                            STATE
-myproject        a1b2c3d4e5f6  /absolute/path/to/myproject          /absolute/path/to/myproject          claude/claude-sonnet-4-20250514        running
-another-project  f6e5d4c3b2a1  /absolute/path/to/another-project    /absolute/path/to/another-project    goose                                  stopped
+NAME             SHORT ID      PROJECT                              SOURCES                              AGENT    MODEL                          STATE
+myproject        a1b2c3d4e5f6  /absolute/path/to/myproject          /absolute/path/to/myproject          claude   claude-sonnet-4-20250514       running
+another-project  f6e5d4c3b2a1  /absolute/path/to/another-project    /absolute/path/to/another-project    goose                                   stopped
 ```
 
-When a model is specified, the `AGENT/MODEL` column shows `agent/model` (e.g. `claude/claude-sonnet-4-20250514`). When no model is set, only the agent name is displayed (e.g. `goose`).
+The `AGENT` and `MODEL` columns are displayed separately. When no model is set, the `MODEL` column is empty.
 
 **Use the short alias:**
 ```bash
@@ -2600,7 +2611,7 @@ kdn list -o json
 #### Notes
 
 - When no workspaces are registered, the command displays "No workspaces registered"
-- The `AGENT/MODEL` column shows `agent/model` (e.g. `claude/claude-sonnet-4-20250514`) when a model was set at registration time, or just the agent name (e.g. `claude`) when no model was specified
+- The `AGENT` and `MODEL` columns are displayed separately. The `MODEL` column shows the model name when set at registration time, or is empty when no model was specified
 - In JSON output, the `model` field is only present when a model was explicitly set with `--model` during `init`
 - The JSON output format is useful for scripting and automation
 - All paths are displayed as absolute paths for consistency

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -21,9 +21,18 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	kdnconfig "github.com/openkaiden/kdn/pkg/config"
 )
+
+// containerHost is the hostname used to reach the host machine from inside a container.
+const containerHost = "host.containers.internal"
+
+// localhostAliases lists hostnames and IPs that refer to the local machine.
+var localhostAliases = []string{"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"}
 
 const (
 	// OpenCodeConfigPath is the relative path to the OpenCode configuration file.
@@ -56,8 +65,12 @@ func (o *openCodeAgent) SkipOnboarding(settings map[string][]byte, _ string) (ma
 }
 
 // SetModel configures the model ID in OpenCode settings.
-// It sets the model field in .config/opencode/opencode.json.
-// All other fields in the settings file are preserved.
+// The modelID supports three formats:
+//   - "model" — sets the model directly
+//   - "provider::model" — sets provider/model and auto-configures the provider with its default base URL
+//   - "provider::model::baseURL" — sets provider/model and configures the provider with the given base URL
+//
+// All other fields in .config/opencode/opencode.json are preserved.
 func (o *openCodeAgent) SetModel(settings map[string][]byte, modelID string) (map[string][]byte, error) {
 	if settings == nil {
 		settings = make(map[string][]byte)
@@ -78,7 +91,29 @@ func (o *openCodeAgent) SetModel(settings map[string][]byte, modelID string) (ma
 		config = make(map[string]interface{})
 	}
 
-	config["model"] = modelID
+	// Parse provider::model[::baseURL] format
+	provider, modelName, baseURL := kdnconfig.ParseModelID(modelID)
+	if provider != "" {
+		if modelName == "" {
+			return nil, fmt.Errorf("invalid model ID %q: expected provider::model or provider::model::baseURL", modelID)
+		}
+		resolvedURL := baseURL
+		if resolvedURL == "" {
+			defaultURL, known := defaultProviderBaseURLs[provider]
+			if !known {
+				return nil, fmt.Errorf("unknown provider %q: append ::baseURL to specify the endpoint", provider)
+			}
+			resolvedURL = defaultURL
+		} else {
+			resolvedURL = toContainerURL(resolvedURL)
+		}
+		config["model"] = provider + "/" + modelName
+		if err := configureProvider(config, provider, modelName, resolvedURL); err != nil {
+			return nil, err
+		}
+	} else {
+		config["model"] = modelID
+	}
 
 	modifiedContent, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
@@ -98,4 +133,72 @@ func (o *openCodeAgent) SkillsDir() string {
 // through agent settings files.
 func (o *openCodeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
 	return settings, nil
+}
+
+// configureProvider adds a provider block with the given base URL and registers the model.
+func configureProvider(config map[string]interface{}, provider, modelName, baseURL string) error {
+	providers, _ := config["provider"].(map[string]interface{})
+	if providers == nil {
+		providers = make(map[string]interface{})
+	}
+	config["provider"] = providers
+
+	providerEntry, _ := providers[provider].(map[string]interface{})
+	if providerEntry == nil {
+		providerEntry = map[string]interface{}{
+			"name": provider,
+			"npm":  "@ai-sdk/openai-compatible",
+		}
+	}
+	options, _ := providerEntry["options"].(map[string]interface{})
+	if options == nil {
+		options = make(map[string]interface{})
+	}
+	options["baseURL"] = baseURL
+	providerEntry["options"] = options
+	providers[provider] = providerEntry
+
+	models, _ := providerEntry["models"].(map[string]interface{})
+	if models == nil {
+		models = make(map[string]interface{})
+	}
+	if _, exists := models[modelName]; !exists {
+		models[modelName] = map[string]interface{}{
+			"_launch": true,
+			"name":    modelName,
+		}
+	}
+	providerEntry["models"] = models
+
+	return nil
+}
+
+// toContainerURL replaces localhost aliases in a URL with host.containers.internal
+// so the URL is reachable from inside a container.
+func toContainerURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	hostname := parsed.Hostname()
+	for _, alias := range localhostAliases {
+		if strings.EqualFold(hostname, alias) {
+			port := parsed.Port()
+			if port != "" {
+				parsed.Host = containerHost + ":" + port
+			} else {
+				parsed.Host = containerHost
+			}
+			return parsed.String()
+		}
+	}
+
+	return rawURL
+}
+
+// defaultProviderBaseURLs maps known provider names to their default base URLs.
+var defaultProviderBaseURLs = map[string]string{
+	"ollama":   "http://host.containers.internal:11434/v1",
+	"ramalama": "http://host.containers.internal:8080/v1",
 }

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -242,6 +242,205 @@ func TestOpenCode_SetModel(t *testing.T) {
 			t.Fatal("Expected error for invalid JSON")
 		}
 	})
+
+	t.Run("provider::model configures provider with default URL", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "ollama::gemma4:26b")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "ollama/gemma4:26b" {
+			t.Errorf("model = %v, want %q", config["model"], "ollama/gemma4:26b")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		ollama := providers["ollama"].(map[string]interface{})
+		options := ollama["options"].(map[string]interface{})
+
+		if got := options["baseURL"].(string); got != "http://host.containers.internal:11434/v1" {
+			t.Errorf("baseURL = %q, want default ollama URL", got)
+		}
+
+		models := ollama["models"].(map[string]interface{})
+		modelEntry := models["gemma4:26b"].(map[string]interface{})
+		if name := modelEntry["name"].(string); name != "gemma4:26b" {
+			t.Errorf("model name = %q, want %q", name, "gemma4:26b")
+		}
+		if launch := modelEntry["_launch"].(bool); !launch {
+			t.Errorf("_launch = %v, want true", launch)
+		}
+	})
+
+	t.Run("provider::model::baseURL configures provider with custom URL", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "ollama::gemma4:26b::http://192.168.1.50:11434/v1")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "ollama/gemma4:26b" {
+			t.Errorf("model = %v, want %q", config["model"], "ollama/gemma4:26b")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		ollama := providers["ollama"].(map[string]interface{})
+		options := ollama["options"].(map[string]interface{})
+
+		if got := options["baseURL"].(string); got != "http://192.168.1.50:11434/v1" {
+			t.Errorf("baseURL = %q, want %q", got, "http://192.168.1.50:11434/v1")
+		}
+	})
+
+	t.Run("provider::model::localhost URL converted to container host", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "ollama::gemma4:26b::http://localhost:11434/v1")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		ollama := providers["ollama"].(map[string]interface{})
+		options := ollama["options"].(map[string]interface{})
+
+		if got := options["baseURL"].(string); got != "http://host.containers.internal:11434/v1" {
+			t.Errorf("baseURL = %q, want %q", got, "http://host.containers.internal:11434/v1")
+		}
+	})
+
+	t.Run("ramalama provider with default URL", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "ramalama::granite3.3:8b")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "ramalama/granite3.3:8b" {
+			t.Errorf("model = %v, want %q", config["model"], "ramalama/granite3.3:8b")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		ramalama := providers["ramalama"].(map[string]interface{})
+		options := ramalama["options"].(map[string]interface{})
+
+		if got := options["baseURL"].(string); got != "http://host.containers.internal:8080/v1" {
+			t.Errorf("baseURL = %q, want default ramalama URL", got)
+		}
+	})
+
+	t.Run("provider with empty model name returns error", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		_, err := agent.SetModel(settings, "ollama::")
+		if err == nil {
+			t.Fatal("Expected error for empty model name")
+		}
+	})
+
+	t.Run("unknown provider without baseURL returns error", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		_, err := agent.SetModel(settings, "unknown::some-model")
+		if err == nil {
+			t.Fatal("Expected error for unknown provider without baseURL")
+		}
+	})
+
+	t.Run("unknown provider with baseURL succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "custom::my-model::http://my-server:9090/v1")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "custom/my-model" {
+			t.Errorf("model = %v, want %q", config["model"], "custom/my-model")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		custom := providers["custom"].(map[string]interface{})
+		options := custom["options"].(map[string]interface{})
+
+		if got := options["baseURL"].(string); got != "http://my-server:9090/v1" {
+			t.Errorf("baseURL = %q, want %q", got, "http://my-server:9090/v1")
+		}
+	})
+
+	t.Run("plain model ID without provider", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string][]byte)
+
+		result, err := agent.SetModel(settings, "anthropic/claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "anthropic/claude-sonnet-4-6" {
+			t.Errorf("model = %v, want %q", config["model"], "anthropic/claude-sonnet-4-6")
+		}
+
+		if _, ok := config["provider"]; ok {
+			t.Error("Plain model ID should not create provider block")
+		}
+	})
 }
 
 func TestOpenCode_SkillsDir(t *testing.T) {
@@ -320,4 +519,35 @@ func TestOpenCode_SetMCPServers(t *testing.T) {
 			t.Errorf("SetMCPServers() modified other settings unexpectedly")
 		}
 	})
+}
+
+func TestToContainerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"localhost", "http://localhost:11434/v1", "http://host.containers.internal:11434/v1"},
+		{"127.0.0.1", "http://127.0.0.1:8080/v1", "http://host.containers.internal:8080/v1"},
+		{"0.0.0.0", "http://0.0.0.0:11434/v1", "http://host.containers.internal:11434/v1"},
+		{"::1", "http://[::1]:11434/v1", "http://host.containers.internal:11434/v1"},
+		{"remote host unchanged", "http://192.168.1.50:11434/v1", "http://192.168.1.50:11434/v1"},
+		{"hostname unchanged", "http://my-server:11434/v1", "http://my-server:11434/v1"},
+		{"https preserved", "https://localhost:11434/v1", "https://host.containers.internal:11434/v1"},
+		{"no port", "http://localhost/v1", "http://host.containers.internal/v1"},
+		{"invalid URL returned as-is", "not a url ://", "not a url ://"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toContainerURL(tt.input)
+			if got != tt.expected {
+				t.Errorf("toContainerURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
 }

--- a/pkg/cmd/helpers.go
+++ b/pkg/cmd/helpers.go
@@ -14,7 +14,11 @@
 
 package cmd
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/openkaiden/kdn/pkg/config"
+)
 
 // AdaptExampleForAlias replaces the original command with the alias command
 // in the example string, but only in command lines (not in comments).
@@ -50,4 +54,10 @@ func AdaptExampleForAlias(example, originalCmd, aliasCmd string) string {
 	}
 
 	return strings.Join(result, "\n")
+}
+
+// displayModelID strips the provider:: and ::baseURL encoding from a model ID,
+// returning just the model name for human-readable display.
+func displayModelID(modelID string) string {
+	return config.DisplayModelName(modelID)
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -264,7 +264,14 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(out, "  Project: %s\n", addedInstance.GetProject())
 		fmt.Fprintf(out, "  Agent: %s\n", addedInstance.GetAgent())
 		if model := addedInstance.GetModel(); model != "" {
-			fmt.Fprintf(out, "  Model: %s\n", model)
+			provider, modelName, baseURL := config.ParseModelID(model)
+			fmt.Fprintf(out, "  Model: %s\n", modelName)
+			if provider != "" {
+				fmt.Fprintf(out, "  Provider: %s\n", provider)
+			}
+			if baseURL != "" {
+				fmt.Fprintf(out, "  Base URL: %s\n", baseURL)
+			}
 		} else {
 			fmt.Fprintf(out, "  Model: (default)\n")
 		}
@@ -328,6 +335,12 @@ kdn init --runtime podman --agent opencode
 
 # Register with a specific model
 kdn init --runtime podman --agent claude --model claude-sonnet-4-20250514
+
+# Register with a model provider (auto-configured base URL)
+kdn init --runtime podman --agent opencode --model ollama::gemma4:26b
+
+# Register with a model provider and custom endpoint
+kdn init --runtime podman --agent opencode --model ollama::gemma4:26b::http://192.168.1.50:11434/v1
 
 # Register and start workspace
 kdn init --runtime podman --agent claude --start

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -2484,7 +2484,7 @@ func TestInitCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 9
+	expectedCount := 11
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -144,7 +144,7 @@ func (w *workspaceListCmd) displayTable(cmd *cobra.Command, instancesList []inst
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 	columnFmt := color.New(color.FgYellow).SprintfFunc()
 
-	tbl := table.New("NAME", "SHORT ID", "PROJECT", "SOURCES", "AGENT/MODEL", "STATE")
+	tbl := table.New("NAME", "SHORT ID", "PROJECT", "SOURCES", "AGENT", "MODEL", "STATE")
 	tbl.WithWriter(out)
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
@@ -154,13 +154,11 @@ func (w *workspaceListCmd) displayTable(cmd *cobra.Command, instancesList []inst
 		name := instance.GetName()
 		project := instance.GetProject()
 		sources := compactPath(instance.GetSourceDir())
-		agentModel := instance.GetAgent()
-		if model := instance.GetModel(); model != "" {
-			agentModel += "/" + model
-		}
+		agent := instance.GetAgent()
+		model := displayModelID(instance.GetModel())
 		state := instance.GetRuntimeData().State
 
-		tbl.AddRow(name, shortID, project, sources, agentModel, state)
+		tbl.AddRow(name, shortID, project, sources, agent, model, state)
 	}
 
 	// Print the table

--- a/pkg/cmd/workspace_list_test.go
+++ b/pkg/cmd/workspace_list_test.go
@@ -550,7 +550,7 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 func TestWorkspaceListCmd_Model(t *testing.T) {
 	t.Parallel()
 
-	t.Run("table header shows AGENT/MODEL", func(t *testing.T) {
+	t.Run("table header shows AGENT and MODEL columns", func(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
@@ -589,12 +589,18 @@ func TestWorkspaceListCmd_Model(t *testing.T) {
 		}
 
 		result := output.String()
-		if !strings.Contains(result, "AGENT/MODEL") {
-			t.Errorf("Expected table header 'AGENT/MODEL', got: %s", result)
+		if !strings.Contains(result, "AGENT") {
+			t.Errorf("Expected table header 'AGENT', got: %s", result)
+		}
+		if !strings.Contains(result, "MODEL") {
+			t.Errorf("Expected table header 'MODEL', got: %s", result)
+		}
+		if strings.Contains(result, "AGENT/MODEL") {
+			t.Errorf("Expected separate AGENT and MODEL headers, got combined header: %s", result)
 		}
 	})
 
-	t.Run("shows agent/model in table when model is set", func(t *testing.T) {
+	t.Run("shows agent and model in separate columns when model is set", func(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
@@ -638,12 +644,18 @@ func TestWorkspaceListCmd_Model(t *testing.T) {
 		}
 
 		result := output.String()
-		if !strings.Contains(result, "claude/claude-sonnet-4-20250514") {
-			t.Errorf("Expected 'claude/claude-sonnet-4-20250514' in table, got: %s", result)
+		if !strings.Contains(result, "claude") {
+			t.Errorf("Expected 'claude' in AGENT column, got: %s", result)
+		}
+		if !strings.Contains(result, "claude-sonnet-4-20250514") {
+			t.Errorf("Expected 'claude-sonnet-4-20250514' in MODEL column, got: %s", result)
+		}
+		if strings.Contains(result, "claude/claude-sonnet-4-20250514") {
+			t.Errorf("Expected agent/model in separate columns, got combined value: %s", result)
 		}
 	})
 
-	t.Run("shows only agent name in table when model is not set", func(t *testing.T) {
+	t.Run("shows agent with empty model column when model is not set", func(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
@@ -688,10 +700,10 @@ func TestWorkspaceListCmd_Model(t *testing.T) {
 
 		result := output.String()
 		if !strings.Contains(result, "claude") {
-			t.Errorf("Expected 'claude' in table, got: %s", result)
+			t.Errorf("Expected 'claude' in AGENT column, got: %s", result)
 		}
 		if strings.Contains(result, "claude/") {
-			t.Errorf("Expected no slash after agent name when model is empty, got: %s", result)
+			t.Errorf("Expected empty MODEL column when model is unset, got combined agent/model output: %s", result)
 		}
 	})
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "strings"
+
+// ParseModelID splits a model ID encoded as "provider::model::baseURL" into its
+// components. Returns (provider, model, baseURL). For plain model IDs,
+// provider and baseURL are empty.
+func ParseModelID(modelID string) (provider, model, baseURL string) {
+	parts := strings.SplitN(modelID, "::", 3)
+	switch len(parts) {
+	case 3:
+		return parts[0], parts[1], parts[2]
+	case 2:
+		return parts[0], parts[1], ""
+	default:
+		return "", modelID, ""
+	}
+}
+
+// DisplayModelName returns just the model name, stripping the provider:: and
+// ::baseURL encoding for human-readable display.
+func DisplayModelName(modelID string) string {
+	_, name, _ := ParseModelID(modelID)
+	return name
+}

--- a/skills/working-with-config-system/SKILL.md
+++ b/skills/working-with-config-system/SKILL.md
@@ -63,7 +63,7 @@ This means you can optionally customize agent preferences (theme, etc.) in the s
 
 When the `--model` flag is provided during `init`, kdn does two things with the model:
 
-1. **Persists it in instance data**: The model ID is stored in `InstanceData.Model` and saved to `instances.json`. It can be retrieved via `instance.GetModel()` and is shown in `init` verbose output and `kdn list` (`AGENT/MODEL` column and JSON `model` field).
+1. **Persists it in instance data**: The model ID is stored in `InstanceData.Model` and saved to `instances.json`. It can be retrieved via `instance.GetModel()` and is shown in `init` verbose output and `kdn list` (`MODEL` column and JSON `model` field).
 
 2. **Writes it to agent settings**: Calls the agent's `SetModel()` method to configure the model in the agent-specific settings file baked into the container image:
    - Claude: `model` field in `.claude/settings.json`
@@ -72,6 +72,15 @@ When the `--model` flag is provided during `init`, kdn does two things with the 
    - OpenCode: `model` field in `.config/opencode/opencode.json`
 
 The `--model` flag takes precedence over any model already defined in the settings files. If no model is specified, `GetModel()` returns an empty string and the `model` field is omitted from JSON output.
+
+**Provider Configuration (OpenCode):**
+
+The `--model` flag supports a `provider::model` format that auto-configures the provider endpoint in `SetModel()`. Three formats are supported:
+- `model` — plain model ID, no provider configuration
+- `provider::model` — auto-configures provider with its known default base URL
+- `provider::model::baseURL` — auto-configures provider with a custom base URL
+
+The model ID is stored as `provider/model` in the config. Known providers with default base URLs: `ollama` (`http://host.containers.internal:11434/v1`), `ramalama` (`http://host.containers.internal:8080/v1`). Unknown providers require the full `provider::model::baseURL` format. Localhost aliases in base URLs are auto-converted to `host.containers.internal`.
 
 **MCP Server Configuration:**
 


### PR DESCRIPTION
feat(agent): add provider auto-config via model ID encoding
OpenCode's SetModel now supports a provider::model[::baseURL] encoding
in the --model flag to auto-configure provider endpoints in the
generated .config/opencode/opencode.json.

Three formats are supported:
- "model" — plain model, no provider config
- "provider::model" — auto-configures with known default base URL
- "provider::model::baseURL" — auto-configures with custom endpoint

Known providers (ollama, ramalama) have default base URLs pointing to
host.containers.internal. Unknown providers require the baseURL suffix.
Localhost aliases in base URLs are auto-converted to
host.containers.internal for container accessibility.

The encoding is persisted as-is in instances.json so image rebuilds
can reproduce the full provider config. Display commands (kdn list,
init --verbose) show only the model name, with provider and base URL
on separate lines when set.

Parsing helpers (ParseModelID, DisplayModelName) live in pkg/config
for reuse across packages.

refactor(cmd): split AGENT/MODEL into separate columns in kdn list
The workspace list table now shows AGENT and MODEL as distinct columns
instead of the combined AGENT/MODEL column. The MODEL column displays
the resolved model name (stripping provider:: encoding) and is empty
when no model is configured.


### Testing ollama
> (launch ollama)

Then
> ./kdn init /path/to/project  --runtime podman --agent opencode --model ollama::gemma4:31b-cloud

### Testing ramalama on non-default port:
> ramalama serve hf://bartowski/Qwen_Qwen3.5-2B-GGUF/Qwen_Qwen3.5-2B-Q4_K_M.gguf --port 9191

Then
> ./kdn init /path/to/project --runtime podman --agent opencode --model ramalama::hf://bartowski/Qwen_Qwen3.5-2B-GGUF/Qwen_Qwen3.5-2B-Q4_K_M.gguf::http://0.0.0.0:9191 

In `kdn list`, the agent and model were split at @jeffmaury's request 
<img width="1685" height="82" alt="Screenshot 2026-04-16 at 10 56 16" src="https://github.com/user-attachments/assets/c68798a6-a78e-4cd6-95ee-4d580c5de7a3" />
