### PR TITLE
feat(onecli): configure secrets for OneCLI credential gateway 

### DIFF
--- a/pkg/cmd/service_list_test.go
+++ b/pkg/cmd/service_list_test.go
@@ -181,8 +181,8 @@ func TestServiceListCmd_E2E(t *testing.T) {
 		for _, svc := range response.Items {
 			if svc.Name == "github" {
 				found = true
-				if svc.HostPattern != `api\.github\.com` {
-					t.Errorf("Expected HostPattern %q, got %q", `api\.github\.com`, svc.HostPattern)
+				if svc.HostPattern != "api.github.com" {
+					t.Errorf("Expected HostPattern %q, got %q", "api.github.com", svc.HostPattern)
 				}
 				if svc.HeaderName != "Authorization" {
 					t.Errorf("Expected HeaderName %q, got %q", "Authorization", svc.HeaderName)

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -136,9 +136,12 @@ func (w *workspaceStartCmd) run(cmd *cobra.Command, args []string) error {
 		return w.outputJSON(cmd, instanceID)
 	}
 
-	// Output only the ID (text mode)
+	// Output the ID and OneCLI dashboard URL if available (text mode)
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, instanceID)
+	if port, ok := instance.GetRuntimeData().Info["onecli_web_port"]; ok {
+		fmt.Fprintf(out, "OneCLI dashboard: http://localhost:%s\n", port)
+	}
 	return nil
 }
 

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/config"
 	"github.com/openkaiden/kdn/pkg/generator"
 	"github.com/openkaiden/kdn/pkg/git"
+	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
@@ -287,6 +288,28 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		// If agent not found in registry, use settings as-is (not all agents may be implemented)
 	}
 
+	// Map workspace secrets to OneCLI secret definitions and collect env vars
+	var onecliSecrets []onecli.CreateSecretInput
+	secretEnvVars := make(map[string]string)
+	if mergedConfig != nil && mergedConfig.Secrets != nil && len(*mergedConfig.Secrets) > 0 {
+		mapper := onecli.NewSecretMapper(m.secretServiceRegistry)
+		for i, s := range *mergedConfig.Secrets {
+			input, err := mapper.Map(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map secret at index %d: %w", i, err)
+			}
+			onecliSecrets = append(onecliSecrets, input)
+
+			if s.Type != "other" {
+				if svc, svcErr := m.secretServiceRegistry.Get(s.Type); svcErr == nil {
+					for _, envVar := range svc.EnvVars() {
+						secretEnvVars[envVar] = "placeholder"
+					}
+				}
+			}
+		}
+	}
+
 	// Create runtime instance with merged configuration
 	runtimeInfo, err := rt.Create(ctx, runtime.CreateParams{
 		Name:            name,
@@ -294,6 +317,8 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		WorkspaceConfig: mergedConfig,
 		Agent:           opts.Agent,
 		AgentSettings:   agentSettings,
+		OnecliSecrets:   onecliSecrets,
+		SecretEnvVars:   secretEnvVars,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)

--- a/pkg/onecli/client.go
+++ b/pkg/onecli/client.go
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package onecli provides a client for the OneCLI API and utilities for
+// mapping workspace secrets to OneCLI secret definitions.
+package onecli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client defines the contract for interacting with the OneCLI API.
+type Client interface {
+	CreateSecret(ctx context.Context, input CreateSecretInput) (*Secret, error)
+	UpdateSecret(ctx context.Context, id string, input UpdateSecretInput) error
+	ListSecrets(ctx context.Context) ([]Secret, error)
+	DeleteSecret(ctx context.Context, id string) error
+	GetContainerConfig(ctx context.Context) (*ContainerConfig, error)
+}
+
+// UpdateSecretInput is the request body for updating a secret.
+type UpdateSecretInput struct {
+	Value           *string          `json:"value,omitempty"`
+	HostPattern     *string          `json:"hostPattern,omitempty"`
+	PathPattern     *string          `json:"pathPattern,omitempty"`
+	InjectionConfig *InjectionConfig `json:"injectionConfig,omitempty"`
+}
+
+// ContainerConfig holds the environment variables and CA certificate returned
+// by the OneCLI /api/container-config endpoint.
+type ContainerConfig struct {
+	Env                        map[string]string `json:"env"`
+	CACertificate              string            `json:"caCertificate"`
+	CACertificateContainerPath string            `json:"caCertificateContainerPath"`
+}
+
+// Secret represents a secret returned by the OneCLI API.
+type Secret struct {
+	ID              string           `json:"id"`
+	Name            string           `json:"name"`
+	Type            string           `json:"type"`
+	HostPattern     string           `json:"hostPattern"`
+	PathPattern     *string          `json:"pathPattern"`
+	InjectionConfig *InjectionConfig `json:"injectionConfig"`
+	CreatedAt       string           `json:"createdAt"`
+}
+
+// InjectionConfig describes how a secret is injected into HTTP requests.
+type InjectionConfig struct {
+	HeaderName  string `json:"headerName"`
+	ValueFormat string `json:"valueFormat,omitempty"`
+}
+
+// CreateSecretInput is the request body for creating a secret.
+type CreateSecretInput struct {
+	Name            string           `json:"name"`
+	Type            string           `json:"type"`
+	Value           string           `json:"value"`
+	HostPattern     string           `json:"hostPattern"`
+	PathPattern     string           `json:"pathPattern,omitempty"`
+	InjectionConfig *InjectionConfig `json:"injectionConfig,omitempty"`
+}
+
+// APIError represents an error response from the OneCLI API.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return e.Message
+}
+
+type client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+var _ Client = (*client)(nil)
+
+// NewClient creates a new OneCLI API client.
+func NewClient(baseURL, apiKey string) Client {
+	return &client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// CreateSecret creates a new secret in OneCLI.
+func (c *client) CreateSecret(ctx context.Context, input CreateSecretInput) (*Secret, error) {
+	var secret Secret
+	if err := c.do(ctx, http.MethodPost, "/api/secrets", input, &secret); err != nil {
+		return nil, fmt.Errorf("creating secret: %w", err)
+	}
+	return &secret, nil
+}
+
+// ListSecrets returns all secrets for the authenticated user.
+func (c *client) ListSecrets(ctx context.Context) ([]Secret, error) {
+	var secrets []Secret
+	if err := c.do(ctx, http.MethodGet, "/api/secrets", nil, &secrets); err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+	return secrets, nil
+}
+
+// UpdateSecret updates an existing secret by ID.
+func (c *client) UpdateSecret(ctx context.Context, id string, input UpdateSecretInput) error {
+	if err := c.do(ctx, http.MethodPatch, "/api/secrets/"+id, input, nil); err != nil {
+		return fmt.Errorf("updating secret: %w", err)
+	}
+	return nil
+}
+
+// DeleteSecret deletes a secret by ID.
+func (c *client) DeleteSecret(ctx context.Context, id string) error {
+	if err := c.do(ctx, http.MethodDelete, "/api/secrets/"+id, nil, nil); err != nil {
+		return fmt.Errorf("deleting secret: %w", err)
+	}
+	return nil
+}
+
+// GetContainerConfig returns the proxy environment variables, CA certificate, and
+// agent access token needed to configure a workspace container.
+func (c *client) GetContainerConfig(ctx context.Context) (*ContainerConfig, error) {
+	var cfg ContainerConfig
+	if err := c.do(ctx, http.MethodGet, "/api/container-config", nil, &cfg); err != nil {
+		return nil, fmt.Errorf("getting container config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func (c *client) do(ctx context.Context, method, path string, body any, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshaling request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
+			return &APIError{StatusCode: resp.StatusCode, Message: errResp.Error}
+		}
+		return &APIError{StatusCode: resp.StatusCode, Message: http.StatusText(resp.StatusCode)}
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/onecli/client_test.go
+++ b/pkg/onecli/client_test.go
@@ -1,0 +1,206 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateSecret(t *testing.T) {
+	t.Parallel()
+
+	want := Secret{
+		ID:          "sec-123",
+		Name:        "GitHub Token",
+		Type:        "generic",
+		HostPattern: "api.github.com",
+	}
+
+	var gotInput CreateSecretInput
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/secrets" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected content type: %s", r.Header.Get("Content-Type"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotInput); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	input := CreateSecretInput{
+		Name:        "GitHub Token",
+		Type:        "generic",
+		Value:       "ghp_xxx",
+		HostPattern: "api.github.com",
+	}
+	got, err := c.CreateSecret(context.Background(), input)
+	if err != nil {
+		t.Fatalf("CreateSecret() error: %v", err)
+	}
+	if got.ID != want.ID {
+		t.Errorf("got ID %q, want %q", got.ID, want.ID)
+	}
+	if gotInput.Name != input.Name {
+		t.Errorf("server got name %q, want %q", gotInput.Name, input.Name)
+	}
+}
+
+func TestCreateSecret_Conflict(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "secret already exists"})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	_, err := c.CreateSecret(context.Background(), CreateSecretInput{Name: "test"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Errorf("got status %d, want %d", apiErr.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestCreateSecret_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid api key"})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "bad-key")
+	_, err := c.CreateSecret(context.Background(), CreateSecretInput{Name: "test"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("got status %d, want %d", apiErr.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestListSecrets(t *testing.T) {
+	t.Parallel()
+
+	want := []Secret{
+		{ID: "sec-1", Name: "one"},
+		{ID: "sec-2", Name: "two"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/secrets" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	got, err := c.ListSecrets(context.Background())
+	if err != nil {
+		t.Fatalf("ListSecrets() error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d secrets, want 2", len(got))
+	}
+	if got[0].ID != "sec-1" || got[1].ID != "sec-2" {
+		t.Errorf("unexpected secrets: %+v", got)
+	}
+}
+
+func TestDeleteSecret(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/secrets/sec-123" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	if err := c.DeleteSecret(context.Background(), "sec-123"); err != nil {
+		t.Fatalf("DeleteSecret() error: %v", err)
+	}
+}
+
+func TestGetContainerConfig(t *testing.T) {
+	t.Parallel()
+
+	want := ContainerConfig{
+		Env: map[string]string{
+			"HTTPS_PROXY":         "http://x:aoc_token@localhost:10255",
+			"HTTP_PROXY":          "http://x:aoc_token@localhost:10255",
+			"NODE_EXTRA_CA_CERTS": "/tmp/onecli-gateway-ca.pem",
+			"ANTHROPIC_API_KEY":   "placeholder",
+		},
+		CACertificate:              "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----",
+		CACertificateContainerPath: "/tmp/onecli-gateway-ca.pem",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/container-config" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	got, err := c.GetContainerConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetContainerConfig() error: %v", err)
+	}
+	if got.CACertificateContainerPath != want.CACertificateContainerPath {
+		t.Errorf("CACertificateContainerPath = %q, want %q", got.CACertificateContainerPath, want.CACertificateContainerPath)
+	}
+	if got.Env["HTTPS_PROXY"] != want.Env["HTTPS_PROXY"] {
+		t.Errorf("HTTPS_PROXY = %q, want %q", got.Env["HTTPS_PROXY"], want.Env["HTTPS_PROXY"])
+	}
+	if got.CACertificate == "" {
+		t.Error("CACertificate should not be empty")
+	}
+}

--- a/pkg/onecli/credentials.go
+++ b/pkg/onecli/credentials.go
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const apiKeyPrefix = "oc_"
+
+// CredentialProvider retrieves the OneCLI API key.
+type CredentialProvider interface {
+	// APIKey returns the OneCLI API key.
+	APIKey(ctx context.Context) (string, error)
+}
+
+type credentialProvider struct {
+	baseURL string
+}
+
+var _ CredentialProvider = (*credentialProvider)(nil)
+
+// NewCredentialProvider creates a CredentialProvider that retrieves the API key
+// from the OneCLI web service at the given base URL.
+// In local mode, the first call bootstraps the local user and generates the key.
+func NewCredentialProvider(baseURL string) CredentialProvider {
+	return &credentialProvider{
+		baseURL: baseURL,
+	}
+}
+
+// APIKey retrieves the API key by calling GET /api/user/api-key.
+// In local mode (no auth required), this bootstraps the local user on first call.
+func (p *credentialProvider) APIKey(ctx context.Context) (string, error) {
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/api/user/api-key", nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting API key: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to get API key (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		APIKey string `json:"apiKey"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding API key response: %w", err)
+	}
+
+	if !strings.HasPrefix(result.APIKey, apiKeyPrefix) {
+		return "", fmt.Errorf("API key has unexpected format")
+	}
+
+	return result.APIKey, nil
+}

--- a/pkg/onecli/credentials_test.go
+++ b/pkg/onecli/credentials_test.go
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCredentialProvider_Success(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/user/api-key" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_test_key_123"})
+	}))
+	defer server.Close()
+
+	provider := NewCredentialProvider(server.URL)
+	key, err := provider.APIKey(context.Background())
+	if err != nil {
+		t.Fatalf("APIKey() error: %v", err)
+	}
+	if key != "oc_test_key_123" {
+		t.Errorf("got key %q, want %q", key, "oc_test_key_123")
+	}
+}
+
+func TestCredentialProvider_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	provider := NewCredentialProvider(server.URL)
+	_, err := provider.APIKey(context.Background())
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestCredentialProvider_InvalidKeyFormat(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "bad_prefix"})
+	}))
+	defer server.Close()
+
+	provider := NewCredentialProvider(server.URL)
+	_, err := provider.APIKey(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid key format")
+	}
+}
+
+func TestCredentialProvider_Unreachable(t *testing.T) {
+	t.Parallel()
+
+	provider := NewCredentialProvider("http://localhost:1")
+	_, err := provider.APIKey(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}

--- a/pkg/onecli/mapper.go
+++ b/pkg/onecli/mapper.go
@@ -1,0 +1,129 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"fmt"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+const secretTypeOther = "other"
+
+// SecretMapper converts workspace secrets to OneCLI CreateSecretInput values.
+type SecretMapper interface {
+	Map(secret workspace.Secret) (CreateSecretInput, error)
+}
+
+type secretMapper struct {
+	registry secretservice.Registry
+}
+
+var _ SecretMapper = (*secretMapper)(nil)
+
+// NewSecretMapper creates a SecretMapper that uses the given registry to look up
+// secret service metadata for known secret types.
+func NewSecretMapper(registry secretservice.Registry) SecretMapper {
+	return &secretMapper{registry: registry}
+}
+
+// Map converts a workspace secret to a CreateSecretInput.
+// For type "other", the secret's own fields are used directly.
+// For all other types, the SecretService registry provides host pattern, header, and template.
+func (m *secretMapper) Map(secret workspace.Secret) (CreateSecretInput, error) {
+	if secret.Type == secretTypeOther {
+		return m.mapOtherSecret(secret)
+	}
+	return m.mapKnownSecret(secret)
+}
+
+func (m *secretMapper) mapKnownSecret(secret workspace.Secret) (CreateSecretInput, error) {
+	svc, err := m.registry.Get(secret.Type)
+	if err != nil {
+		return CreateSecretInput{}, fmt.Errorf("unknown secret type %q: %w", secret.Type, err)
+	}
+
+	input := CreateSecretInput{
+		Name:        secretName(secret.Name, secret.Type),
+		Type:        "generic",
+		Value:       secret.Value,
+		HostPattern: svc.HostPattern(),
+		PathPattern: svc.Path(),
+	}
+
+	if headerName := svc.HeaderName(); headerName != "" {
+		input.InjectionConfig = &InjectionConfig{
+			HeaderName:  headerName,
+			ValueFormat: convertTemplate(svc.HeaderTemplate()),
+		}
+	}
+
+	return input, nil
+}
+
+func (m *secretMapper) mapOtherSecret(secret workspace.Secret) (CreateSecretInput, error) {
+	if secret.Hosts != nil && len(*secret.Hosts) > 1 {
+		return CreateSecretInput{}, fmt.Errorf("secret type %q supports only one host per secret; declare one secret per host (got %d hosts)", secretTypeOther, len(*secret.Hosts))
+	}
+
+	input := CreateSecretInput{
+		Name:        secretName(secret.Name, secretTypeOther),
+		Type:        "generic",
+		Value:       secret.Value,
+		HostPattern: otherHostPattern(secret.Hosts),
+		PathPattern: derefString(secret.Path),
+	}
+
+	if header := derefString(secret.Header); header != "" {
+		input.InjectionConfig = &InjectionConfig{
+			HeaderName:  header,
+			ValueFormat: convertTemplate(derefString(secret.HeaderTemplate)),
+		}
+	}
+
+	return input, nil
+}
+
+func secretName(name *string, fallback string) string {
+	if name != nil && *name != "" {
+		return *name
+	}
+	return fallback
+}
+
+func otherHostPattern(hosts *[]string) string {
+	if hosts != nil && len(*hosts) > 0 {
+		return (*hosts)[0]
+	}
+	return "*"
+}
+
+func derefString(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
+// convertTemplate converts kdn's ${value} placeholder to OneCLI's {value} format.
+func convertTemplate(tmpl string) string {
+	return strings.ReplaceAll(tmpl, "${value}", "{value}")
+}

--- a/pkg/onecli/mapper_test.go
+++ b/pkg/onecli/mapper_test.go
@@ -1,0 +1,252 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"strings"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+func registryWithGitHub(t *testing.T) secretservice.Registry {
+	t.Helper()
+	reg := secretservice.NewRegistry()
+	svc := secretservice.NewSecretService(
+		"github",
+		"api.github.com",
+		"",
+		[]string{"GH_TOKEN", "GITHUB_TOKEN"},
+		"Authorization",
+		"Bearer ${value}",
+	)
+	if err := reg.Register(svc); err != nil {
+		t.Fatal(err)
+	}
+	return reg
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestMapper_KnownType_GitHub(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(registryWithGitHub(t))
+	secret := workspace.Secret{
+		Type:  "github",
+		Value: "ghp_abc123",
+	}
+
+	got, err := mapper.Map(secret)
+	if err != nil {
+		t.Fatalf("Map() error: %v", err)
+	}
+
+	if got.Name != "github" {
+		t.Errorf("Name = %q, want %q", got.Name, "github")
+	}
+	if got.Type != "generic" {
+		t.Errorf("Type = %q, want %q", got.Type, "generic")
+	}
+	if got.Value != "ghp_abc123" {
+		t.Errorf("Value = %q, want %q", got.Value, "ghp_abc123")
+	}
+	if got.HostPattern != "api.github.com" {
+		t.Errorf("HostPattern = %q, want %q", got.HostPattern, "api.github.com")
+	}
+	if got.InjectionConfig == nil {
+		t.Fatal("InjectionConfig is nil")
+	}
+	if got.InjectionConfig.HeaderName != "Authorization" {
+		t.Errorf("HeaderName = %q, want %q", got.InjectionConfig.HeaderName, "Authorization")
+	}
+	if got.InjectionConfig.ValueFormat != "Bearer {value}" {
+		t.Errorf("ValueFormat = %q, want %q", got.InjectionConfig.ValueFormat, "Bearer {value}")
+	}
+}
+
+func TestMapper_KnownType_WithName(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(registryWithGitHub(t))
+	secret := workspace.Secret{
+		Type:  "github",
+		Value: "ghp_abc123",
+		Name:  strPtr("my-gh-token"),
+	}
+
+	got, err := mapper.Map(secret)
+	if err != nil {
+		t.Fatalf("Map() error: %v", err)
+	}
+	if got.Name != "my-gh-token" {
+		t.Errorf("Name = %q, want %q", got.Name, "my-gh-token")
+	}
+}
+
+func TestMapper_UnknownType(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	secret := workspace.Secret{
+		Type:  "unknown-service",
+		Value: "token",
+	}
+
+	_, err := mapper.Map(secret)
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
+func TestMapper_OtherType_AllFields(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	hosts := []string{"api.example.com"}
+	secret := workspace.Secret{
+		Type:           "other",
+		Value:          "my-key-123",
+		Name:           strPtr("custom-api"),
+		Header:         strPtr("X-Api-Key"),
+		HeaderTemplate: strPtr("Token ${value}"),
+		Hosts:          &hosts,
+		Path:           strPtr("/v2"),
+	}
+
+	got, err := mapper.Map(secret)
+	if err != nil {
+		t.Fatalf("Map() error: %v", err)
+	}
+
+	if got.Name != "custom-api" {
+		t.Errorf("Name = %q, want %q", got.Name, "custom-api")
+	}
+	if got.Type != "generic" {
+		t.Errorf("Type = %q, want %q", got.Type, "generic")
+	}
+	if got.Value != "my-key-123" {
+		t.Errorf("Value = %q, want %q", got.Value, "my-key-123")
+	}
+	if got.HostPattern != "api.example.com" {
+		t.Errorf("HostPattern = %q, want %q", got.HostPattern, "api.example.com")
+	}
+	if got.PathPattern != "/v2" {
+		t.Errorf("PathPattern = %q, want %q", got.PathPattern, "/v2")
+	}
+	if got.InjectionConfig == nil {
+		t.Fatal("InjectionConfig is nil")
+	}
+	if got.InjectionConfig.HeaderName != "X-Api-Key" {
+		t.Errorf("HeaderName = %q, want %q", got.InjectionConfig.HeaderName, "X-Api-Key")
+	}
+	if got.InjectionConfig.ValueFormat != "Token {value}" {
+		t.Errorf("ValueFormat = %q, want %q", got.InjectionConfig.ValueFormat, "Token {value}")
+	}
+}
+
+func TestMapper_OtherType_MultipleHosts_Error(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	hosts := []string{"api.example.com", "api2.example.com"}
+	secret := workspace.Secret{
+		Type:  "other",
+		Value: "my-key-123",
+		Hosts: &hosts,
+	}
+
+	_, err := mapper.Map(secret)
+	if err == nil {
+		t.Fatal("expected error for multiple hosts, got nil")
+	}
+	if !strings.Contains(err.Error(), "one host per secret") {
+		t.Errorf("error should mention 'one host per secret', got: %v", err)
+	}
+}
+
+func TestMapper_OtherType_MinimalFields(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	secret := workspace.Secret{
+		Type:  "other",
+		Value: "secret-val",
+	}
+
+	got, err := mapper.Map(secret)
+	if err != nil {
+		t.Fatalf("Map() error: %v", err)
+	}
+
+	if got.Name != "other" {
+		t.Errorf("Name = %q, want %q", got.Name, "other")
+	}
+	if got.HostPattern != "*" {
+		t.Errorf("HostPattern = %q, want %q", got.HostPattern, "*")
+	}
+	if got.PathPattern != "" {
+		t.Errorf("PathPattern = %q, want empty", got.PathPattern)
+	}
+	if got.InjectionConfig != nil {
+		t.Errorf("InjectionConfig should be nil for other type without header, got %+v", got.InjectionConfig)
+	}
+}
+
+func TestMapper_OtherType_EmptyHosts(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	emptyHosts := []string{}
+	secret := workspace.Secret{
+		Type:  "other",
+		Value: "val",
+		Hosts: &emptyHosts,
+	}
+
+	got, err := mapper.Map(secret)
+	if err != nil {
+		t.Fatalf("Map() error: %v", err)
+	}
+	if got.HostPattern != "*" {
+		t.Errorf("HostPattern = %q, want %q for empty hosts", got.HostPattern, "*")
+	}
+}
+
+func TestConvertTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Bearer ${value}", "Bearer {value}"},
+		{"${value}", "{value}"},
+		{"no-placeholder", "no-placeholder"},
+		{"", ""},
+		{"${value} and ${value}", "{value} and {value}"},
+	}
+
+	for _, tt := range tests {
+		if got := convertTemplate(tt.input); got != tt.want {
+			t.Errorf("convertTemplate(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/onecli/provisioner.go
+++ b/pkg/onecli/provisioner.go
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// SecretProvisioner creates or updates OneCLI secrets from a list of pre-mapped CreateSecretInput values.
+type SecretProvisioner interface {
+	ProvisionSecrets(ctx context.Context, secrets []CreateSecretInput) error
+}
+
+type secretProvisioner struct {
+	client Client
+}
+
+var _ SecretProvisioner = (*secretProvisioner)(nil)
+
+// NewSecretProvisioner creates a SecretProvisioner that uses the given client to create secrets.
+func NewSecretProvisioner(client Client) SecretProvisioner {
+	return &secretProvisioner{client: client}
+}
+
+// ProvisionSecrets creates each secret via the OneCLI API.
+// If a secret already exists (409 conflict), it is updated with the new values.
+func (p *secretProvisioner) ProvisionSecrets(ctx context.Context, secrets []CreateSecretInput) error {
+	for i, input := range secrets {
+		if _, err := p.client.CreateSecret(ctx, input); err != nil {
+			var apiErr *APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+				if updateErr := p.updateExisting(ctx, input); updateErr != nil {
+					return fmt.Errorf("failed to update existing secret %d (%q): %w", i, input.Name, updateErr)
+				}
+				continue
+			}
+			return fmt.Errorf("failed to create secret %d (%q): %w", i, input.Name, err)
+		}
+	}
+	return nil
+}
+
+// updateExisting finds the existing secret by name and updates it.
+func (p *secretProvisioner) updateExisting(ctx context.Context, input CreateSecretInput) error {
+	existing, err := p.client.ListSecrets(ctx)
+	if err != nil {
+		return fmt.Errorf("listing secrets to find existing: %w", err)
+	}
+
+	for _, s := range existing {
+		if s.Name == input.Name {
+			update := UpdateSecretInput{
+				Value:       &input.Value,
+				HostPattern: &input.HostPattern,
+			}
+			if input.PathPattern != "" {
+				update.PathPattern = &input.PathPattern
+			}
+			if input.InjectionConfig != nil {
+				update.InjectionConfig = input.InjectionConfig
+			}
+			return p.client.UpdateSecret(ctx, s.ID, update)
+		}
+	}
+
+	return fmt.Errorf("secret %q not found after 409 conflict", input.Name)
+}

--- a/pkg/onecli/provisioner_test.go
+++ b/pkg/onecli/provisioner_test.go
@@ -1,0 +1,183 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package onecli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+type fakeClient struct {
+	created    []CreateSecretInput
+	updated    []UpdateSecretInput
+	updatedIDs []string
+	existing   []Secret
+	createErr  error
+}
+
+// Ensure fakeClient implements Client at compile time.
+var _ Client = (*fakeClient)(nil)
+
+func (f *fakeClient) CreateSecret(_ context.Context, input CreateSecretInput) (*Secret, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	f.created = append(f.created, input)
+	return &Secret{ID: "fake-id", Name: input.Name}, nil
+}
+
+func (f *fakeClient) UpdateSecret(_ context.Context, id string, input UpdateSecretInput) error {
+	f.updatedIDs = append(f.updatedIDs, id)
+	f.updated = append(f.updated, input)
+	return nil
+}
+
+func (f *fakeClient) ListSecrets(_ context.Context) ([]Secret, error) {
+	return f.existing, nil
+}
+
+func (f *fakeClient) DeleteSecret(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeClient) GetContainerConfig(_ context.Context) (*ContainerConfig, error) {
+	return &ContainerConfig{Env: map[string]string{}}, nil
+}
+
+func TestProvisioner_AllSecretsCreated(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	prov := NewSecretProvisioner(fc)
+
+	secrets := []CreateSecretInput{
+		{Name: "secret-1", Type: "generic", Value: "val1", HostPattern: "a.com"},
+		{Name: "secret-2", Type: "generic", Value: "val2", HostPattern: "b.com"},
+	}
+
+	if err := prov.ProvisionSecrets(context.Background(), secrets); err != nil {
+		t.Fatalf("ProvisionSecrets() error: %v", err)
+	}
+	if len(fc.created) != 2 {
+		t.Fatalf("created %d secrets, want 2", len(fc.created))
+	}
+}
+
+func TestProvisioner_EmptySlice(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	prov := NewSecretProvisioner(fc)
+
+	if err := prov.ProvisionSecrets(context.Background(), nil); err != nil {
+		t.Fatalf("ProvisionSecrets() error: %v", err)
+	}
+	if len(fc.created) != 0 {
+		t.Errorf("created %d secrets for nil input, want 0", len(fc.created))
+	}
+}
+
+func TestProvisioner_ConflictUpdatesExisting(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{
+		createErr: &APIError{StatusCode: http.StatusConflict, Message: "already exists"},
+		existing: []Secret{
+			{ID: "sec-42", Name: "existing", Type: "generic", HostPattern: "old.com"},
+		},
+	}
+	prov := NewSecretProvisioner(fc)
+
+	secrets := []CreateSecretInput{
+		{Name: "existing", Type: "generic", Value: "new-val", HostPattern: "new.com"},
+	}
+
+	if err := prov.ProvisionSecrets(context.Background(), secrets); err != nil {
+		t.Fatalf("ProvisionSecrets() error: %v", err)
+	}
+	if len(fc.updatedIDs) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(fc.updatedIDs))
+	}
+	if fc.updatedIDs[0] != "sec-42" {
+		t.Errorf("updated ID = %q, want %q", fc.updatedIDs[0], "sec-42")
+	}
+	if *fc.updated[0].Value != "new-val" {
+		t.Errorf("updated value = %q, want %q", *fc.updated[0].Value, "new-val")
+	}
+	if *fc.updated[0].HostPattern != "new.com" {
+		t.Errorf("updated host = %q, want %q", *fc.updated[0].HostPattern, "new.com")
+	}
+}
+
+func TestProvisioner_ConflictSecretNotFound(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{
+		createErr: &APIError{StatusCode: http.StatusConflict, Message: "already exists"},
+		existing:  []Secret{},
+	}
+	prov := NewSecretProvisioner(fc)
+
+	secrets := []CreateSecretInput{
+		{Name: "ghost", Type: "generic", Value: "val", HostPattern: "a.com"},
+	}
+
+	err := prov.ProvisionSecrets(context.Background(), secrets)
+	if err == nil {
+		t.Fatal("expected error when existing secret not found after 409")
+	}
+}
+
+func TestProvisioner_OtherErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{
+		createErr: &APIError{StatusCode: http.StatusUnauthorized, Message: "bad key"},
+	}
+	prov := NewSecretProvisioner(fc)
+
+	secrets := []CreateSecretInput{
+		{Name: "test", Type: "generic", Value: "val", HostPattern: "a.com"},
+	}
+
+	err := prov.ProvisionSecrets(context.Background(), secrets)
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+}
+
+func TestProvisioner_NonAPIErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{
+		createErr: fmt.Errorf("network failure"),
+	}
+	prov := NewSecretProvisioner(fc)
+
+	secrets := []CreateSecretInput{
+		{Name: "test", Type: "generic", Value: "val", HostPattern: "a.com"},
+	}
+
+	err := prov.ProvisionSecrets(context.Background(), secrets)
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+}

--- a/pkg/runtime/podman/config/defaults.go
+++ b/pkg/runtime/podman/config/defaults.go
@@ -62,6 +62,8 @@ func defaultImageConfig() *ImageConfig {
 			"/bin/kill",
 			"/usr/bin/kill",
 			"/usr/bin/killall",
+			"/usr/bin/cp",
+			"/usr/bin/update-ca-trust",
 		},
 		RunCommands: []string{},
 	}

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -26,6 +26,7 @@ import (
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/pods"
@@ -127,19 +128,50 @@ func (p *podmanRuntime) buildImage(ctx context.Context, imageName, instanceDir s
 	return nil
 }
 
+// containerConfigArgs holds optional OneCLI container configuration to inject into the workspace.
+type containerConfigArgs struct {
+	envVars         map[string]string
+	caFilePath      string
+	caContainerPath string
+}
+
 // buildContainerArgs builds the arguments for creating the workspace container inside the pod.
-func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string) ([]string, error) {
+func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string, ccArgs *containerConfigArgs) ([]string, error) {
 	args := []string{"create", "--pod", params.Name, "--name", params.Name}
 
-	// Add environment variables from workspace config
+	// Collect workspace env var names for collision detection
+	workspaceEnvNames := make(map[string]bool)
 	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Environment != nil {
 		for _, env := range *params.WorkspaceConfig.Environment {
 			if env.Value != nil {
 				args = append(args, "-e", fmt.Sprintf("%s=%s", env.Name, *env.Value))
+				workspaceEnvNames[env.Name] = true
 			} else if env.Secret != nil {
 				secretArg := fmt.Sprintf("%s,type=env,target=%s", *env.Secret, env.Name)
 				args = append(args, "--secret", secretArg)
+				workspaceEnvNames[env.Name] = true
 			}
+		}
+	}
+
+	// Add OneCLI proxy env vars after workspace config (OneCLI takes precedence).
+	// Log collisions so users know their workspace values are being overridden.
+	if ccArgs != nil {
+		for k, v := range ccArgs.envVars {
+			if workspaceEnvNames[k] {
+				fmt.Fprintf(os.Stderr, "warning: OneCLI overrides workspace env var %q\n", k)
+			}
+			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+		}
+		if ccArgs.caFilePath != "" && ccArgs.caContainerPath != "" {
+			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", ccArgs.caFilePath, ccArgs.caContainerPath))
+		}
+	}
+
+	// Add secret service env vars with placeholder values so CLI tools detect a configured credential.
+	for k, v := range params.SecretEnvVars {
+		if !workspaceEnvNames[k] {
+			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 		}
 	}
 
@@ -285,12 +317,51 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to create pod via kube play: %w", err)
 	}
 
-	// Add the workspace container to the pod
+	// Clean up the pod if any subsequent step fails.
+	// Use context.Background() so cleanup still runs if ctx is cancelled.
+	podCreatedOK := false
+	defer func() {
+		if !podCreatedOK {
+			_ = p.executor.Run(context.Background(), l.Stdout(), l.Stderr(), "pod", "rm", "-f", params.Name)
+		}
+	}()
+
+	// Start the pod so OneCLI can initialize and we can provision secrets + get proxy config
+	var ccArgs *containerConfigArgs
+	if len(params.OnecliSecrets) > 0 {
+		containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets)
+		if setupErr != nil {
+			return runtime.RuntimeInfo{}, setupErr
+		}
+		if containerConfig != nil {
+			ccArgs = &containerConfigArgs{
+				envVars: containerConfig.Env,
+			}
+			// Write CA certificate to a durable location for mounting into the workspace container.
+			// Use a shared certs directory under storageDir (not instanceDir which is cleaned up).
+			if containerConfig.CACertificate != "" && containerConfig.CACertificateContainerPath != "" {
+				certsDir := filepath.Join(p.storageDir, "certs", params.Name)
+				if mkErr := os.MkdirAll(certsDir, 0755); mkErr != nil {
+					return runtime.RuntimeInfo{}, fmt.Errorf("failed to create certs directory: %w", mkErr)
+				}
+				caPath := filepath.Join(certsDir, "onecli-ca.pem")
+				if writeErr := os.WriteFile(caPath, []byte(containerConfig.CACertificate), 0644); writeErr != nil {
+					return runtime.RuntimeInfo{}, fmt.Errorf("failed to write CA certificate: %w", writeErr)
+				}
+				ccArgs.caFilePath = caPath
+				ccArgs.caContainerPath = containerConfig.CACertificateContainerPath
+			}
+		}
+	}
+
+	// Build workspace container args with proxy env vars and CA cert mount from OneCLI
 	stepLogger.Start(fmt.Sprintf("Creating workspace container: %s", params.Name), "Workspace container created")
-	createArgs, err := p.buildContainerArgs(params, imageName)
+	createArgs, err := p.buildContainerArgs(params, imageName, ccArgs)
 	if err != nil {
+		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}
+
 	containerID, err := p.createContainer(ctx, createArgs)
 	if err != nil {
 		stepLogger.Fail(err)
@@ -301,13 +372,24 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	if err := p.writePodFiles(containerID, tmplData); err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to persist pod files: %w", err)
 	}
+	if ccArgs != nil && ccArgs.caContainerPath != "" {
+		if err := p.writeCAContainerPath(containerID, ccArgs.caContainerPath); err != nil {
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to persist CA container path: %w", err)
+		}
+	}
+
+	podCreatedOK = true
 
 	// Return RuntimeInfo
 	info := map[string]string{
-		"container_id": containerID,
-		"image_name":   imageName,
-		"source_path":  params.SourcePath,
-		"agent":        params.Agent,
+		"container_id":    containerID,
+		"image_name":      imageName,
+		"source_path":     params.SourcePath,
+		"agent":           params.Agent,
+		"onecli_web_port": fmt.Sprintf("%d", tmplData.OnecliWebPort),
+	}
+	if ccArgs != nil && ccArgs.caContainerPath != "" {
+		info["ca_container_path"] = ccArgs.caContainerPath
 	}
 
 	return runtime.RuntimeInfo{
@@ -315,6 +397,76 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		State: api.WorkspaceStateStopped,
 		Info:  info,
 	}, nil
+}
+
+// setupOnecli starts postgres, waits for it, then starts onecli to avoid migration race conditions.
+// After provisioning secrets and retrieving container config, it stops the pod.
+func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.StepLogger, l logger.Logger, podName string, tmplData podTemplateData, secrets []onecli.CreateSecretInput) (*onecli.ContainerConfig, error) {
+	postgresContainer := podName + "-postgres"
+	onecliContainer := podName + "-onecli"
+
+	// Start only the postgres container first
+	stepLogger.Start("Starting postgres", "Postgres started")
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", postgresContainer); err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("failed to start postgres: %w", err)
+	}
+
+	// Wait for postgres to be ready before starting onecli
+	stepLogger.Start("Waiting for postgres readiness", "Postgres ready")
+	if err := p.waitForPostgres(ctx, podName); err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("postgres not ready: %w", err)
+	}
+
+	// Now start the onecli container (postgres is ready, migrations will succeed)
+	stepLogger.Start("Starting OneCLI", "OneCLI started")
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", onecliContainer); err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("failed to start OneCLI: %w", err)
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%d", tmplData.OnecliWebPort)
+
+	stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
+	if err := waitForReady(ctx, baseURL); err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("OneCLI service not ready: %w", err)
+	}
+
+	// Get API key from OneCLI (bootstraps local user on first call)
+	creds := onecli.NewCredentialProvider(baseURL)
+	apiKey, err := creds.APIKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OneCLI API key: %w", err)
+	}
+
+	client := onecli.NewClient(baseURL, apiKey)
+
+	// Provision secrets
+	stepLogger.Start("Provisioning OneCLI secrets", "OneCLI secrets provisioned")
+	provisioner := onecli.NewSecretProvisioner(client)
+	if err := provisioner.ProvisionSecrets(ctx, secrets); err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("failed to provision OneCLI secrets: %w", err)
+	}
+
+	// Get container config (proxy env vars, CA cert, agent token)
+	stepLogger.Start("Retrieving OneCLI container config", "Container config retrieved")
+	containerConfig, err := client.GetContainerConfig(ctx)
+	if err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("failed to get container config: %w", err)
+	}
+
+	// Stop the pod before creating the workspace container
+	stepLogger.Start("Stopping OneCLI services", "OneCLI services stopped")
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "stop", podName); err != nil {
+		stepLogger.Fail(err)
+		return nil, fmt.Errorf("failed to stop pod after OneCLI setup: %w", err)
+	}
+
+	return containerConfig, nil
 }
 
 // writePodYAMLFile renders and writes the pod YAML template to the given path.

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -36,11 +36,9 @@ const defaultOnecliVersion = "1.17"
 
 // podTemplateData holds the values used to render the pod YAML template.
 type podTemplateData struct {
-	Name            string
-	PostgresPort    int
-	OnecliWebPort   int
-	OnecliProxyPort int
-	OnecliVersion   string
+	Name          string
+	OnecliWebPort int
+	OnecliVersion string
 }
 
 // validateCreateParams validates the create parameters.
@@ -258,18 +256,16 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	}
 
 	// Allocate random free ports for the pod
-	freePorts, err := findFreePorts(3)
+	freePorts, err := findFreePorts(1)
 	if err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to allocate free ports: %w", err)
 	}
 
 	// Render the pod YAML template
 	tmplData := podTemplateData{
-		Name:            params.Name,
-		PostgresPort:    freePorts[0],
-		OnecliWebPort:   freePorts[1],
-		OnecliProxyPort: freePorts[2],
-		OnecliVersion:   defaultOnecliVersion,
+		Name:          params.Name,
+		OnecliWebPort: freePorts[0],
+		OnecliVersion: defaultOnecliVersion,
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -410,7 +410,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildContainerArgs(params, imageName, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -464,7 +464,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildContainerArgs(params, imageName, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -513,7 +513,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildContainerArgs(params, imageName, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -550,7 +550,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildContainerArgs(params, imageName, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -572,6 +572,109 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		if !strings.Contains(argsStr, expectedGitconfig) {
 			t.Errorf("Expected .gitconfig config mount: %s", expectedGitconfig)
+		}
+	})
+
+	t.Run("with containerConfigArgs env vars and CA cert", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+		caFile := filepath.Join(t.TempDir(), "ca.pem")
+		if err := os.WriteFile(caFile, []byte("cert-data"), 0644); err != nil {
+			t.Fatalf("failed to write CA fixture: %v", err)
+		}
+
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+		}
+		imageName := "kdn-test-workspace"
+
+		ccArgs := &containerConfigArgs{
+			envVars: map[string]string{
+				"HTTP_PROXY":  "http://proxy:8080",
+				"HTTPS_PROXY": "https://proxy:8443",
+			},
+			caFilePath:      caFile,
+			caContainerPath: "/etc/ssl/certs/onecli-ca.pem",
+		}
+
+		args, err := p.buildContainerArgs(params, imageName, ccArgs)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+
+		argsStr := strings.Join(args, " ")
+
+		// Verify OneCLI proxy env vars are present
+		if !strings.Contains(argsStr, "-e HTTP_PROXY=http://proxy:8080") {
+			t.Error("Expected HTTP_PROXY env var")
+		}
+		if !strings.Contains(argsStr, "-e HTTPS_PROXY=https://proxy:8443") {
+			t.Error("Expected HTTPS_PROXY env var")
+		}
+
+		// Verify CA cert volume mount
+		expectedMount := fmt.Sprintf("-v %s:/etc/ssl/certs/onecli-ca.pem:ro,Z", caFile)
+		if !strings.Contains(argsStr, expectedMount) {
+			t.Errorf("Expected CA cert mount %q in args: %s", expectedMount, argsStr)
+		}
+	})
+
+	t.Run("onecli env vars override workspace env vars", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+
+		proxyValue := "http://user-proxy:9090"
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Environment: &[]workspace.EnvironmentVariable{
+					{Name: "HTTP_PROXY", Value: &proxyValue},
+				},
+			},
+		}
+		imageName := "kdn-test-workspace"
+
+		ccArgs := &containerConfigArgs{
+			envVars: map[string]string{
+				"HTTP_PROXY": "http://onecli-proxy:8080",
+			},
+		}
+
+		args, err := p.buildContainerArgs(params, imageName, ccArgs)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+
+		// Find the indices of both -e HTTP_PROXY entries
+		onecliIdx, wsIdx := -1, -1
+		for i, arg := range args {
+			if arg == "-e" && i+1 < len(args) {
+				if args[i+1] == "HTTP_PROXY=http://onecli-proxy:8080" {
+					onecliIdx = i
+				}
+				if args[i+1] == "HTTP_PROXY=http://user-proxy:9090" {
+					wsIdx = i
+				}
+			}
+		}
+
+		if onecliIdx == -1 {
+			t.Fatal("OneCLI HTTP_PROXY not found in args")
+		}
+		if wsIdx == -1 {
+			t.Fatal("Workspace HTTP_PROXY not found in args")
+		}
+		// OneCLI env var should come after workspace env var (later wins in podman)
+		if onecliIdx <= wsIdx {
+			t.Errorf("OneCLI HTTP_PROXY (index %d) should come after workspace HTTP_PROXY (index %d) for precedence", onecliIdx, wsIdx)
 		}
 	})
 
@@ -608,7 +711,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName)
+		args, err := p.buildContainerArgs(params, imageName, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -648,6 +751,77 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		if !strings.Contains(argsStr, "sleep infinity") {
 			t.Error("Expected sleep infinity command")
+		}
+	})
+
+	t.Run("with secret env vars", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+			SecretEnvVars: map[string]string{
+				"GH_TOKEN":     "placeholder",
+				"GITHUB_TOKEN": "placeholder",
+			},
+		}
+		imageName := "kdn-test-workspace"
+
+		args, err := p.buildContainerArgs(params, imageName, nil)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+
+		argsStr := strings.Join(args, " ")
+		if !strings.Contains(argsStr, "-e GH_TOKEN=placeholder") {
+			t.Error("Expected GH_TOKEN=placeholder environment variable")
+		}
+		if !strings.Contains(argsStr, "-e GITHUB_TOKEN=placeholder") {
+			t.Error("Expected GITHUB_TOKEN=placeholder environment variable")
+		}
+	})
+
+	t.Run("secret env vars skip workspace-defined vars", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+
+		customToken := "my-real-token"
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Environment: &[]workspace.EnvironmentVariable{
+					{Name: "GH_TOKEN", Value: &customToken},
+				},
+			},
+			SecretEnvVars: map[string]string{
+				"GH_TOKEN":     "placeholder",
+				"GITHUB_TOKEN": "placeholder",
+			},
+		}
+		imageName := "kdn-test-workspace"
+
+		args, err := p.buildContainerArgs(params, imageName, nil)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+
+		argsStr := strings.Join(args, " ")
+
+		if strings.Contains(argsStr, "GH_TOKEN=placeholder") {
+			t.Error("Secret env var GH_TOKEN should not override workspace-defined value")
+		}
+		if !strings.Contains(argsStr, "GH_TOKEN=my-real-token") {
+			t.Error("Expected workspace GH_TOKEN=my-real-token")
+		}
+		if !strings.Contains(argsStr, "GITHUB_TOKEN=placeholder") {
+			t.Error("Expected GITHUB_TOKEN=placeholder")
 		}
 	})
 }

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -16,6 +16,7 @@
 package podman
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -123,6 +124,14 @@ func (p *podmanRuntime) writePodFiles(containerID string, data podTemplateData) 
 	if err := os.WriteFile(p.podNamePath(containerID), []byte(data.Name), 0644); err != nil {
 		return fmt.Errorf("failed to write pod name file: %w", err)
 	}
+
+	tmplJSON, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal pod template data: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, podTemplateDataFile), tmplJSON, 0644); err != nil {
+		return fmt.Errorf("failed to write pod template data: %w", err)
+	}
 	return nil
 }
 
@@ -138,6 +147,40 @@ func (p *podmanRuntime) readPodName(containerID string) (string, error) {
 // cleanupPodFiles removes the pod metadata directory for a given container ID.
 func (p *podmanRuntime) cleanupPodFiles(containerID string) {
 	os.RemoveAll(p.podDir(containerID))
+}
+
+const (
+	podTemplateDataFile = "pod-template-data.json"
+	caContainerPathFile = "ca-container-path"
+)
+
+// writeCAContainerPath persists the CA certificate container path for a workspace.
+func (p *podmanRuntime) writeCAContainerPath(containerID, caPath string) error {
+	return os.WriteFile(filepath.Join(p.podDir(containerID), caContainerPathFile), []byte(caPath), 0644)
+}
+
+// readCAContainerPath reads the persisted CA certificate container path.
+// Returns empty string if not set.
+func (p *podmanRuntime) readCAContainerPath(containerID string) string {
+	data, err := os.ReadFile(filepath.Join(p.podDir(containerID), caContainerPathFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// readPodTemplateData reads the persisted pod template data for a container.
+func (p *podmanRuntime) readPodTemplateData(containerID string) (podTemplateData, error) {
+	path := filepath.Join(p.podDir(containerID), podTemplateDataFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return podTemplateData{}, fmt.Errorf("failed to read pod template data: %w", err)
+	}
+	var tmplData podTemplateData
+	if err := json.Unmarshal(data, &tmplData); err != nil {
+		return podTemplateData{}, fmt.Errorf("failed to unmarshal pod template data: %w", err)
+	}
+	return tmplData, nil
 }
 
 // ListAgents implements runtime.AgentLister.

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -189,11 +189,9 @@ func TestWritePodFiles(t *testing.T) {
 		containerID := "abc123"
 
 		data := podTemplateData{
-			Name:            "my-project",
-			PostgresPort:    30000,
-			OnecliWebPort:   30001,
-			OnecliProxyPort: 30002,
-			OnecliVersion:   "1.17",
+			Name:          "my-project",
+			OnecliWebPort: 30001,
+			OnecliVersion: "1.17",
 		}
 
 		err := p.writePodFiles(containerID, data)
@@ -216,14 +214,8 @@ func TestWritePodFiles(t *testing.T) {
 			t.Error("Container name within pod should remain 'onecli'")
 		}
 
-		if !strings.Contains(yamlStr, "hostPort: 30000") {
-			t.Error("Pod YAML should contain postgres hostPort 30000")
-		}
 		if !strings.Contains(yamlStr, "hostPort: 30001") {
 			t.Error("Pod YAML should contain onecli web hostPort 30001")
-		}
-		if !strings.Contains(yamlStr, "hostPort: 30002") {
-			t.Error("Pod YAML should contain onecli proxy hostPort 30002")
 		}
 		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
 			t.Error("Pod YAML should contain versioned onecli image")
@@ -237,11 +229,9 @@ func TestWritePodFiles(t *testing.T) {
 		containerID := "def456"
 
 		data := podTemplateData{
-			Name:            "test-ws",
-			PostgresPort:    40000,
-			OnecliWebPort:   40001,
-			OnecliProxyPort: 40002,
-			OnecliVersion:   "1.17",
+			Name:          "test-ws",
+			OnecliWebPort: 40001,
+			OnecliVersion: "1.17",
 		}
 
 		err := p.writePodFiles(containerID, data)
@@ -278,11 +268,9 @@ func TestCleanupPodFiles(t *testing.T) {
 	containerID := "abc123"
 
 	data := podTemplateData{
-		Name:            "my-ws",
-		PostgresPort:    50000,
-		OnecliWebPort:   50001,
-		OnecliProxyPort: 50002,
-		OnecliVersion:   "1.17",
+		Name:          "my-ws",
+		OnecliWebPort: 50001,
+		OnecliVersion: "1.17",
 	}
 
 	if err := p.writePodFiles(containerID, data); err != nil {
@@ -307,11 +295,9 @@ func TestRenderPodYAML(t *testing.T) {
 		t.Parallel()
 
 		data := podTemplateData{
-			Name:            "my-project",
-			PostgresPort:    32100,
-			OnecliWebPort:   32101,
-			OnecliProxyPort: 32102,
-			OnecliVersion:   "1.17",
+			Name:          "my-project",
+			OnecliWebPort: 32101,
+			OnecliVersion: "1.17",
 		}
 
 		result, err := renderPodYAML(data)
@@ -324,14 +310,8 @@ func TestRenderPodYAML(t *testing.T) {
 		if !strings.Contains(yamlStr, "  name: my-project\n") {
 			t.Error("Expected rendered YAML to contain pod name 'my-project'")
 		}
-		if !strings.Contains(yamlStr, "hostPort: 32100") {
-			t.Error("Expected rendered YAML to contain postgres hostPort 32100")
-		}
 		if !strings.Contains(yamlStr, "hostPort: 32101") {
 			t.Error("Expected rendered YAML to contain onecli web hostPort 32101")
-		}
-		if !strings.Contains(yamlStr, "hostPort: 32102") {
-			t.Error("Expected rendered YAML to contain onecli proxy hostPort 32102")
 		}
 		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
 			t.Error("Expected rendered YAML to contain versioned onecli image")
@@ -342,17 +322,23 @@ func TestRenderPodYAML(t *testing.T) {
 		if strings.Contains(yamlStr, "volumes:") {
 			t.Error("Expected rendered YAML to NOT contain volumes section")
 		}
+
+		// Postgres (5432) and proxy (10255) ports should NOT have hostPort mappings
+		if strings.Contains(yamlStr, "hostPort: 5432") {
+			t.Error("Expected rendered YAML to NOT contain hostPort for postgres (5432)")
+		}
+		if strings.Contains(yamlStr, "hostPort: 10255") {
+			t.Error("Expected rendered YAML to NOT contain hostPort for proxy (10255)")
+		}
 	})
 
 	t.Run("does not contain original template placeholders", func(t *testing.T) {
 		t.Parallel()
 
 		data := podTemplateData{
-			Name:            "test",
-			PostgresPort:    10000,
-			OnecliWebPort:   10001,
-			OnecliProxyPort: 10002,
-			OnecliVersion:   "2.0",
+			Name:          "test",
+			OnecliWebPort: 10001,
+			OnecliVersion: "2.0",
 		}
 
 		result, err := renderPodYAML(data)

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -5,7 +5,10 @@ metadata:
   labels:
     app: onecli
 spec:
-  restartPolicy: Always
+  # Never: we manage container start order ourselves (postgres before onecli) to
+  # avoid migration race conditions. OnFailure/Always would restart onecli before
+  # postgres is ready, causing repeated migration failures.
+  restartPolicy: Never
   containers:
     - name: postgres
       image: docker.io/library/postgres:18-alpine
@@ -16,10 +19,6 @@ spec:
           value: "onecli"
         - name: POSTGRES_DB
           value: "onecli"
-      ports:
-        - containerPort: 5432
-          hostPort: {{.PostgresPort}}
-          hostIP: "127.0.0.1"
       readinessProbe:
         exec:
           command:
@@ -42,10 +41,9 @@ spec:
           value: "http://127.0.0.1:10254"
         - name: APP_URL
           value: "http://127.0.0.1:10254"
+        - name: GATEWAY_BASE_URL
+          value: "localhost:10255"
       ports:
         - containerPort: 10254
           hostPort: {{.OnecliWebPort}}
-          hostIP: "127.0.0.1"
-        - containerPort: 10255
-          hostPort: {{.OnecliProxyPort}}
           hostIP: "127.0.0.1"

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -17,6 +17,8 @@ package podman
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
@@ -68,6 +70,7 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	}
 
 	p.cleanupPodFiles(id)
+	p.cleanupCerts(podName)
 
 	// Remove the container image
 	imageName := info.Info["image_name"]
@@ -80,6 +83,15 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	}
 
 	return nil
+}
+
+// cleanupCerts removes the CA certificate directory for a workspace.
+func (p *podmanRuntime) cleanupCerts(podName string) {
+	certsDir := filepath.Join(p.storageDir, "certs", podName)
+	if !strings.HasPrefix(filepath.Clean(certsDir), filepath.Join(p.storageDir, "certs")+string(filepath.Separator)) {
+		return
+	}
+	os.RemoveAll(certsDir)
 }
 
 // isNotFoundError checks if an error indicates that a container was not found.

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/openkaiden/kdn/pkg/logger"
@@ -73,6 +74,15 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start pod: %w", err)
 	}
 
+	// Install OneCLI CA certificate into system trust store if present
+	if caPath := p.readCAContainerPath(id); caPath != "" {
+		stepLogger.Start("Installing CA certificate", "CA certificate installed")
+		if err := p.installCACert(ctx, id, caPath); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to install CA certificate: %w", err)
+		}
+	}
+
 	// Verify workspace container status
 	stepLogger.Start("Verifying container status", "Container status verified")
 	info, err := p.getContainerInfo(ctx, id)
@@ -82,6 +92,25 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	}
 
 	return info, nil
+}
+
+const caTrustAnchorPath = "/etc/pki/ca-trust/source/anchors/onecli-ca.pem"
+
+// installCACert copies the OneCLI CA certificate into the system trust store
+// and runs update-ca-trust so all tools (gh, curl, etc.) trust the proxy.
+func (p *podmanRuntime) installCACert(ctx context.Context, containerID, caContainerPath string) error {
+	l := logger.FromContext(ctx)
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(),
+		"exec", containerID, "sudo", "cp", caContainerPath, caTrustAnchorPath,
+	); err != nil {
+		return fmt.Errorf("failed to copy CA certificate: %w", err)
+	}
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(),
+		"exec", containerID, "sudo", "update-ca-trust",
+	); err != nil {
+		return fmt.Errorf("update-ca-trust failed: %w", err)
+	}
+	return nil
 }
 
 // waitForPostgres polls the postgres container inside the pod until pg_isready succeeds.
@@ -104,4 +133,37 @@ func (p *podmanRuntime) waitForPostgres(ctx context.Context, podName string) err
 		}
 	}
 	return fmt.Errorf("postgres not ready after %d retries: %w", postgresMaxRetries, lastErr)
+}
+
+const (
+	readinessTimeout  = 60 * time.Second
+	readinessInterval = 2 * time.Second
+)
+
+// waitForReady polls the OneCLI health endpoint until it responds or the timeout expires.
+func waitForReady(ctx context.Context, baseURL string) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, readinessTimeout)
+	defer cancel()
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+
+	for {
+		req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, baseURL+"/api/health", nil)
+		if err != nil {
+			return err
+		}
+		resp, err := httpClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+			return fmt.Errorf("timed out after %s waiting for OneCLI at %s: %w", readinessTimeout, baseURL, timeoutCtx.Err())
+		case <-time.After(readinessInterval):
+		}
+	}
 }

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -90,11 +90,9 @@ func setupPodFiles(t *testing.T, p *podmanRuntime, containerID, workspaceName st
 		p.storageDir = t.TempDir()
 	}
 	data := podTemplateData{
-		Name:            workspaceName,
-		PostgresPort:    15432,
-		OnecliWebPort:   20254,
-		OnecliProxyPort: 20255,
-		OnecliVersion:   defaultOnecliVersion,
+		Name:          workspaceName,
+		OnecliWebPort: 20254,
+		OnecliVersion: defaultOnecliVersion,
 	}
 	if err := p.writePodFiles(containerID, data); err != nil {
 		t.Fatalf("failed to write pod files for test: %v", err)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/onecli"
 )
 
 // Runtime manages the lifecycle of workspace instances in a specific execution environment.
@@ -73,6 +74,17 @@ type CreateParams struct {
 	// forward slashes (e.g., ".claude/settings.json"), values are file contents.
 	// This map can be nil or empty if no default settings are configured.
 	AgentSettings map[string][]byte
+
+	// OnecliSecrets contains pre-mapped OneCLI secret definitions to provision
+	// when the workspace is first started. These are created by the manager from
+	// workspace configuration secrets. Can be nil or empty.
+	OnecliSecrets []onecli.CreateSecretInput
+
+	// SecretEnvVars maps environment variable names to placeholder values.
+	// These are derived from secret service definitions (e.g. GH_TOKEN, GITHUB_TOKEN
+	// for the "github" secret type) and injected into the workspace container so
+	// that CLI tools detect a configured credential. Real auth goes through OneCLI proxy.
+	SecretEnvVars map[string]string
 }
 
 // RuntimeInfo contains information about a runtime instance.

--- a/pkg/secretservicesetup/register_test.go
+++ b/pkg/secretservicesetup/register_test.go
@@ -188,8 +188,8 @@ func TestAvailableSecretServicesContainGitHub(t *testing.T) {
 	if svc.Name() != "github" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "github")
 	}
-	if svc.HostPattern() != `api\.github\.com` {
-		t.Errorf("HostPattern() = %q, want %q", svc.HostPattern(), `api\.github\.com`)
+	if svc.HostPattern() != "api.github.com" {
+		t.Errorf("HostPattern() = %q, want %q", svc.HostPattern(), "api.github.com")
 	}
 	if svc.Path() != "" {
 		t.Errorf("Path() = %q, want empty string", svc.Path())

--- a/pkg/secretservicesetup/secretservices.json
+++ b/pkg/secretservicesetup/secretservices.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "github",
-    "hostPattern": "api\\.github\\.com",
+    "hostPattern": "api.github.com",
     "headerName": "Authorization",
     "headerTemplate": "Bearer ${value}",
     "envVars": ["GH_TOKEN", "GITHUB_TOKEN"]


### PR DESCRIPTION
Map workspace secrets to OneCLI secret definitions and provision them
during workspace creation. The OneCLI proxy env vars and CA certificate
are injected into the workspace container for transparent credential
injection via the gateway.

The way I tested it:

- create an account and API token on ollama.com
- generate a Github personal access token
- create/edit ~/.kdn/config/projects.json and add 
```
{
  "": {
    "secrets": [
      {
        "type": "github",
        "value": "<real GH_TOKEN>"
      },
      {
        "type": "other",
        "name": "Ollama",
        "value": "<real OLLAMA_API_KEY>",
        "header": "Authorization",
        "headerTemplate": "Bearer ${value}",
        "hosts": [
          "ollama.com"
        ]
      }
    ]
  }
}
```
- `./kdn init /path/to/my-project --runtime podman --agent opencode --show-logs`
- `./kdn start my-project`
- `./kdn terminal my-project` opencode should open
- `/models` then `ctrl+a` to select the provider
- Select `Ollama Cloud` and enter a fake value for the API Key (`FAKE_API_KEY`)
- pick your model (I tried `kimi-k2.5`)
- ask something, it should work
- type `! env | grep TOKEN`, it should show the GH_TOKEN and GITHUB_TOKEN have a `placeholder` value
- type `! gh auth status`, it should should you're correctly authenticated with Github

<img width="1436" height="1055" alt="Screenshot 2026-04-21 at 12 13 19" src="https://github.com/user-attachments/assets/f6f7f278-bf86-48aa-b7f6-86b45fcec38c" />


The onecli web port is exposed to the host, so you can access it and change the Ollama key value, to something wrong. When you return to the opencode tui, next interaction will show `Unauthorized: unauthorized`

Fixes #266 and #295
