### PR TITLE
feat(Onecli): starting onecli containers as part of Podman agent implementation

### DIFF
--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -15,6 +15,7 @@
 package podman
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -25,6 +26,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
+	"github.com/openkaiden/kdn/pkg/runtime/podman/pods"
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
@@ -114,19 +116,16 @@ func (p *podmanRuntime) buildImage(ctx context.Context, imageName, instanceDir s
 	return nil
 }
 
-// buildContainerArgs builds the arguments for creating a podman container.
+// buildContainerArgs builds the arguments for creating the workspace container inside the pod.
 func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string) ([]string, error) {
-	args := []string{"create", "--name", params.Name}
+	args := []string{"create", "--pod", params.Name, "--name", params.Name}
 
 	// Add environment variables from workspace config
 	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Environment != nil {
 		for _, env := range *params.WorkspaceConfig.Environment {
 			if env.Value != nil {
-				// Regular environment variable with a value
 				args = append(args, "-e", fmt.Sprintf("%s=%s", env.Name, *env.Value))
 			} else if env.Secret != nil {
-				// Secret reference - use podman --secret flag
-				// Format: --secret <secret-name>,type=env,target=<ENV_VAR_NAME>
 				secretArg := fmt.Sprintf("%s,type=env,target=%s", *env.Secret, env.Name)
 				args = append(args, "--secret", secretArg)
 			}
@@ -134,7 +133,6 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 	}
 
 	// Mount the source directory at /workspace/sources
-	// This allows symlinks to work correctly with dependencies
 	args = append(args, "-v", fmt.Sprintf("%s:/workspace/sources:Z", params.SourcePath))
 
 	// Mount additional directories if specified
@@ -171,6 +169,8 @@ func (p *podmanRuntime) createContainer(ctx context.Context, args []string) (str
 }
 
 // Create creates a new Podman runtime instance.
+// It uses kube play to create a pod with onecli services from the embedded YAML,
+// then adds the workspace container to the same pod.
 func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
@@ -187,8 +187,6 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
-	// Clean up instance directory after use (whether success or error)
-	// The Containerfile and sudoers are only needed during image build
 	defer os.RemoveAll(instanceDir)
 
 	// Load configurations
@@ -197,7 +195,6 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load image config: %w", err)
 	}
 
-	// Load agent configuration using the agent name from params
 	agentConfig, err := p.config.LoadAgent(params.Agent)
 	if err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load agent config: %w", err)
@@ -218,18 +215,40 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, err
 	}
 
-	// Build container creation arguments
+	// Write the per-workspace pod YAML (pod name = workspace name) to a temporary location
+	// so we can use it with kube play. We'll persist the final files once we have the container ID.
+	tmpPodDir := filepath.Join(instanceDir, "pod")
+	if err := os.MkdirAll(tmpPodDir, 0755); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to create temp pod directory: %w", err)
+	}
+	tmpYAMLPath := filepath.Join(tmpPodDir, podYAMLFile)
+	if err := p.writeTempPodYAML(tmpYAMLPath, params.Name); err != nil {
+		return runtime.RuntimeInfo{}, err
+	}
+
+	// Create the pod with onecli services via kube play (--start=false keeps all containers stopped)
+	stepLogger.Start("Creating onecli services", "Onecli services created")
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "kube", "play", "--start=false", tmpYAMLPath); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to create pod via kube play: %w", err)
+	}
+
+	// Add the workspace container to the pod
+	stepLogger.Start(fmt.Sprintf("Creating workspace container: %s", params.Name), "Workspace container created")
 	createArgs, err := p.buildContainerArgs(params, imageName)
 	if err != nil {
 		return runtime.RuntimeInfo{}, err
 	}
-
-	// Create container and get its ID directly from podman create output
-	stepLogger.Start(fmt.Sprintf("Creating container: %s", params.Name), "Container created")
 	containerID, err := p.createContainer(ctx, createArgs)
 	if err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
+	}
+
+	// Persist pod files keyed by the workspace container ID
+	if err := p.writePodFiles(containerID, params.Name); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to persist pod files: %w", err)
 	}
 
 	// Return RuntimeInfo
@@ -245,4 +264,28 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		State: api.WorkspaceStateStopped,
 		Info:  info,
 	}, nil
+}
+
+// writeTempPodYAML writes the embedded YAML with the pod name replaced to a temporary path.
+func (p *podmanRuntime) writeTempPodYAML(path, workspaceName string) error {
+	yamlContent := p.templatePodYAML(workspaceName)
+	if err := os.WriteFile(path, yamlContent, 0644); err != nil {
+		return fmt.Errorf("failed to write pod YAML: %w", err)
+	}
+	return nil
+}
+
+// templatePodYAML returns the embedded YAML with the pod metadata name replaced.
+func (p *podmanRuntime) templatePodYAML(workspaceName string) []byte {
+	return replaceYAMLPodName(workspaceName)
+}
+
+// replaceYAMLPodName replaces the pod metadata name in the embedded YAML template.
+func replaceYAMLPodName(workspaceName string) []byte {
+	return bytes.Replace(
+		pods.OnecliPodYAML,
+		[]byte("  name: onecli\n"),
+		[]byte("  name: "+workspaceName+"\n"),
+		1,
+	)
 }

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -36,11 +36,11 @@ const defaultOnecliVersion = "1.17"
 
 // podTemplateData holds the values used to render the pod YAML template.
 type podTemplateData struct {
-	Name              string
-	PostgresPort      int
-	OnecliPort        int
-	OnecliMetricsPort int
-	OnecliVersion     string
+	Name            string
+	PostgresPort    int
+	OnecliWebPort   int
+	OnecliProxyPort int
+	OnecliVersion   string
 }
 
 // validateCreateParams validates the create parameters.
@@ -265,11 +265,11 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 
 	// Render the pod YAML template
 	tmplData := podTemplateData{
-		Name:              params.Name,
-		PostgresPort:      freePorts[0],
-		OnecliPort:        freePorts[1],
-		OnecliMetricsPort: freePorts[2],
-		OnecliVersion:     defaultOnecliVersion,
+		Name:            params.Name,
+		PostgresPort:    freePorts[0],
+		OnecliWebPort:   freePorts[1],
+		OnecliProxyPort: freePorts[2],
+		OnecliVersion:   defaultOnecliVersion,
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -18,9 +18,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/logger"
@@ -29,6 +31,17 @@ import (
 	"github.com/openkaiden/kdn/pkg/runtime/podman/pods"
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
+
+const defaultOnecliVersion = "1.17"
+
+// podTemplateData holds the values used to render the pod YAML template.
+type podTemplateData struct {
+	Name              string
+	PostgresPort      int
+	OnecliPort        int
+	OnecliMetricsPort int
+	OnecliVersion     string
+}
 
 // validateCreateParams validates the create parameters.
 func (p *podmanRuntime) validateCreateParams(params runtime.CreateParams) error {
@@ -168,8 +181,37 @@ func (p *podmanRuntime) createContainer(ctx context.Context, args []string) (str
 	return strings.TrimSpace(string(output)), nil
 }
 
+// findFreePorts returns n free TCP ports on 127.0.0.1.
+// Each port is obtained by binding to :0 and immediately closing the listener.
+func findFreePorts(n int) ([]int, error) {
+	ports := make([]int, 0, n)
+	for range n {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, fmt.Errorf("failed to find free port: %w", err)
+		}
+		port := l.Addr().(*net.TCPAddr).Port
+		l.Close()
+		ports = append(ports, port)
+	}
+	return ports, nil
+}
+
+// renderPodYAML renders the embedded pod YAML template with the given data.
+func renderPodYAML(data podTemplateData) ([]byte, error) {
+	tmpl, err := template.New("pod").Parse(string(pods.OnecliPodYAML))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pod template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to render pod template: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 // Create creates a new Podman runtime instance.
-// It uses kube play to create a pod with onecli services from the embedded YAML,
+// It uses kube play to create a pod with onecli services from the embedded YAML template,
 // then adds the workspace container to the same pod.
 func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
 	stepLogger := steplogger.FromContext(ctx)
@@ -215,14 +257,27 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, err
 	}
 
-	// Write the per-workspace pod YAML (pod name = workspace name) to a temporary location
-	// so we can use it with kube play. We'll persist the final files once we have the container ID.
+	// Allocate random free ports for the pod
+	freePorts, err := findFreePorts(3)
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to allocate free ports: %w", err)
+	}
+
+	// Render the pod YAML template
+	tmplData := podTemplateData{
+		Name:              params.Name,
+		PostgresPort:      freePorts[0],
+		OnecliPort:        freePorts[1],
+		OnecliMetricsPort: freePorts[2],
+		OnecliVersion:     defaultOnecliVersion,
+	}
+
 	tmpPodDir := filepath.Join(instanceDir, "pod")
 	if err := os.MkdirAll(tmpPodDir, 0755); err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to create temp pod directory: %w", err)
 	}
 	tmpYAMLPath := filepath.Join(tmpPodDir, podYAMLFile)
-	if err := p.writeTempPodYAML(tmpYAMLPath, params.Name); err != nil {
+	if err := writePodYAMLFile(tmpYAMLPath, tmplData); err != nil {
 		return runtime.RuntimeInfo{}, err
 	}
 
@@ -247,7 +302,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}
 
 	// Persist pod files keyed by the workspace container ID
-	if err := p.writePodFiles(containerID, params.Name); err != nil {
+	if err := p.writePodFiles(containerID, tmplData); err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to persist pod files: %w", err)
 	}
 
@@ -266,26 +321,14 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}, nil
 }
 
-// writeTempPodYAML writes the embedded YAML with the pod name replaced to a temporary path.
-func (p *podmanRuntime) writeTempPodYAML(path, workspaceName string) error {
-	yamlContent := p.templatePodYAML(workspaceName)
-	if err := os.WriteFile(path, yamlContent, 0644); err != nil {
+// writePodYAMLFile renders and writes the pod YAML template to the given path.
+func writePodYAMLFile(path string, data podTemplateData) error {
+	content, err := renderPodYAML(data)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
 		return fmt.Errorf("failed to write pod YAML: %w", err)
 	}
 	return nil
-}
-
-// templatePodYAML returns the embedded YAML with the pod metadata name replaced.
-func (p *podmanRuntime) templatePodYAML(workspaceName string) []byte {
-	return replaceYAMLPodName(workspaceName)
-}
-
-// replaceYAMLPodName replaces the pod metadata name in the embedded YAML template.
-func replaceYAMLPodName(workspaceName string) []byte {
-	return bytes.Replace(
-		pods.OnecliPodYAML,
-		[]byte("  name: onecli\n"),
-		[]byte("  name: "+workspaceName+"\n"),
-		1,
-	)
 }

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -415,9 +415,10 @@ func TestBuildContainerArgs(t *testing.T) {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
 
-		// Verify basic structure
+		// Verify basic structure (includes --pod for single-pod architecture)
 		expectedArgs := []string{
 			"create",
+			"--pod", "test-workspace",
 			"--name", "test-workspace",
 			"-v", fmt.Sprintf("%s:/workspace/sources:Z", sourcePath),
 			"-w", "/workspace/sources",
@@ -696,7 +697,7 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Verify Start was called 4 times with correct messages
+	// Verify Start was called 5 times with correct messages
 	expectedSteps := []stepCall{
 		{
 			inProgress: "Creating temporary build directory",
@@ -711,8 +712,12 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 			completed:  "Container image built",
 		},
 		{
-			inProgress: "Creating container: test-workspace",
-			completed:  "Container created",
+			inProgress: "Creating onecli services",
+			completed:  "Onecli services created",
+		},
+		{
+			inProgress: "Creating workspace container: test-workspace",
+			completed:  "Workspace container created",
 		},
 	}
 
@@ -963,16 +968,17 @@ func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called 4 times (all steps)
-	if len(fakeLogger.startCalls) != 4 {
-		t.Fatalf("Expected 4 Start() calls, got %d", len(fakeLogger.startCalls))
+	// Verify Start was called 5 times (all steps through workspace container creation)
+	if len(fakeLogger.startCalls) != 5 {
+		t.Fatalf("Expected 5 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
 		"Creating temporary build directory",
 		"Generating Containerfile",
 		"Building container image: kdn-test-workspace",
-		"Creating container: test-workspace",
+		"Creating onecli services",
+		"Creating workspace container: test-workspace",
 	}
 
 	for i, expected := range expectedSteps {

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -17,7 +17,9 @@ package podman
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
@@ -85,6 +87,59 @@ func (p *podmanRuntime) Initialize(storageDir string) error {
 	}
 
 	return nil
+}
+
+const (
+	podYAMLFile = "onecli-pod.yaml"
+	podNameFile = "podname"
+)
+
+// podDir returns the directory for storing pod metadata for a given container ID.
+func (p *podmanRuntime) podDir(containerID string) string {
+	return filepath.Join(p.storageDir, "pods", containerID)
+}
+
+// podYAMLPath returns the path to the pod YAML for a given container ID.
+func (p *podmanRuntime) podYAMLPath(containerID string) string {
+	return filepath.Join(p.podDir(containerID), podYAMLFile)
+}
+
+// podNamePath returns the path to the pod name file for a given container ID.
+func (p *podmanRuntime) podNamePath(containerID string) string {
+	return filepath.Join(p.podDir(containerID), podNameFile)
+}
+
+// writePodFiles writes the per-workspace pod YAML and pod name file.
+// The YAML is derived from the embedded template with the pod name set to the workspace name.
+func (p *podmanRuntime) writePodFiles(containerID, workspaceName string) error {
+	dir := p.podDir(containerID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create pod directory: %w", err)
+	}
+
+	yamlContent := replaceYAMLPodName(workspaceName)
+
+	if err := os.WriteFile(p.podYAMLPath(containerID), yamlContent, 0644); err != nil {
+		return fmt.Errorf("failed to write pod YAML: %w", err)
+	}
+	if err := os.WriteFile(p.podNamePath(containerID), []byte(workspaceName), 0644); err != nil {
+		return fmt.Errorf("failed to write pod name file: %w", err)
+	}
+	return nil
+}
+
+// readPodName reads the pod name for a given container ID from the stored file.
+func (p *podmanRuntime) readPodName(containerID string) (string, error) {
+	data, err := os.ReadFile(p.podNamePath(containerID))
+	if err != nil {
+		return "", fmt.Errorf("failed to read pod name: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// cleanupPodFiles removes the pod metadata directory for a given container ID.
+func (p *podmanRuntime) cleanupPodFiles(containerID string) {
+	os.RemoveAll(p.podDir(containerID))
 }
 
 // ListAgents implements runtime.AgentLister.

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -110,19 +110,17 @@ func (p *podmanRuntime) podNamePath(containerID string) string {
 }
 
 // writePodFiles writes the per-workspace pod YAML and pod name file.
-// The YAML is derived from the embedded template with the pod name set to the workspace name.
-func (p *podmanRuntime) writePodFiles(containerID, workspaceName string) error {
+// The YAML is rendered from the embedded template using the supplied data.
+func (p *podmanRuntime) writePodFiles(containerID string, data podTemplateData) error {
 	dir := p.podDir(containerID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create pod directory: %w", err)
 	}
 
-	yamlContent := replaceYAMLPodName(workspaceName)
-
-	if err := os.WriteFile(p.podYAMLPath(containerID), yamlContent, 0644); err != nil {
-		return fmt.Errorf("failed to write pod YAML: %w", err)
+	if err := writePodYAMLFile(p.podYAMLPath(containerID), data); err != nil {
+		return err
 	}
-	if err := os.WriteFile(p.podNamePath(containerID), []byte(workspaceName), 0644); err != nil {
+	if err := os.WriteFile(p.podNamePath(containerID), []byte(data.Name), 0644); err != nil {
 		return fmt.Errorf("failed to write pod name file: %w", err)
 	}
 	return nil

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
@@ -91,7 +92,6 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 		storageDir := t.TempDir()
 		rt := newWithDeps(system.New(), exec.New())
 
-		// Type assert to StorageAware to access Initialize method
 		storageAware, ok := rt.(interface{ Initialize(string) error })
 		if !ok {
 			t.Fatal("Expected runtime to implement StorageAware interface")
@@ -102,19 +102,16 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 			t.Fatalf("Initialize() failed: %v", err)
 		}
 
-		// Verify config directory was created
 		configDir := filepath.Join(storageDir, "config")
 		if _, err := os.Stat(configDir); os.IsNotExist(err) {
 			t.Error("Config directory was not created")
 		}
 
-		// Verify default image config was created
 		imageConfigPath := filepath.Join(configDir, config.ImageConfigFileName)
 		if _, err := os.Stat(imageConfigPath); os.IsNotExist(err) {
 			t.Error("Default image config was not created")
 		}
 
-		// Verify default claude config was created
 		claudeConfigPath := filepath.Join(configDir, config.ClaudeConfigFileName)
 		if _, err := os.Stat(claudeConfigPath); os.IsNotExist(err) {
 			t.Error("Default claude config was not created")
@@ -126,7 +123,6 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 
 		rt := newWithDeps(system.New(), exec.New())
 
-		// Type assert to StorageAware to access Initialize method
 		storageAware, ok := rt.(interface{ Initialize(string) error })
 		if !ok {
 			t.Fatal("Expected runtime to implement StorageAware interface")
@@ -144,19 +140,16 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 		storageDir := t.TempDir()
 		rt := newWithDeps(system.New(), exec.New())
 
-		// Type assert to StorageAware to access Initialize method
 		storageAware, ok := rt.(interface{ Initialize(string) error })
 		if !ok {
 			t.Fatal("Expected runtime to implement StorageAware interface")
 		}
 
-		// Initialize once to create defaults
 		err := storageAware.Initialize(storageDir)
 		if err != nil {
 			t.Fatalf("First Initialize() failed: %v", err)
 		}
 
-		// Modify the image config
 		configDir := filepath.Join(storageDir, "config")
 		imageConfigPath := filepath.Join(configDir, config.ImageConfigFileName)
 		customContent := []byte(`{"version":"40","packages":[],"sudo":[],"run_commands":[]}`)
@@ -164,7 +157,6 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 			t.Fatalf("Failed to write custom config: %v", err)
 		}
 
-		// Initialize again
 		rt2 := newWithDeps(system.New(), exec.New())
 		storageAware2, ok := rt2.(interface{ Initialize(string) error })
 		if !ok {
@@ -176,7 +168,6 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 			t.Fatalf("Second Initialize() failed: %v", err)
 		}
 
-		// Verify custom config was not overwritten
 		content, err := os.ReadFile(imageConfigPath)
 		if err != nil {
 			t.Fatalf("Failed to read config: %v", err)
@@ -186,6 +177,119 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 			t.Error("Custom config was overwritten")
 		}
 	})
+}
+
+func TestWritePodFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates YAML with workspace-specific pod name", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{storageDir: t.TempDir()}
+		containerID := "abc123"
+		workspaceName := "my-project"
+
+		err := p.writePodFiles(containerID, workspaceName)
+		if err != nil {
+			t.Fatalf("writePodFiles() failed: %v", err)
+		}
+
+		content, err := os.ReadFile(p.podYAMLPath(containerID))
+		if err != nil {
+			t.Fatalf("Failed to read pod YAML: %v", err)
+		}
+
+		if !strings.Contains(string(content), "  name: my-project\n") {
+			t.Error("Pod YAML should contain workspace-specific pod name 'my-project'")
+		}
+
+		// Container name within pod should remain unchanged
+		if !strings.Contains(string(content), "- name: onecli\n") {
+			t.Error("Container name within pod should remain 'onecli'")
+		}
+	})
+
+	t.Run("writes pod name file", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{storageDir: t.TempDir()}
+		containerID := "def456"
+		workspaceName := "test-ws"
+
+		err := p.writePodFiles(containerID, workspaceName)
+		if err != nil {
+			t.Fatalf("writePodFiles() failed: %v", err)
+		}
+
+		name, err := p.readPodName(containerID)
+		if err != nil {
+			t.Fatalf("readPodName() failed: %v", err)
+		}
+
+		if name != "test-ws" {
+			t.Errorf("readPodName() = %q, want %q", name, "test-ws")
+		}
+	})
+
+	t.Run("returns error for missing pod name file", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{storageDir: t.TempDir()}
+
+		_, err := p.readPodName("nonexistent")
+		if err == nil {
+			t.Error("Expected error for missing pod name file, got nil")
+		}
+	})
+}
+
+func TestCleanupPodFiles(t *testing.T) {
+	t.Parallel()
+
+	p := &podmanRuntime{storageDir: t.TempDir()}
+	containerID := "abc123"
+
+	if err := p.writePodFiles(containerID, "my-ws"); err != nil {
+		t.Fatalf("writePodFiles() failed: %v", err)
+	}
+
+	if _, err := os.Stat(p.podDir(containerID)); os.IsNotExist(err) {
+		t.Fatal("Pod directory should exist before cleanup")
+	}
+
+	p.cleanupPodFiles(containerID)
+
+	if _, err := os.Stat(p.podDir(containerID)); !os.IsNotExist(err) {
+		t.Error("Pod directory should be removed after cleanup")
+	}
+}
+
+func TestReplaceYAMLPodName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		workspace string
+		expected  string
+	}{
+		{"my-project", "  name: my-project\n"},
+		{"test", "  name: test\n"},
+		{"foo-bar-baz", "  name: foo-bar-baz\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.workspace, func(t *testing.T) {
+			t.Parallel()
+
+			result := replaceYAMLPodName(tt.workspace)
+			if !strings.Contains(string(result), tt.expected) {
+				t.Errorf("replaceYAMLPodName(%q) should contain %q", tt.workspace, tt.expected)
+			}
+			// The original "  name: onecli\n" should be replaced
+			if strings.Contains(string(result), "  name: onecli\n") {
+				t.Errorf("replaceYAMLPodName(%q) should not contain original 'onecli' pod name", tt.workspace)
+			}
+		})
+	}
 }
 
 func TestPodmanRuntime_WorkspaceSourcesPath(t *testing.T) {
@@ -198,7 +302,6 @@ func TestPodmanRuntime_WorkspaceSourcesPath(t *testing.T) {
 		t.Errorf("WorkspaceSourcesPath() = %q, want %q", path, "/workspace/sources")
 	}
 
-	// Verify it's consistent across calls
 	path2 := rt.WorkspaceSourcesPath()
 	if path != path2 {
 		t.Errorf("WorkspaceSourcesPath() inconsistent: %q != %q", path, path2)
@@ -254,7 +357,6 @@ func TestPodmanRuntime_ListAgents(t *testing.T) {
 			t.Fatalf("ListAgents() failed: %v", err)
 		}
 
-		// Default initialization creates config files for all default agents
 		expected := []string{"claude", "cursor", "goose", "opencode"}
 		if !slices.Equal(agents, expected) {
 			t.Errorf("Expected %v, got: %v", expected, agents)

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -182,14 +182,21 @@ func TestPodmanRuntime_Initialize(t *testing.T) {
 func TestWritePodFiles(t *testing.T) {
 	t.Parallel()
 
-	t.Run("creates YAML with workspace-specific pod name", func(t *testing.T) {
+	t.Run("creates YAML with workspace-specific pod name and ports", func(t *testing.T) {
 		t.Parallel()
 
 		p := &podmanRuntime{storageDir: t.TempDir()}
 		containerID := "abc123"
-		workspaceName := "my-project"
 
-		err := p.writePodFiles(containerID, workspaceName)
+		data := podTemplateData{
+			Name:              "my-project",
+			PostgresPort:      30000,
+			OnecliPort:        30001,
+			OnecliMetricsPort: 30002,
+			OnecliVersion:     "1.17",
+		}
+
+		err := p.writePodFiles(containerID, data)
 		if err != nil {
 			t.Fatalf("writePodFiles() failed: %v", err)
 		}
@@ -199,13 +206,27 @@ func TestWritePodFiles(t *testing.T) {
 			t.Fatalf("Failed to read pod YAML: %v", err)
 		}
 
-		if !strings.Contains(string(content), "  name: my-project\n") {
+		yamlStr := string(content)
+
+		if !strings.Contains(yamlStr, "  name: my-project\n") {
 			t.Error("Pod YAML should contain workspace-specific pod name 'my-project'")
 		}
 
-		// Container name within pod should remain unchanged
-		if !strings.Contains(string(content), "- name: onecli\n") {
+		if !strings.Contains(yamlStr, "- name: onecli\n") {
 			t.Error("Container name within pod should remain 'onecli'")
+		}
+
+		if !strings.Contains(yamlStr, "hostPort: 30000") {
+			t.Error("Pod YAML should contain postgres hostPort 30000")
+		}
+		if !strings.Contains(yamlStr, "hostPort: 30001") {
+			t.Error("Pod YAML should contain onecli hostPort 30001")
+		}
+		if !strings.Contains(yamlStr, "hostPort: 30002") {
+			t.Error("Pod YAML should contain onecli metrics hostPort 30002")
+		}
+		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
+			t.Error("Pod YAML should contain versioned onecli image")
 		}
 	})
 
@@ -214,9 +235,16 @@ func TestWritePodFiles(t *testing.T) {
 
 		p := &podmanRuntime{storageDir: t.TempDir()}
 		containerID := "def456"
-		workspaceName := "test-ws"
 
-		err := p.writePodFiles(containerID, workspaceName)
+		data := podTemplateData{
+			Name:              "test-ws",
+			PostgresPort:      40000,
+			OnecliPort:        40001,
+			OnecliMetricsPort: 40002,
+			OnecliVersion:     "1.17",
+		}
+
+		err := p.writePodFiles(containerID, data)
 		if err != nil {
 			t.Fatalf("writePodFiles() failed: %v", err)
 		}
@@ -249,7 +277,15 @@ func TestCleanupPodFiles(t *testing.T) {
 	p := &podmanRuntime{storageDir: t.TempDir()}
 	containerID := "abc123"
 
-	if err := p.writePodFiles(containerID, "my-ws"); err != nil {
+	data := podTemplateData{
+		Name:              "my-ws",
+		PostgresPort:      50000,
+		OnecliPort:        50001,
+		OnecliMetricsPort: 50002,
+		OnecliVersion:     "1.17",
+	}
+
+	if err := p.writePodFiles(containerID, data); err != nil {
 		t.Fatalf("writePodFiles() failed: %v", err)
 	}
 
@@ -264,32 +300,125 @@ func TestCleanupPodFiles(t *testing.T) {
 	}
 }
 
-func TestReplaceYAMLPodName(t *testing.T) {
+func TestRenderPodYAML(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		workspace string
-		expected  string
-	}{
-		{"my-project", "  name: my-project\n"},
-		{"test", "  name: test\n"},
-		{"foo-bar-baz", "  name: foo-bar-baz\n"},
-	}
+	t.Run("renders all template fields", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.workspace, func(t *testing.T) {
-			t.Parallel()
+		data := podTemplateData{
+			Name:              "my-project",
+			PostgresPort:      32100,
+			OnecliPort:        32101,
+			OnecliMetricsPort: 32102,
+			OnecliVersion:     "1.17",
+		}
 
-			result := replaceYAMLPodName(tt.workspace)
-			if !strings.Contains(string(result), tt.expected) {
-				t.Errorf("replaceYAMLPodName(%q) should contain %q", tt.workspace, tt.expected)
+		result, err := renderPodYAML(data)
+		if err != nil {
+			t.Fatalf("renderPodYAML() failed: %v", err)
+		}
+
+		yamlStr := string(result)
+
+		if !strings.Contains(yamlStr, "  name: my-project\n") {
+			t.Error("Expected rendered YAML to contain pod name 'my-project'")
+		}
+		if !strings.Contains(yamlStr, "hostPort: 32100") {
+			t.Error("Expected rendered YAML to contain postgres hostPort 32100")
+		}
+		if !strings.Contains(yamlStr, "hostPort: 32101") {
+			t.Error("Expected rendered YAML to contain onecli hostPort 32101")
+		}
+		if !strings.Contains(yamlStr, "hostPort: 32102") {
+			t.Error("Expected rendered YAML to contain onecli metrics hostPort 32102")
+		}
+		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
+			t.Error("Expected rendered YAML to contain versioned onecli image")
+		}
+		if strings.Contains(yamlStr, "volumeMounts") {
+			t.Error("Expected rendered YAML to NOT contain volumeMounts")
+		}
+		if strings.Contains(yamlStr, "volumes:") {
+			t.Error("Expected rendered YAML to NOT contain volumes section")
+		}
+	})
+
+	t.Run("does not contain original template placeholders", func(t *testing.T) {
+		t.Parallel()
+
+		data := podTemplateData{
+			Name:              "test",
+			PostgresPort:      10000,
+			OnecliPort:        10001,
+			OnecliMetricsPort: 10002,
+			OnecliVersion:     "2.0",
+		}
+
+		result, err := renderPodYAML(data)
+		if err != nil {
+			t.Fatalf("renderPodYAML() failed: %v", err)
+		}
+
+		yamlStr := string(result)
+
+		if strings.Contains(yamlStr, "{{") || strings.Contains(yamlStr, "}}") {
+			t.Error("Expected rendered YAML to not contain any template placeholders")
+		}
+	})
+}
+
+func TestFindFreePorts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns requested number of ports", func(t *testing.T) {
+		t.Parallel()
+
+		ports, err := findFreePorts(3)
+		if err != nil {
+			t.Fatalf("findFreePorts() failed: %v", err)
+		}
+
+		if len(ports) != 3 {
+			t.Fatalf("Expected 3 ports, got %d", len(ports))
+		}
+
+		for i, port := range ports {
+			if port <= 0 || port > 65535 {
+				t.Errorf("Port %d has invalid value: %d", i, port)
 			}
-			// The original "  name: onecli\n" should be replaced
-			if strings.Contains(string(result), "  name: onecli\n") {
-				t.Errorf("replaceYAMLPodName(%q) should not contain original 'onecli' pod name", tt.workspace)
+		}
+	})
+
+	t.Run("returns unique ports", func(t *testing.T) {
+		t.Parallel()
+
+		ports, err := findFreePorts(3)
+		if err != nil {
+			t.Fatalf("findFreePorts() failed: %v", err)
+		}
+
+		seen := make(map[int]bool)
+		for _, port := range ports {
+			if seen[port] {
+				t.Errorf("Duplicate port found: %d", port)
 			}
-		})
-	}
+			seen[port] = true
+		}
+	})
+
+	t.Run("returns zero ports for zero count", func(t *testing.T) {
+		t.Parallel()
+
+		ports, err := findFreePorts(0)
+		if err != nil {
+			t.Fatalf("findFreePorts() failed: %v", err)
+		}
+
+		if len(ports) != 0 {
+			t.Errorf("Expected 0 ports, got %d", len(ports))
+		}
+	})
 }
 
 func TestPodmanRuntime_WorkspaceSourcesPath(t *testing.T) {

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -189,11 +189,11 @@ func TestWritePodFiles(t *testing.T) {
 		containerID := "abc123"
 
 		data := podTemplateData{
-			Name:              "my-project",
-			PostgresPort:      30000,
-			OnecliPort:        30001,
-			OnecliMetricsPort: 30002,
-			OnecliVersion:     "1.17",
+			Name:            "my-project",
+			PostgresPort:    30000,
+			OnecliWebPort:   30001,
+			OnecliProxyPort: 30002,
+			OnecliVersion:   "1.17",
 		}
 
 		err := p.writePodFiles(containerID, data)
@@ -220,10 +220,10 @@ func TestWritePodFiles(t *testing.T) {
 			t.Error("Pod YAML should contain postgres hostPort 30000")
 		}
 		if !strings.Contains(yamlStr, "hostPort: 30001") {
-			t.Error("Pod YAML should contain onecli hostPort 30001")
+			t.Error("Pod YAML should contain onecli web hostPort 30001")
 		}
 		if !strings.Contains(yamlStr, "hostPort: 30002") {
-			t.Error("Pod YAML should contain onecli metrics hostPort 30002")
+			t.Error("Pod YAML should contain onecli proxy hostPort 30002")
 		}
 		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
 			t.Error("Pod YAML should contain versioned onecli image")
@@ -237,11 +237,11 @@ func TestWritePodFiles(t *testing.T) {
 		containerID := "def456"
 
 		data := podTemplateData{
-			Name:              "test-ws",
-			PostgresPort:      40000,
-			OnecliPort:        40001,
-			OnecliMetricsPort: 40002,
-			OnecliVersion:     "1.17",
+			Name:            "test-ws",
+			PostgresPort:    40000,
+			OnecliWebPort:   40001,
+			OnecliProxyPort: 40002,
+			OnecliVersion:   "1.17",
 		}
 
 		err := p.writePodFiles(containerID, data)
@@ -278,11 +278,11 @@ func TestCleanupPodFiles(t *testing.T) {
 	containerID := "abc123"
 
 	data := podTemplateData{
-		Name:              "my-ws",
-		PostgresPort:      50000,
-		OnecliPort:        50001,
-		OnecliMetricsPort: 50002,
-		OnecliVersion:     "1.17",
+		Name:            "my-ws",
+		PostgresPort:    50000,
+		OnecliWebPort:   50001,
+		OnecliProxyPort: 50002,
+		OnecliVersion:   "1.17",
 	}
 
 	if err := p.writePodFiles(containerID, data); err != nil {
@@ -307,11 +307,11 @@ func TestRenderPodYAML(t *testing.T) {
 		t.Parallel()
 
 		data := podTemplateData{
-			Name:              "my-project",
-			PostgresPort:      32100,
-			OnecliPort:        32101,
-			OnecliMetricsPort: 32102,
-			OnecliVersion:     "1.17",
+			Name:            "my-project",
+			PostgresPort:    32100,
+			OnecliWebPort:   32101,
+			OnecliProxyPort: 32102,
+			OnecliVersion:   "1.17",
 		}
 
 		result, err := renderPodYAML(data)
@@ -328,10 +328,10 @@ func TestRenderPodYAML(t *testing.T) {
 			t.Error("Expected rendered YAML to contain postgres hostPort 32100")
 		}
 		if !strings.Contains(yamlStr, "hostPort: 32101") {
-			t.Error("Expected rendered YAML to contain onecli hostPort 32101")
+			t.Error("Expected rendered YAML to contain onecli web hostPort 32101")
 		}
 		if !strings.Contains(yamlStr, "hostPort: 32102") {
-			t.Error("Expected rendered YAML to contain onecli metrics hostPort 32102")
+			t.Error("Expected rendered YAML to contain onecli proxy hostPort 32102")
 		}
 		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
 			t.Error("Expected rendered YAML to contain versioned onecli image")
@@ -348,11 +348,11 @@ func TestRenderPodYAML(t *testing.T) {
 		t.Parallel()
 
 		data := podTemplateData{
-			Name:              "test",
-			PostgresPort:      10000,
-			OnecliPort:        10001,
-			OnecliMetricsPort: 10002,
-			OnecliVersion:     "2.0",
+			Name:            "test",
+			PostgresPort:    10000,
+			OnecliWebPort:   10001,
+			OnecliProxyPort: 10002,
+			OnecliVersion:   "2.0",
 		}
 
 		result, err := renderPodYAML(data)

--- a/pkg/runtime/podman/pods/embed.go
+++ b/pkg/runtime/podman/pods/embed.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pods
+
+import _ "embed"
+
+//go:embed onecli-pod.yaml
+var OnecliPodYAML []byte

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: onecli
+  labels:
+    app: onecli
+spec:
+  restartPolicy: Always
+  containers:
+    - name: postgres
+      image: postgres:18-alpine
+      env:
+        - name: POSTGRES_USER
+          value: "onecli"
+        - name: POSTGRES_PASSWORD
+          value: "onecli"
+        - name: POSTGRES_DB
+          value: "onecli"
+      ports:
+        - containerPort: 5432
+          hostPort: 5432
+          hostIP: "127.0.0.1"
+        - containerPort: 10254
+          hostPort: 10254
+          hostIP: "127.0.0.1"
+        - containerPort: 10255
+          hostPort: 10255
+          hostIP: "127.0.0.1"
+      volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql
+      readinessProbe:
+        exec:
+          command:
+            - pg_isready
+            - "-U"
+            - onecli
+        initialDelaySeconds: 15
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 10
+
+    - name: onecli
+      image: ghcr.io/onecli/onecli:latest
+      env:
+        - name: DATABASE_URL
+          value: "postgresql://onecli:onecli@localhost:5432/onecli"
+        - name: NEXTAUTH_SECRET
+          value: ""
+        - name: NEXT_PUBLIC_APP_URL
+          value: "http://127.0.0.1:10254"
+        - name: APP_URL
+          value: "http://127.0.0.1:10254"
+      volumeMounts:
+        - name: app-data
+          mountPath: /app/data
+
+  volumes:
+    - name: pgdata
+      persistentVolumeClaim:
+        claimName: pgdata
+    - name: app-data
+      persistentVolumeClaim:
+        claimName: app-data

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -20,12 +20,6 @@ spec:
         - containerPort: 5432
           hostPort: {{.PostgresPort}}
           hostIP: "127.0.0.1"
-        - containerPort: 10254
-          hostPort: {{.OnecliPort}}
-          hostIP: "127.0.0.1"
-        - containerPort: 10255
-          hostPort: {{.OnecliMetricsPort}}
-          hostIP: "127.0.0.1"
       readinessProbe:
         exec:
           command:
@@ -48,3 +42,10 @@ spec:
           value: "http://127.0.0.1:10254"
         - name: APP_URL
           value: "http://127.0.0.1:10254"
+      ports:
+        - containerPort: 10254
+          hostPort: {{.OnecliWebPort}}
+          hostIP: "127.0.0.1"
+        - containerPort: 10255
+          hostPort: {{.OnecliProxyPort}}
+          hostIP: "127.0.0.1"

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: onecli
+  name: {{.Name}}
   labels:
     app: onecli
 spec:
@@ -18,17 +18,14 @@ spec:
           value: "onecli"
       ports:
         - containerPort: 5432
-          hostPort: 5432
+          hostPort: {{.PostgresPort}}
           hostIP: "127.0.0.1"
         - containerPort: 10254
-          hostPort: 10254
+          hostPort: {{.OnecliPort}}
           hostIP: "127.0.0.1"
         - containerPort: 10255
-          hostPort: 10255
+          hostPort: {{.OnecliMetricsPort}}
           hostIP: "127.0.0.1"
-      volumeMounts:
-        - name: pgdata
-          mountPath: /var/lib/postgresql
       readinessProbe:
         exec:
           command:
@@ -41,7 +38,7 @@ spec:
         failureThreshold: 10
 
     - name: onecli
-      image: ghcr.io/onecli/onecli:latest
+      image: ghcr.io/onecli/onecli:{{.OnecliVersion}}
       env:
         - name: DATABASE_URL
           value: "postgresql://onecli:onecli@localhost:5432/onecli"
@@ -51,14 +48,3 @@ spec:
           value: "http://127.0.0.1:10254"
         - name: APP_URL
           value: "http://127.0.0.1:10254"
-      volumeMounts:
-        - name: app-data
-          mountPath: /app/data
-
-  volumes:
-    - name: pgdata
-      persistentVolumeClaim:
-        claimName: pgdata
-    - name: app-data
-      persistentVolumeClaim:
-        claimName: app-data

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -25,22 +25,21 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-// Remove removes a Podman container and its associated resources.
+// Remove removes the workspace pod and all its containers.
 func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
 
-	// Validate the ID parameter
 	if id == "" {
 		return fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Check if the container exists and get its state
+	// Check if the workspace container exists and get its state
 	stepLogger.Start("Checking container state", "Container state checked")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
-		// If the container doesn't exist, treat it as already removed (idempotent)
 		if isNotFoundError(err) {
+			p.cleanupPodFiles(id)
 			return nil
 		}
 		stepLogger.Fail(err)
@@ -54,22 +53,22 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Remove the container
-	stepLogger.Start(fmt.Sprintf("Removing container: %s", id), "Container removed")
-	if err := p.removeContainer(ctx, id); err != nil {
-		stepLogger.Fail(err)
-		return err
+	// Resolve the pod name
+	podName, err := p.readPodName(id)
+	if err != nil {
+		return fmt.Errorf("failed to resolve pod name: %w", err)
 	}
 
-	return nil
-}
-
-// removeContainer removes a podman container by ID.
-func (p *podmanRuntime) removeContainer(ctx context.Context, id string) error {
+	// Remove the entire pod and all its containers
+	stepLogger.Start(fmt.Sprintf("Removing pod: %s", podName), "Pod removed")
 	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "rm", id); err != nil {
-		return fmt.Errorf("failed to remove podman container: %w", err)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "rm", "-f", podName); err != nil {
+		stepLogger.Fail(err)
+		return fmt.Errorf("failed to remove pod: %w", err)
 	}
+
+	p.cleanupPodFiles(id)
+
 	return nil
 }
 
@@ -79,7 +78,6 @@ func isNotFoundError(err error) bool {
 		return false
 	}
 	errMsg := err.Error()
-	// Check for podman-specific "not found" error messages
 	return strings.Contains(errMsg, "no such container") ||
 		strings.Contains(errMsg, "no such object") ||
 		strings.Contains(errMsg, "error getting container") ||

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -50,29 +51,32 @@ func TestRemove_Success(t *testing.T) {
 	containerID := "abc123def456"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info showing stopped state
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "inspect" {
-			// Return a stopped container
 			return []byte(fmt.Sprintf("%s|stopped|kdn-test", containerID)), nil
 		}
 		return nil, fmt.Errorf("unexpected command: %v", args)
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "my-project")
 
 	err := p.Remove(context.Background(), containerID)
 	if err != nil {
 		t.Fatalf("Remove() failed: %v", err)
 	}
 
-	// Verify Output was called to inspect the container
 	if len(fakeExec.OutputCalls) == 0 {
 		t.Error("Expected Output to be called to inspect container")
 	}
 
-	// Verify Run was called to remove the container
-	fakeExec.AssertRunCalledWith(t, "rm", containerID)
+	// Verify pod rm -f was called
+	fakeExec.AssertRunCalledWith(t, "pod", "rm", "-f", podName)
+
+	// Verify pod files were cleaned up
+	if _, err := os.Stat(p.podDir(containerID)); !os.IsNotExist(err) {
+		t.Error("Expected pod directory to be cleaned up after Remove")
+	}
 }
 
 func TestRemove_IdempotentWhenContainerNotFound(t *testing.T) {
@@ -81,7 +85,6 @@ func TestRemove_IdempotentWhenContainerNotFound(t *testing.T) {
 	containerID := "nonexistent"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return a "not found" error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "inspect" {
 			return nil, fmt.Errorf("failed to inspect container: no such container")
@@ -91,18 +94,15 @@ func TestRemove_IdempotentWhenContainerNotFound(t *testing.T) {
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 
-	// Should succeed without error (idempotent)
 	err := p.Remove(context.Background(), containerID)
 	if err != nil {
 		t.Fatalf("Remove() should be idempotent for non-existent containers, got error: %v", err)
 	}
 
-	// Verify Output was called to check if container exists
 	if len(fakeExec.OutputCalls) == 0 {
 		t.Error("Expected Output to be called to check if container exists")
 	}
 
-	// Run should NOT be called since container doesn't exist
 	if len(fakeExec.RunCalls) > 0 {
 		t.Error("Run should not be called for non-existent container")
 	}
@@ -114,10 +114,8 @@ func TestRemove_RejectsRunningContainer(t *testing.T) {
 	containerID := "running123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info showing running state
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "inspect" {
-			// Return a running container
 			return []byte(fmt.Sprintf("%s|running|kdn-test", containerID)), nil
 		}
 		return nil, fmt.Errorf("unexpected command: %v", args)
@@ -135,24 +133,21 @@ func TestRemove_RejectsRunningContainer(t *testing.T) {
 		t.Errorf("Expected error message to contain %q, got: %v", expectedMsg, err)
 	}
 
-	// Verify Output was called to check container state
 	if len(fakeExec.OutputCalls) == 0 {
 		t.Error("Expected Output to be called to check container state")
 	}
 
-	// Run should NOT be called since container is running
 	if len(fakeExec.RunCalls) > 0 {
 		t.Error("Run should not be called for running container")
 	}
 }
 
-func TestRemove_RemoveContainerFailure(t *testing.T) {
+func TestRemove_PodRemoveFailure(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info showing stopped state
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "inspect" {
 			return []byte(fmt.Sprintf("%s|stopped|kdn-test", containerID)), nil
@@ -160,20 +155,19 @@ func TestRemove_RemoveContainerFailure(t *testing.T) {
 		return nil, fmt.Errorf("unexpected command: %v", args)
 	}
 
-	// Set up RunFunc to return an error when removing
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("device busy")
+		return fmt.Errorf("pod rm failed")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	err := p.Remove(context.Background(), containerID)
 	if err == nil {
-		t.Fatal("Expected error when remove fails, got nil")
+		t.Fatal("Expected error when pod rm fails, got nil")
 	}
 
-	// Verify Run was called
-	fakeExec.AssertRunCalledWith(t, "rm", containerID)
+	fakeExec.AssertRunCalledWith(t, "pod", "rm", "-f", podName)
 }
 
 func TestIsNotFoundError(t *testing.T) {
@@ -253,13 +247,13 @@ func TestRemove_StepLogger_Success(t *testing.T) {
 	containerID := "abc123def456"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return stopped container info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		output := fmt.Sprintf("%s|exited|kdn-test\n", containerID)
 		return []byte(output), nil
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -269,25 +263,22 @@ func TestRemove_StepLogger_Success(t *testing.T) {
 		t.Fatalf("Remove() failed: %v", err)
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify no Fail calls
 	if len(fakeLogger.failCalls) != 0 {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Verify Start was called 2 times with correct messages
 	expectedSteps := []stepCall{
 		{
 			inProgress: "Checking container state",
 			completed:  "Container state checked",
 		},
 		{
-			inProgress: "Removing container: abc123def456",
-			completed:  "Container removed",
+			inProgress: fmt.Sprintf("Removing pod: %s", podName),
+			completed:  "Pod removed",
 		},
 	}
 
@@ -312,7 +303,6 @@ func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return a "not found" error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("no such container: %s", containerID)
 	}
@@ -327,12 +317,10 @@ func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
 		t.Fatalf("Remove() should be idempotent for not found, got error: %v", err)
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (checking container state)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
@@ -341,7 +329,6 @@ func TestRemove_StepLogger_ContainerNotFound(t *testing.T) {
 		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
-	// Verify no Fail calls (idempotent operation)
 	if len(fakeLogger.failCalls) != 0 {
 		t.Errorf("Expected no Fail() calls for not found (idempotent), got %d", len(fakeLogger.failCalls))
 	}
@@ -353,8 +340,6 @@ func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return malformed output (not an error that matches isNotFoundError)
-	// This will cause getContainerInfo to fail with a parsing error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		return []byte("invalid|output"), nil
 	}
@@ -369,12 +354,10 @@ func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Fatal("Expected Remove() to fail, got nil")
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (checking container state)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
@@ -383,13 +366,8 @@ func TestRemove_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
-	// Verify Fail was called once
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
-	}
-
-	if fakeLogger.failCalls[0] == nil {
-		t.Error("Expected Fail() to be called with non-nil error")
 	}
 }
 
@@ -399,7 +377,6 @@ func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return a running container
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
 		return []byte(output), nil
@@ -415,12 +392,10 @@ func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
 		t.Fatal("Expected Remove() to fail for running container, got nil")
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (checking container state)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
@@ -429,37 +404,28 @@ func TestRemove_StepLogger_FailOnRunningContainer(t *testing.T) {
 		t.Errorf("Expected first step to be 'Checking container state', got %q", fakeLogger.startCalls[0].inProgress)
 	}
 
-	// Verify Fail was called once
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
 	}
-
-	if fakeLogger.failCalls[0] == nil {
-		t.Error("Expected Fail() to be called with non-nil error")
-	}
 }
 
-func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
+func TestRemove_StepLogger_FailOnPodRemove(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return stopped container info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		output := fmt.Sprintf("%s|exited|kdn-test\n", containerID)
 		return []byte(output), nil
 	}
 
-	// Set up RunFunc to fail on remove
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		if len(args) > 0 && args[0] == "rm" {
-			return fmt.Errorf("failed to remove container")
-		}
-		return nil
+		return fmt.Errorf("failed to remove pod")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -469,19 +435,17 @@ func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
 		t.Fatal("Expected Remove() to fail, got nil")
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called twice (checking state, removing container)
-	if len(fakeLogger.startCalls) != 2 {
-		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
-	}
-
 	expectedSteps := []string{
 		"Checking container state",
-		"Removing container: abc123",
+		fmt.Sprintf("Removing pod: %s", podName),
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
 	}
 
 	for i, expected := range expectedSteps {
@@ -490,12 +454,7 @@ func TestRemove_StepLogger_FailOnRemoveContainer(t *testing.T) {
 		}
 	}
 
-	// Verify Fail was called once
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
-	}
-
-	if fakeLogger.failCalls[0] == nil {
-		t.Error("Expected Fail() to be called with non-nil error")
 	}
 }

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -23,24 +23,30 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-// Start starts a previously created Podman container.
+// Start starts all containers in the workspace pod.
 func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
 
-	// Validate the ID parameter
 	if id == "" {
 		return runtime.RuntimeInfo{}, fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Start the container
-	stepLogger.Start(fmt.Sprintf("Starting container: %s", id), "Container started")
-	if err := p.startContainer(ctx, id); err != nil {
-		stepLogger.Fail(err)
-		return runtime.RuntimeInfo{}, err
+	// Resolve the pod name from the stored mapping
+	podName, err := p.readPodName(id)
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to resolve pod name: %w", err)
 	}
 
-	// Get updated container information
+	// Start the entire pod (all containers at once)
+	stepLogger.Start(fmt.Sprintf("Starting pod: %s", podName), "Pod started")
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "start", podName); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start pod: %w", err)
+	}
+
+	// Verify workspace container status
 	stepLogger.Start("Verifying container status", "Container status verified")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
@@ -49,13 +55,4 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	}
 
 	return info, nil
-}
-
-// startContainer starts a podman container by ID.
-func (p *podmanRuntime) startContainer(ctx context.Context, id string) error {
-	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", id); err != nil {
-		return fmt.Errorf("failed to start podman container: %w", err)
-	}
-	return nil
 }

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -48,29 +48,28 @@ func TestStart_Success(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123def456"
+	workspaceName := "my-project"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		// Simulate podman inspect output
 		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
 		return []byte(output), nil
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, workspaceName)
 
 	info, err := p.Start(context.Background(), containerID)
 	if err != nil {
 		t.Fatalf("Start() failed: %v", err)
 	}
 
-	// Verify Run was called to start the container
-	fakeExec.AssertRunCalledWith(t, "start", containerID)
+	// Verify pod start was called
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
 
-	// Verify Output was called to inspect the container
+	// Verify inspect was called
 	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
 
-	// Verify returned info
 	if info.ID != containerID {
 		t.Errorf("Expected ID %s, got %s", containerID, info.ID)
 	}
@@ -85,26 +84,25 @@ func TestStart_Success(t *testing.T) {
 	}
 }
 
-func TestStart_StartContainerFailure(t *testing.T) {
+func TestStart_PodStartFailure(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	_, err := p.Start(context.Background(), containerID)
 	if err == nil {
-		t.Fatal("Expected error when start fails, got nil")
+		t.Fatal("Expected error when pod start fails, got nil")
 	}
 
-	// Verify Run was called
-	fakeExec.AssertRunCalledWith(t, "start", containerID)
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
 }
 
 func TestStart_InspectFailure(t *testing.T) {
@@ -113,20 +111,19 @@ func TestStart_InspectFailure(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return an error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("inspect failed")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	_, err := p.Start(context.Background(), containerID)
 	if err == nil {
 		t.Fatal("Expected error when inspect fails, got nil")
 	}
 
-	// Verify both Run and Output were called
-	fakeExec.AssertRunCalledWith(t, "start", containerID)
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
 	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
 }
 
@@ -136,13 +133,13 @@ func TestStart_StepLogger_Success(t *testing.T) {
 	containerID := "abc123def456"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return container info
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
 		return []byte(output), nil
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -152,21 +149,18 @@ func TestStart_StepLogger_Success(t *testing.T) {
 		t.Fatalf("Start() failed: %v", err)
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify no Fail calls
 	if len(fakeLogger.failCalls) != 0 {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Verify Start was called 2 times with correct messages
 	expectedSteps := []stepCall{
 		{
-			inProgress: "Starting container: abc123def456",
-			completed:  "Container started",
+			inProgress: fmt.Sprintf("Starting pod: %s", podName),
+			completed:  "Pod started",
 		},
 		{
 			inProgress: "Verifying container status",
@@ -189,18 +183,18 @@ func TestStart_StepLogger_Success(t *testing.T) {
 	}
 }
 
-func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
+func TestStart_StepLogger_FailOnPodStart(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -210,27 +204,20 @@ func TestStart_StepLogger_FailOnStartContainer(t *testing.T) {
 		t.Fatal("Expected Start() to fail, got nil")
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (start container step)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Starting container: abc123" {
-		t.Errorf("Expected first step to be 'Starting container: abc123', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != fmt.Sprintf("Starting pod: %s", podName) {
+		t.Errorf("Expected first step to be 'Starting pod: %s', got %q", podName, fakeLogger.startCalls[0].inProgress)
 	}
 
-	// Verify Fail was called once
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
-	}
-
-	if fakeLogger.failCalls[0] == nil {
-		t.Error("Expected Fail() to be called with non-nil error")
 	}
 }
 
@@ -240,15 +227,12 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up RunFunc to succeed, but OutputFunc to fail
-	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return nil
-	}
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to inspect container")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -258,18 +242,16 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Fatal("Expected Start() to fail, got nil")
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called twice (start container, verify status)
 	if len(fakeLogger.startCalls) != 2 {
 		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
-		"Starting container: abc123",
+		fmt.Sprintf("Starting pod: %s", podName),
 		"Verifying container status",
 	}
 
@@ -279,12 +261,7 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		}
 	}
 
-	// Verify Fail was called once
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
-	}
-
-	if fakeLogger.failCalls[0] == nil {
-		t.Error("Expected Fail() to be called with non-nil error")
 	}
 }

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -15,6 +15,8 @@
 package podman
 
 import (
+	"testing"
+
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
@@ -78,4 +80,17 @@ func (f *fakeConfig) ListAgents() ([]string, error) {
 
 func (f *fakeConfig) GenerateDefaults() error {
 	return nil
+}
+
+// setupPodFiles creates per-container pod files in a temporary storage directory for testing.
+// Returns the pod name that was written.
+func setupPodFiles(t *testing.T, p *podmanRuntime, containerID, workspaceName string) string {
+	t.Helper()
+	if p.storageDir == "" {
+		p.storageDir = t.TempDir()
+	}
+	if err := p.writePodFiles(containerID, workspaceName); err != nil {
+		t.Fatalf("failed to write pod files for test: %v", err)
+	}
+	return workspaceName
 }

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -89,7 +89,14 @@ func setupPodFiles(t *testing.T, p *podmanRuntime, containerID, workspaceName st
 	if p.storageDir == "" {
 		p.storageDir = t.TempDir()
 	}
-	if err := p.writePodFiles(containerID, workspaceName); err != nil {
+	data := podTemplateData{
+		Name:              workspaceName,
+		PostgresPort:      15432,
+		OnecliPort:        20254,
+		OnecliMetricsPort: 20255,
+		OnecliVersion:     defaultOnecliVersion,
+	}
+	if err := p.writePodFiles(containerID, data); err != nil {
 		t.Fatalf("failed to write pod files for test: %v", err)
 	}
 	return workspaceName

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -90,11 +90,11 @@ func setupPodFiles(t *testing.T, p *podmanRuntime, containerID, workspaceName st
 		p.storageDir = t.TempDir()
 	}
 	data := podTemplateData{
-		Name:              workspaceName,
-		PostgresPort:      15432,
-		OnecliPort:        20254,
-		OnecliMetricsPort: 20255,
-		OnecliVersion:     defaultOnecliVersion,
+		Name:            workspaceName,
+		PostgresPort:    15432,
+		OnecliWebPort:   20254,
+		OnecliProxyPort: 20255,
+		OnecliVersion:   defaultOnecliVersion,
 	}
 	if err := p.writePodFiles(containerID, data); err != nil {
 		t.Fatalf("failed to write pod files for test: %v", err)

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -23,31 +23,28 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-// Stop stops a Podman container.
+// Stop stops all containers in the workspace pod.
 func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
-	logger := steplogger.FromContext(ctx)
-	defer logger.Complete()
+	stepLogger := steplogger.FromContext(ctx)
+	defer stepLogger.Complete()
 
-	// Validate the ID parameter
 	if id == "" {
 		return fmt.Errorf("%w: container ID is required", runtime.ErrInvalidParams)
 	}
 
-	// Stop the container
-	logger.Start(fmt.Sprintf("Stopping container: %s", id), "Container stopped")
-	if err := p.stopContainer(ctx, id); err != nil {
-		logger.Fail(err)
-		return err
+	// Resolve the pod name from the stored mapping
+	podName, err := p.readPodName(id)
+	if err != nil {
+		return fmt.Errorf("failed to resolve pod name: %w", err)
 	}
 
-	return nil
-}
-
-// stopContainer stops a podman container by ID.
-func (p *podmanRuntime) stopContainer(ctx context.Context, id string) error {
+	// Stop the entire pod (all containers at once)
+	stepLogger.Start(fmt.Sprintf("Stopping pod: %s", podName), "Pod stopped")
 	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "stop", id); err != nil {
-		return fmt.Errorf("failed to stop podman container: %w", err)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "stop", podName); err != nil {
+		stepLogger.Fail(err)
+		return fmt.Errorf("failed to stop pod: %w", err)
 	}
+
 	return nil
 }

--- a/pkg/runtime/podman/stop_test.go
+++ b/pkg/runtime/podman/stop_test.go
@@ -51,36 +51,35 @@ func TestStop_Success(t *testing.T) {
 	fakeExec := exec.NewFake()
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "my-project")
 
 	err := p.Stop(context.Background(), containerID)
 	if err != nil {
 		t.Fatalf("Stop() failed: %v", err)
 	}
 
-	// Verify Run was called to stop the container
-	fakeExec.AssertRunCalledWith(t, "stop", containerID)
+	fakeExec.AssertRunCalledWith(t, "pod", "stop", podName)
 }
 
-func TestStop_StopContainerFailure(t *testing.T) {
+func TestStop_PodStopFailure(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	err := p.Stop(context.Background(), containerID)
 	if err == nil {
-		t.Fatal("Expected error when stop fails, got nil")
+		t.Fatal("Expected error when pod stop fails, got nil")
 	}
 
-	// Verify Run was called
-	fakeExec.AssertRunCalledWith(t, "stop", containerID)
+	fakeExec.AssertRunCalledWith(t, "pod", "stop", podName)
 }
 
 func TestStop_StepLogger_Success(t *testing.T) {
@@ -90,6 +89,7 @@ func TestStop_StepLogger_Success(t *testing.T) {
 	fakeExec := exec.NewFake()
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -99,21 +99,18 @@ func TestStop_StepLogger_Success(t *testing.T) {
 		t.Fatalf("Stop() failed: %v", err)
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify no Fail calls
 	if len(fakeLogger.failCalls) != 0 {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Verify Start was called once with correct messages
 	expectedSteps := []stepCall{
 		{
-			inProgress: "Stopping container: abc123def456",
-			completed:  "Container stopped",
+			inProgress: fmt.Sprintf("Stopping pod: %s", podName),
+			completed:  "Pod stopped",
 		},
 	}
 
@@ -132,18 +129,18 @@ func TestStop_StepLogger_Success(t *testing.T) {
 	}
 }
 
-func TestStop_StepLogger_FailOnStopContainer(t *testing.T) {
+func TestStop_StepLogger_FailOnPodStop(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up RunFunc to return an error
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("container not found")
+		return fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -153,26 +150,19 @@ func TestStop_StepLogger_FailOnStopContainer(t *testing.T) {
 		t.Fatal("Expected Stop() to fail, got nil")
 	}
 
-	// Verify Complete was called once (deferred call)
 	if fakeLogger.completeCalls != 1 {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called once (stop container step)
 	if len(fakeLogger.startCalls) != 1 {
 		t.Fatalf("Expected 1 Start() call, got %d", len(fakeLogger.startCalls))
 	}
 
-	if fakeLogger.startCalls[0].inProgress != "Stopping container: abc123" {
-		t.Errorf("Expected first step to be 'Stopping container: abc123', got %q", fakeLogger.startCalls[0].inProgress)
+	if fakeLogger.startCalls[0].inProgress != fmt.Sprintf("Stopping pod: %s", podName) {
+		t.Errorf("Expected step to be 'Stopping pod: %s', got %q", podName, fakeLogger.startCalls[0].inProgress)
 	}
 
-	// Verify Fail was called once
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
-	}
-
-	if fakeLogger.failCalls[0] == nil {
-		t.Error("Expected Fail() to be called with non-nil error")
 	}
 }


### PR DESCRIPTION
This PR adds a onecli containers to be created/started/stopped/removed with workspace container (all of them are in one pod) - there should be 4 containers in total in the pod

YAML: https://gist.github.com/jeffmaury/aa4be3928aae1ef084b549b12117255a

Closes https://github.com/openkaiden/kdn/issues/263

<img width="1142" height="855" alt="Screenshot 2026-04-16 at 12 49 34" src="https://github.com/user-attachments/assets/0d259a44-23c2-44b4-9eba-666b43f74ddd" />


You can test this by: 
Using this PR, build the `kdn`, start the podman desktop run:

1. `kdn init --agent claude --runtime podman` -> you should see in Podman Desktop that a pod with 4 containers is created (if you dont have the env variable set or you did not pass `--start` ALL of them should be STOPPED, if you have passed --start or you do have env var set ALL of them should be STARTED)
2. Start/stop of workspace using kdn should start/stop ALL containers
3. You should be able to do `kdn terminal` as well 
4. Removing should delete all of them