### PR TITLE
fix(cmd): exit non-zero for unknown subcommands

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -39,10 +40,18 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:          "kdn",
-		Short:        "Launch and manage AI agent workspaces with custom configurations",
-		Args:         cobra.NoArgs,
+		Use:   "kdn",
+		Short: "Launch and manage AI agent workspaces with custom configurations",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return nil
+		},
 		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	// Add command groups

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -68,6 +68,28 @@ func TestExecute_NoArgs(t *testing.T) {
 	}
 }
 
+func TestExecute_UnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"foobar"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Expected Execute() to return an error for unknown command")
+	}
+
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("Expected error to contain 'unknown command', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "foobar") {
+		t.Errorf("Expected error to contain 'foobar', got: %s", err.Error())
+	}
+}
+
 func TestRootCmd_StorageFlag(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/service.go
+++ b/pkg/cmd/service.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +29,15 @@ func NewServiceCmd() *cobra.Command {
 		Use:   "service",
 		Short: "Manage services",
 		Long:  "Manage secret services registered with kdn",
-		Args:  cobra.NoArgs,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	// Add subcommands

--- a/pkg/cmd/service_test.go
+++ b/pkg/cmd/service_test.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +52,27 @@ func TestServiceCmd(t *testing.T) {
 
 	if !foundList {
 		t.Error("Expected service command to have 'list' subcommand")
+	}
+}
+
+func TestServiceCmd_UnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"service", "foobar"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Expected Execute() to return an error for unknown command")
+	}
+
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("Expected error to contain 'unknown command', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "foobar") {
+		t.Errorf("Expected error to contain 'foobar', got: %s", err.Error())
 	}
 }

--- a/pkg/cmd/workspace.go
+++ b/pkg/cmd/workspace.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +29,15 @@ func NewWorkspaceCmd() *cobra.Command {
 		Use:   "workspace",
 		Short: "Manage workspaces",
 		Long:  "Manage workspaces registered with kdn init",
-		Args:  cobra.NoArgs,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	// Add subcommands

--- a/pkg/cmd/workspace_test.go
+++ b/pkg/cmd/workspace_test.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +52,27 @@ func TestWorkspaceCmd(t *testing.T) {
 
 	if !foundList {
 		t.Error("Expected workspace command to have 'list' subcommand")
+	}
+}
+
+func TestWorkspaceCmd_UnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"workspace", "foobar"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Expected Execute() to return an error for unknown command")
+	}
+
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("Expected error to contain 'unknown command', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "foobar") {
+		t.Errorf("Expected error to contain 'foobar', got: %s", err.Error())
 	}
 }

--- a/skills/add-parent-command/SKILL.md
+++ b/skills/add-parent-command/SKILL.md
@@ -24,6 +24,8 @@ Create `pkg/cmd/<parent>.go` with the following structure:
 package cmd
 
 import (
+    "fmt"
+
     "github.com/spf13/cobra"
 )
 
@@ -37,7 +39,15 @@ kdn <parent> --help
 
 # Execute a subcommand
 kdn <parent> <subcommand>`,
-        Args: cobra.NoArgs,  // Parent commands typically don't accept args directly
+        Args: func(cmd *cobra.Command, args []string) error {
+            if len(args) > 0 {
+                return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+            }
+            return nil
+        },
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
     }
 
     // Add subcommands
@@ -55,6 +65,8 @@ kdn <parent> <subcommand>`,
 package cmd
 
 import (
+    "fmt"
+
     "github.com/spf13/cobra"
 )
 
@@ -73,7 +85,15 @@ kdn workspace list
 
 # Remove a workspace
 kdn workspace remove <id>`,
-        Args: cobra.NoArgs,
+        Args: func(cmd *cobra.Command, args []string) error {
+            if len(args) > 0 {
+                return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+            }
+            return nil
+        },
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
     }
 
     // Add subcommands
@@ -251,12 +271,12 @@ Update relevant documentation to describe the parent command and its subcommands
 
 ## Key Points
 
-- **No Direct Execution**: Parent commands typically don't have RunE/Run - they just organize subcommands
-- **Args Validation**: Always set `Args: cobra.NoArgs` since parent commands don't accept arguments directly
-- **Subcommand Organization**: Use `cmd.AddCommand()` to register all subcommands
-- **Help Text**: Provide clear Short and Long descriptions explaining the purpose of the command group
-- **Examples**: Show how to use --help and demonstrate key subcommands
-- **Testing**: Verify subcommand structure and examples
+- **Always set RunE**: Parent commands must define `RunE` (showing help) so that Cobra treats them as runnable and runs `Args` validation. Without `RunE`, Cobra skips `Args` entirely and returns exit code 0 for unknown subcommands.
+- **Custom Args for clear errors**: Use a custom `Args` function instead of `cobra.NoArgs` to produce `unknown command "foo" for "kdn parent"` rather than the generic `accepts 0 arg(s), received 1`.
+- **Subcommand Organization**: Use `cmd.AddCommand()` to register all subcommands.
+- **Help Text**: Provide clear Short and Long descriptions explaining the purpose of the command group.
+- **Examples**: Show how to use --help and demonstrate key subcommands.
+- **Testing**: Verify subcommand structure and that unknown subcommands return a non-zero exit code.
 
 ## Parent Command Patterns
 
@@ -267,7 +287,15 @@ func NewParentCmd() *cobra.Command {
     cmd := &cobra.Command{
         Use:   "parent",
         Short: "Parent command category",
-        Args:  cobra.NoArgs,
+        Args: func(cmd *cobra.Command, args []string) error {
+            if len(args) > 0 {
+                return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+            }
+            return nil
+        },
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
     }
 
     cmd.AddCommand(NewParentSubCmd1())
@@ -286,7 +314,15 @@ func NewParentCmd() *cobra.Command {
     cmd := &cobra.Command{
         Use:   "parent",
         Short: "Parent command category",
-        Args:  cobra.NoArgs,
+        Args: func(cmd *cobra.Command, args []string) error {
+            if len(args) > 0 {
+                return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+            }
+            return nil
+        },
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
     }
 
     // Persistent flags are inherited by subcommands
@@ -308,7 +344,15 @@ func NewParentCmd() *cobra.Command {
     cmd := &cobra.Command{
         Use:   "parent",
         Short: "Parent command category",
-        Args:  cobra.NoArgs,
+        Args: func(cmd *cobra.Command, args []string) error {
+            if len(args) > 0 {
+                return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+            }
+            return nil
+        },
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
         PersistentPreRun: func(cmd *cobra.Command, args []string) {
             // Common initialization for all subcommands
             // This runs before any subcommand's PreRun
@@ -345,6 +389,8 @@ pkg/cmd/
 package cmd
 
 import (
+    "fmt"
+
     "github.com/spf13/cobra"
 )
 
@@ -367,7 +413,15 @@ kdn workspace remove <id>
 
 # Initialize a new workspace
 kdn workspace init /path/to/project`,
-        Args: cobra.NoArgs,
+        Args: func(cmd *cobra.Command, args []string) error {
+            if len(args) > 0 {
+                return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+            }
+            return nil
+        },
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
     }
 
     // Add subcommands


### PR DESCRIPTION
Parent commands (kdn, workspace, service) had no Run/RunE defined, so Cobra skipped Args validation and returned nil (exit 0) when an unknown subcommand was given. Adding RunE makes each command runnable so Args validation fires, and the custom Args func produces the expected "unknown command" error message.

Updated the add-parent-command skill to reflect this pattern in all templates, patterns, and examples.

Closes #242