### PR TITLE
feat(terminal): auto-start stopped instances on terminal connect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 **Optional Interfaces:**
 - **StorageAware**: Enables runtimes to persist data in a dedicated storage directory
 - **AgentLister**: Enables runtimes to report which agents they support
-- **Terminal**: Enables interactive terminal sessions with running instances
+- **Terminal**: Enables interactive terminal sessions with instances (auto-starts if needed)
 
 **For detailed runtime implementation guidance, use:** `/working-with-runtime-system`
 

--- a/README.md
+++ b/README.md
@@ -2882,9 +2882,9 @@ Output:
 - When using `--output json`, errors are also returned in JSON format for consistent parsing
 - **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure
 
-### `workspace terminal` - Connect to a Running Workspace
+### `workspace terminal` - Connect to a Workspace
 
-Connects to a running workspace with an interactive terminal session. Also available as the shorter alias `terminal`.
+Connects to a workspace with an interactive terminal session. If the workspace is stopped, it is automatically started before connecting. Also available as the shorter alias `terminal`.
 
 #### Usage
 
@@ -2914,7 +2914,7 @@ kdn workspace terminal a1b2c3d4e5f6...
 kdn workspace terminal my-project
 ```
 
-This starts an interactive session with the default agent (typically Claude Code) inside the running workspace container.
+This starts an interactive session with the default agent (typically Claude Code) inside the workspace container, auto-starting it if needed.
 
 **Use the short alias:**
 ```bash
@@ -2933,15 +2933,15 @@ kdn terminal a1b2c3d4e5f6... -- bash -c 'echo hello'
 
 The `--` separator tells kdn to stop parsing flags and pass everything after it directly to the container. This is useful when your command includes flags that would otherwise be interpreted by kdn.
 
-**List workspaces and connect to a running one:**
+**List workspaces and connect:**
 ```bash
 # First, list all workspaces to find the ID
 kdn list
 
-# Start a workspace if it's not running
+# Optionally start a workspace explicitly
 kdn start a1b2c3d4e5f6...
 
-# Then connect with a terminal
+# Connect with a terminal (auto-starts stopped workspaces)
 kdn terminal a1b2c3d4e5f6...
 ```
 
@@ -2957,24 +2957,13 @@ Error: workspace not found: invalid-id
 Use 'workspace list' to see available workspaces
 ```
 
-**Workspace not running:**
-```bash
-kdn terminal a1b2c3d4e5f6...
-```
-Output:
-```text
-Error: instance is not running (current state: created)
-```
+**Workspace not running (auto-started):**
 
-In this case, you need to start the workspace first:
-```bash
-kdn start a1b2c3d4e5f6...
-kdn terminal a1b2c3d4e5f6...
-```
+If the workspace is stopped, `terminal` automatically starts it before connecting. You can also start it explicitly with `kdn start` beforehand.
 
 #### Notes
 
-- The workspace must be in a **running state** before you can connect to it. Use `workspace start` to start a workspace first
+- If the workspace is stopped, it is automatically started before connecting. You can also use `workspace start` explicitly beforehand
 - You can specify the workspace using either its name or ID (both can be obtained using the `workspace list` or `list` command)
 - By default (when no command is provided), the runtime uses the `terminal_command` from the agent's configuration file
   - For example, if the workspace was created with `--agent claude`, it will use the command defined in `claude.json` (typically `["claude"]`)

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -78,6 +78,13 @@ func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, 
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
+// completeWorkspaceID provides completion for all workspaces regardless of state
+// The args and toComplete parameters are part of Cobra's ValidArgsFunction signature but are unused
+// because Cobra's shell completion framework automatically filters results based on user input.
+func completeWorkspaceID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return getFilteredWorkspaceIDs(cmd, nil)
+}
+
 // completeNonRunningWorkspaceID provides completion for non-running workspaces (for start and remove)
 // The args and toComplete parameters are part of Cobra's ValidArgsFunction signature but are unused
 // because Cobra's shell completion framework automatically filters results based on user input.

--- a/pkg/cmd/terminal_test.go
+++ b/pkg/cmd/terminal_test.go
@@ -103,7 +103,7 @@ func TestTerminalCmd_E2E(t *testing.T) {
 		}
 	})
 
-	t.Run("fails for stopped workspace", func(t *testing.T) {
+	t.Run("auto-starts stopped workspace", func(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
@@ -133,7 +133,7 @@ func TestTerminalCmd_E2E(t *testing.T) {
 		}
 		workspaceID := instancesList[0].GetID()
 
-		// Try to connect to terminal (workspace is not started)
+		// Try to connect to terminal (workspace is not started, should auto-start)
 		rootCmd = NewRootCmd()
 		rootCmd.SetArgs([]string{"terminal", workspaceID, "--storage", storageDir})
 
@@ -143,12 +143,12 @@ func TestTerminalCmd_E2E(t *testing.T) {
 
 		err = rootCmd.Execute()
 		if err == nil {
-			t.Fatal("Expected error for stopped workspace")
+			t.Fatal("Expected error because fake runtime does not support terminal")
 		}
 
-		// Should fail because workspace is not running
-		if !strings.Contains(err.Error(), "not running") {
-			t.Errorf("Expected 'not running' error, got: %v", err)
+		// Should auto-start successfully, then fail because fake runtime doesn't implement Terminal
+		if !strings.Contains(err.Error(), "does not support terminal sessions") {
+			t.Errorf("Expected 'does not support terminal sessions' error, got: %v", err)
 		}
 	})
 }

--- a/pkg/cmd/workspace_terminal.go
+++ b/pkg/cmd/workspace_terminal.go
@@ -102,15 +102,13 @@ func NewWorkspaceTerminalCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "terminal NAME|ID [COMMAND...]",
-		Short: "Connect to a running workspace with an interactive terminal",
-		Long: `Connect to a running workspace with an interactive terminal session.
+		Short: "Connect to a workspace with an interactive terminal",
+		Long: `Connect to a workspace with an interactive terminal session.
 
-The terminal command starts an interactive session inside a running workspace instance.
+The terminal command starts an interactive session inside a workspace instance.
+If the workspace is not running, it will be automatically started first.
 By default, it launches the agent command configured in the runtime. You can override
-this by providing a custom command.
-
-The workspace must be in a running state. Use 'workspace start' to start a workspace
-before connecting.`,
+this by providing a custom command.`,
 		Example: `# Connect using the default agent command (by ID)
 kdn workspace terminal abc123
 
@@ -123,7 +121,7 @@ kdn workspace terminal abc123 bash
 # Run a command with flags (use -- to prevent kdn from parsing them)
 kdn workspace terminal abc123 -- bash -c 'echo hello'`,
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: completeRunningWorkspaceID,
+		ValidArgsFunction: completeWorkspaceID,
 		PreRunE:           c.preRun,
 		RunE:              c.run,
 	}

--- a/pkg/cmd/workspace_terminal_test.go
+++ b/pkg/cmd/workspace_terminal_test.go
@@ -165,7 +165,7 @@ func TestWorkspaceTerminalCmd_E2E(t *testing.T) {
 		}
 	})
 
-	t.Run("fails for stopped workspace", func(t *testing.T) {
+	t.Run("auto-starts stopped workspace", func(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
@@ -195,7 +195,7 @@ func TestWorkspaceTerminalCmd_E2E(t *testing.T) {
 		}
 		workspaceID := instancesList[0].GetID()
 
-		// Try to connect to terminal (workspace is not started)
+		// Try to connect to terminal (workspace is not started, should auto-start)
 		rootCmd = NewRootCmd()
 		rootCmd.SetArgs([]string{"workspace", "terminal", workspaceID, "--storage", storageDir})
 
@@ -205,12 +205,12 @@ func TestWorkspaceTerminalCmd_E2E(t *testing.T) {
 
 		err = rootCmd.Execute()
 		if err == nil {
-			t.Fatal("Expected error for stopped workspace")
+			t.Fatal("Expected error because fake runtime does not support terminal")
 		}
 
-		// Should fail because workspace is not running
-		if !strings.Contains(err.Error(), "not running") {
-			t.Errorf("Expected 'not running' error, got: %v", err)
+		// Should auto-start successfully, then fail because fake runtime doesn't implement Terminal
+		if !strings.Contains(err.Error(), "does not support terminal sessions") {
+			t.Errorf("Expected 'does not support terminal sessions' error, got: %v", err)
 		}
 	})
 }

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -71,7 +71,7 @@ type Manager interface {
 	Start(ctx context.Context, id string) error
 	// Stop stops a runtime instance by ID
 	Stop(ctx context.Context, id string) error
-	// Terminal starts an interactive terminal session in a running instance
+	// Terminal starts an interactive terminal session, auto-starting the instance if needed
 	Terminal(ctx context.Context, id string, command []string) error
 	// List returns all registered instances
 	List() ([]Instance, error)
@@ -476,7 +476,23 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 }
 
 // Terminal starts an interactive terminal session in a running instance.
+// If the instance is not running, it will be automatically started first.
 func (m *manager) Terminal(ctx context.Context, id string, command []string) error {
+	// Check instance state without holding the lock for the entire operation,
+	// because Start() needs to acquire a write lock.
+	runtimeData, err := m.terminalCheckState(id)
+	if err != nil {
+		return err
+	}
+
+	// Auto-start the instance if it is not running
+	if runtimeData.State != api.WorkspaceStateRunning {
+		if err := m.Start(ctx, id); err != nil {
+			return fmt.Errorf("failed to auto-start instance: %w", err)
+		}
+	}
+
+	// Re-read the instance under RLock and connect to terminal
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -485,30 +501,19 @@ func (m *manager) Terminal(ctx context.Context, id string, command []string) err
 		return err
 	}
 
-	// Find the instance
 	var instanceToConnect Instance
-	found := false
 	for _, instance := range instances {
 		if instance.GetID() == id {
 			instanceToConnect = instance
-			found = true
 			break
 		}
 	}
 
-	if !found {
+	if instanceToConnect == nil {
 		return ErrInstanceNotFound
 	}
 
-	runtimeData := instanceToConnect.GetRuntimeData()
-	if runtimeData.Type == "" || runtimeData.InstanceID == "" {
-		return errors.New("instance has no runtime configured")
-	}
-
-	// Verify instance is running
-	if runtimeData.State != api.WorkspaceStateRunning {
-		return fmt.Errorf("instance is not running (current state: %s)", runtimeData.State)
-	}
+	runtimeData = instanceToConnect.GetRuntimeData()
 
 	// Get the runtime
 	rt, err := m.runtimeRegistry.Get(runtimeData.Type)
@@ -524,6 +529,30 @@ func (m *manager) Terminal(ctx context.Context, id string, command []string) err
 
 	// Start terminal session, passing the agent name
 	return terminalRT.Terminal(ctx, runtimeData.InstanceID, instanceToConnect.GetAgent(), command)
+}
+
+// terminalCheckState validates that the instance exists and has a runtime configured.
+// It returns the runtime data for state inspection.
+func (m *manager) terminalCheckState(id string) (RuntimeData, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	instances, err := m.loadInstances()
+	if err != nil {
+		return RuntimeData{}, err
+	}
+
+	for _, instance := range instances {
+		if instance.GetID() == id {
+			runtimeData := instance.GetRuntimeData()
+			if runtimeData.Type == "" || runtimeData.InstanceID == "" {
+				return RuntimeData{}, errors.New("instance has no runtime configured")
+			}
+			return runtimeData, nil
+		}
+	}
+
+	return RuntimeData{}, ErrInstanceNotFound
 }
 
 // List returns all registered instances

--- a/pkg/instances/manager_terminal_test.go
+++ b/pkg/instances/manager_terminal_test.go
@@ -167,7 +167,7 @@ func TestManager_Terminal(t *testing.T) {
 		}
 	})
 
-	t.Run("returns error for stopped instance", func(t *testing.T) {
+	t.Run("auto-starts stopped instance", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
@@ -187,15 +187,27 @@ func TestManager_Terminal(t *testing.T) {
 		})
 		added, _ := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake", Agent: "test-agent"})
 
-		// Instance is in "created" state (not running)
-		err := manager.Terminal(ctx, added.GetID(), []string{"bash"})
-		if err == nil {
-			t.Fatal("Expected error for stopped instance")
+		// Instance is in "created" state (not running) — Terminal should auto-start it
+		command := []string{"bash"}
+		err := manager.Terminal(ctx, added.GetID(), command)
+		if err != nil {
+			t.Fatalf("Terminal() unexpected error = %v", err)
 		}
 
-		// Should contain message about state
-		if err.Error() == "" {
-			t.Error("Error message should not be empty")
+		// Verify instance was started
+		got, _ := manager.Get(added.GetID())
+		if got.GetRuntimeData().State != "running" {
+			t.Errorf("Expected instance state to be running after auto-start, got %s", got.GetRuntimeData().State)
+		}
+
+		// Verify Terminal was called on the runtime
+		if len(fakeRT.terminalCalls) != 1 {
+			t.Fatalf("Expected 1 Terminal call, got %d", len(fakeRT.terminalCalls))
+		}
+
+		call := fakeRT.terminalCalls[0]
+		if call.agent != "test-agent" {
+			t.Errorf("Terminal called with agent = %v, want test-agent", call.agent)
 		}
 	})
 

--- a/skills/working-with-instances-manager/SKILL.md
+++ b/skills/working-with-instances-manager/SKILL.md
@@ -17,7 +17,7 @@ The instances manager handles:
 - Project detection and grouping
 - Configuration merging (workspace, project, agent configs)
 - Agent settings files and automatic onboarding configuration
-- Interactive terminal sessions with running instances
+- Interactive terminal sessions with instances (auto-starts if needed)
 
 ## Creating the Manager
 
@@ -230,7 +230,7 @@ fmt.Fprintln(cmd.OutOrStdout(), instanceID)
 
 ### Terminal - Interactive Terminal Session
 
-Connect to a running instance with an interactive terminal (requires ID):
+Connect to an instance with an interactive terminal (requires ID). If the instance is not running, it will be automatically started first:
 
 ```go
 err := manager.Terminal(cmd.Context(), id, []string{"bash"})
@@ -243,16 +243,16 @@ if err != nil {
 ```
 
 **Terminal Method Behavior:**
-- Verifies the instance exists and is in a running state
+- Verifies the instance exists and has a runtime configured
+- Auto-starts the instance if it is not in a running state
 - Checks if the runtime implements the `runtime.Terminal` interface
 - Delegates to the runtime's Terminal implementation
-- Returns an error if the instance is not running or runtime doesn't support terminals
 
 **Key Points:**
-- Uses a read lock (doesn't modify instance state)
+- Automatically starts stopped instances before connecting
 - Command is a slice of strings: `[]string{"bash"}` or `[]string{"claude-code", "--debug"}`
 - Returns `ErrInstanceNotFound` if instance doesn't exist
-- Returns an error if instance state is not "running"
+- Returns an error if auto-start fails
 - Returns an error if the runtime doesn't implement `runtime.Terminal` interface
 
 **For commands accepting name or ID:**


### PR DESCRIPTION
Terminal command now automatically starts stopped workspace instances
instead of returning an error, removing the need to manually run
'workspace start' before connecting.

Fixes #159