### PR TITLE
fix(instances): sanitize workspace names to ensure runtime compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,8 @@ manager.Stop(ctx, id)
 manager.Terminal(ctx, id, []string{"bash"})
 ```
 
+**Workspace Name Sanitization:** The manager automatically sanitizes workspace names — whether auto-generated from the source directory basename or provided via `--name`. Names are lowercased and any run of invalid characters (spaces, `@`, etc.) is collapsed into a single hyphen. This ensures compatibility with runtimes like Podman that require lowercase image names.
+
 **For detailed manager API and project detection, use:** `/working-with-instances-manager`
 
 ### Cross-Platform Path Handling

--- a/README.md
+++ b/README.md
@@ -2474,6 +2474,7 @@ kdn init --runtime podman --agent claude --show-logs
 #### Workspace Naming
 
 - If `--name` is not provided, the name is automatically generated from the last component of the sources directory path
+- Names are automatically sanitized: uppercased letters are lowercased and any run of characters that are not alphanumeric, hyphens, dots, or underscores (including spaces) is collapsed into a single hyphen
 - If a workspace with the same name already exists, kdn automatically appends an increment (`-2`, `-3`, etc.) to ensure uniqueness
 
 **Examples:**
@@ -2481,6 +2482,14 @@ kdn init --runtime podman --agent claude --show-logs
 # First workspace in /home/user/project
 kdn init /home/user/project --runtime podman --agent claude
 # Name: "project"
+
+# Directory with spaces in its name
+kdn init "/home/user/my project" --runtime podman --agent claude
+# Name: "my-project"
+
+# Custom name with uppercase letters
+kdn init /home/user/project --runtime podman --agent claude --name MyWork
+# Name: "mywork"
 
 # Second workspace with the same directory name
 kdn init /home/user/another-location/project --runtime podman --agent claude --name "project"

--- a/README.md
+++ b/README.md
@@ -2474,7 +2474,7 @@ kdn init --runtime podman --agent claude --show-logs
 #### Workspace Naming
 
 - If `--name` is not provided, the name is automatically generated from the last component of the sources directory path
-- Names are automatically sanitized: uppercased letters are lowercased and any run of characters that are not alphanumeric, hyphens, dots, or underscores (including spaces) is collapsed into a single hyphen
+- Names are automatically sanitized: uppercased letters are lowercased, any run of characters that are not alphanumeric, hyphens, dots, or underscores (including spaces) is collapsed into a single hyphen, and leading/trailing separators (hyphens, dots, underscores) are stripped
 - If a workspace with the same name already exists, kdn automatically appends an increment (`-2`, `-3`, etc.) to ensure uniqueness
 
 **Examples:**

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -206,8 +207,8 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 	if name == "" {
 		name = m.generateUniqueName(inst.GetSourceDir(), instances)
 	} else {
-		// Ensure the provided name is unique
-		name = m.ensureUniqueName(name, instances)
+		// Ensure the provided name is sanitized and unique
+		name = m.ensureUniqueName(sanitizeName(name), instances)
 	}
 
 	// Use custom project identifier if provided, otherwise auto-detect
@@ -653,12 +654,26 @@ func (m *manager) RegisterSecretService(service secretservice.SecretService) err
 	return m.secretServiceRegistry.Register(service)
 }
 
+var invalidNameChars = regexp.MustCompile(`[^a-z0-9._-]+`)
+
+// sanitizeName converts a name to a valid workspace name by lowercasing it
+// and replacing invalid characters with hyphens.
+func sanitizeName(name string) string {
+	name = strings.ToLower(name)
+	name = invalidNameChars.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if name == "" {
+		return "workspace"
+	}
+	return name
+}
+
 // generateUniqueName generates a unique name from the source directory
 // by extracting the last component of the path and adding an increment if needed
 func (m *manager) generateUniqueName(sourceDir string, instances []Instance) string {
 	// Extract the last component of the source directory
 	baseName := filepath.Base(sourceDir)
-	return m.ensureUniqueName(baseName, instances)
+	return m.ensureUniqueName(sanitizeName(baseName), instances)
 }
 
 // ensureUniqueName ensures the name is unique by adding an increment if needed

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -661,7 +661,7 @@ var invalidNameChars = regexp.MustCompile(`[^a-z0-9._-]+`)
 func sanitizeName(name string) string {
 	name = strings.ToLower(name)
 	name = invalidNameChars.ReplaceAllString(name, "-")
-	name = strings.Trim(name, "-")
+	name = strings.Trim(name, "-._")
 	if name == "" {
 		return "workspace"
 	}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -1786,6 +1786,37 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 	})
 }
 
+func TestSanitizeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "valid name unchanged", input: "my-project", want: "my-project"},
+		{name: "spaces replaced with hyphens", input: "my project", want: "my-project"},
+		{name: "uppercase lowercased", input: "MyProject", want: "myproject"},
+		{name: "uppercase with spaces", input: "My Project", want: "my-project"},
+		{name: "name from issue 255", input: "Lemminx", want: "lemminx"},
+		{name: "consecutive invalid chars collapsed", input: "foo  bar", want: "foo-bar"},
+		{name: "leading and trailing hyphens trimmed", input: " -foo- ", want: "foo"},
+		{name: "all invalid chars returns workspace", input: "---", want: "workspace"},
+		{name: "empty string returns workspace", input: "", want: "workspace"},
+		{name: "dots and underscores preserved", input: "my.project_v2", want: "my.project_v2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitizeName(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManager_ensureUniqueName(t *testing.T) {
 	t.Parallel()
 
@@ -2015,12 +2046,46 @@ func TestManager_generateUniqueName(t *testing.T) {
 
 		// Get the current working directory
 		wd, _ := os.Getwd()
-		expectedName := filepath.Base(wd)
+		expectedName := sanitizeName(filepath.Base(wd))
 
 		result := mgr.generateUniqueName(wd, instances)
 
 		if result != expectedName {
 			t.Errorf("generateUniqueName() = %v, want %v", result, expectedName)
+		}
+	})
+
+	t.Run("sanitizes spaces in directory name", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+
+		mgr := m.(*manager)
+
+		instances := []Instance{}
+
+		result := mgr.generateUniqueName("/tmp/my project", instances)
+
+		if result != "my-project" {
+			t.Errorf("generateUniqueName() = %v, want my-project", result)
+		}
+	})
+
+	t.Run("sanitizes uppercase directory name", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+
+		mgr := m.(*manager)
+
+		instances := []Instance{}
+
+		result := mgr.generateUniqueName("/tmp/MyProject", instances)
+
+		if result != "myproject" {
+			t.Errorf("generateUniqueName() = %v, want myproject", result)
 		}
 	})
 }

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -1804,6 +1804,9 @@ func TestSanitizeName(t *testing.T) {
 		{name: "all invalid chars returns workspace", input: "---", want: "workspace"},
 		{name: "empty string returns workspace", input: "", want: "workspace"},
 		{name: "dots and underscores preserved", input: "my.project_v2", want: "my.project_v2"},
+		{name: "leading dot trimmed", input: ".foo", want: "foo"},
+		{name: "trailing underscore trimmed", input: "foo_", want: "foo"},
+		{name: "only separator chars returns workspace", input: "_", want: "workspace"},
 	}
 
 	for _, tt := range tests {
@@ -2065,7 +2068,8 @@ func TestManager_generateUniqueName(t *testing.T) {
 
 		instances := []Instance{}
 
-		result := mgr.generateUniqueName("/tmp/my project", instances)
+		sourceDir := filepath.Join(t.TempDir(), "my project")
+		result := mgr.generateUniqueName(sourceDir, instances)
 
 		if result != "my-project" {
 			t.Errorf("generateUniqueName() = %v, want my-project", result)
@@ -2082,7 +2086,8 @@ func TestManager_generateUniqueName(t *testing.T) {
 
 		instances := []Instance{}
 
-		result := mgr.generateUniqueName("/tmp/MyProject", instances)
+		sourceDir := filepath.Join(t.TempDir(), "MyProject")
+		result := mgr.generateUniqueName(sourceDir, instances)
 
 		if result != "myproject" {
 			t.Errorf("generateUniqueName() = %v, want myproject", result)

--- a/skills/working-with-instances-manager/SKILL.md
+++ b/skills/working-with-instances-manager/SKILL.md
@@ -41,6 +41,7 @@ Add a new workspace instance to the manager:
 instance, err := instances.NewInstance(instances.NewInstanceParams{
     SourceDir: sourceDir,
     ConfigDir: configDir,
+    Name:      name, // Optional: user-provided name, sanitized by manager
 })
 if err != nil {
     return fmt.Errorf("failed to create instance: %w", err)
@@ -60,15 +61,21 @@ if err != nil {
 ```
 
 The `Add()` method:
-1. Detects project ID (or uses custom override)
-2. Loads project config (global `""` + project-specific merged)
-3. Loads agent config (if agent name provided)
-4. Merges configs: workspace → global → project → agent
-5. Reads agent settings files from `<storage-dir>/config/<agent>/` into `map[string][]byte`
-6. Calls agent's `SkipOnboarding()` method if agent is registered (e.g., Claude agent automatically sets onboarding flags)
-7. Calls agent's `SetModel()` method if model is specified (takes precedence over model in settings files)
-8. Calls agent's `SetMCPServers()` method if the merged config contains MCP servers (writes them into agent settings)
-9. Passes merged config and modified agent settings to runtime for injection into workspace
+1. Sanitizes and generates a unique workspace name:
+   - If `Name` is empty, it is derived from the source directory basename
+   - The name is sanitized: lowercased, spaces and invalid characters replaced with hyphens
+   - A numeric suffix (`-2`, `-3`, …) is appended if the name is already in use
+2. Detects project ID (or uses custom override)
+3. Loads project config (global `""` + project-specific merged)
+4. Loads agent config (if agent name provided)
+5. Merges configs: workspace → global → project → agent
+6. Reads agent settings files from `<storage-dir>/config/<agent>/` into `map[string][]byte`
+7. Calls agent's `SkipOnboarding()` method if agent is registered (e.g., Claude agent automatically sets onboarding flags)
+8. Calls agent's `SetModel()` method if model is specified (takes precedence over model in settings files)
+9. Calls agent's `SetMCPServers()` method if the merged config contains MCP servers (writes them into agent settings)
+10. Passes merged config and modified agent settings to runtime for injection into workspace
+
+**Name sanitization rules:** valid characters are `[a-z0-9._-]`. Uppercase letters are lowercased; any run of invalid characters (spaces, `@`, `+`, etc.) is collapsed into a single hyphen; leading and trailing hyphens are stripped. An empty result falls back to `"workspace"`.
 
 ### List - Get All Instances
 

--- a/skills/working-with-instances-manager/SKILL.md
+++ b/skills/working-with-instances-manager/SKILL.md
@@ -75,7 +75,7 @@ The `Add()` method:
 9. Calls agent's `SetMCPServers()` method if the merged config contains MCP servers (writes them into agent settings)
 10. Passes merged config and modified agent settings to runtime for injection into workspace
 
-**Name sanitization rules:** valid characters are `[a-z0-9._-]`. Uppercase letters are lowercased; any run of invalid characters (spaces, `@`, `+`, etc.) is collapsed into a single hyphen; leading and trailing hyphens are stripped. An empty result falls back to `"workspace"`.
+**Name sanitization rules:** valid characters are `[a-z0-9._-]`. Uppercase letters are lowercased; any run of invalid characters (spaces, `@`, `+`, etc.) is collapsed into a single hyphen; leading and trailing separators (hyphens, dots, and underscores) are stripped. An empty result falls back to `"workspace"`.
 
 ### List - Get All Instances
 


### PR DESCRIPTION
Workspace names containing spaces or uppercase letters caused Podman image builds to fail, since Podman requires image names to be lowercase and free of whitespace. Names are now sanitized in the manager: lowercased and any run of invalid characters replaced with a single hyphen.

Fixes #240

Fixes #255