### PR TITLE
fix(runtime/podman): remove image when workspace is removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3103,7 +3103,7 @@ kdn remove a1b2c3d4e5f6... --force
 
 - You can specify the workspace using either its name or ID (both can be obtained using the `workspace list` or `list` command)
 - The command always outputs the workspace ID, even when removed by name
-- Removing a workspace only unregisters it from kdn; it does not delete any files from the sources or configuration directories
+- Removing a workspace unregisters it from kdn and cleans up runtime resources (e.g. for the Podman runtime, the container and its image are deleted); it does not delete any files from the sources or configuration directories
 - If the workspace name or ID is not found, the command will fail with a helpful error message
 - Use `--force` to automatically stop a running workspace before removing it; without this flag, removing a running workspace will fail
 - Tab completion for this command suggests only non-running workspaces by default; when `--force` is specified, all workspaces are suggested

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -69,6 +69,16 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 
 	p.cleanupPodFiles(id)
 
+	// Remove the container image
+	imageName := info.Info["image_name"]
+	if imageName != "" {
+		stepLogger.Start(fmt.Sprintf("Removing image: %s", imageName), "Image removed")
+		if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "image", "rm", imageName); err != nil && !isImageNotFoundError(err) {
+			stepLogger.Fail(err)
+			return fmt.Errorf("failed to remove image: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -82,4 +92,14 @@ func isNotFoundError(err error) bool {
 		strings.Contains(errMsg, "no such object") ||
 		strings.Contains(errMsg, "error getting container") ||
 		strings.Contains(errMsg, "failed to inspect container")
+}
+
+// isImageNotFoundError checks if an error indicates that an image was not found.
+func isImageNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "image not known") ||
+		strings.Contains(errMsg, "no such image")
 }

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -73,6 +73,9 @@ func TestRemove_Success(t *testing.T) {
 	// Verify pod rm -f was called
 	fakeExec.AssertRunCalledWith(t, "pod", "rm", "-f", podName)
 
+	// Verify image rm was called
+	fakeExec.AssertRunCalledWith(t, "image", "rm", "kdn-test")
+
 	// Verify pod files were cleaned up
 	if _, err := os.Stat(p.podDir(containerID)); !os.IsNotExist(err) {
 		t.Error("Expected pod directory to be cleaned up after Remove")
@@ -168,6 +171,70 @@ func TestRemove_PodRemoveFailure(t *testing.T) {
 	}
 
 	fakeExec.AssertRunCalledWith(t, "pod", "rm", "-f", podName)
+}
+
+func TestRemove_ImageNotFound_GracefullyHandled(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "inspect" {
+			return []byte(fmt.Sprintf("%s|stopped|kdn-test", containerID)), nil
+		}
+		return nil, fmt.Errorf("unexpected command: %v", args)
+	}
+
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "image" && args[1] == "rm" {
+			return fmt.Errorf("image not known")
+		}
+		return nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	setupPodFiles(t, p, containerID, "my-project")
+
+	err := p.Remove(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Remove() should succeed when image is not found, got error: %v", err)
+	}
+
+	fakeExec.AssertRunCalledWith(t, "image", "rm", "kdn-test")
+}
+
+func TestRemove_ImageRemoveError(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "inspect" {
+			return []byte(fmt.Sprintf("%s|stopped|kdn-test", containerID)), nil
+		}
+		return nil, fmt.Errorf("unexpected command: %v", args)
+	}
+
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "image" && args[1] == "rm" {
+			return fmt.Errorf("permission denied")
+		}
+		return nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	setupPodFiles(t, p, containerID, "my-project")
+
+	err := p.Remove(context.Background(), containerID)
+	if err == nil {
+		t.Fatal("Expected error when image rm fails, got nil")
+	}
+
+	if !contains(err.Error(), "failed to remove image") {
+		t.Errorf("Expected error message to contain 'failed to remove image', got: %v", err)
+	}
 }
 
 func TestIsNotFoundError(t *testing.T) {
@@ -279,6 +346,10 @@ func TestRemove_StepLogger_Success(t *testing.T) {
 		{
 			inProgress: fmt.Sprintf("Removing pod: %s", podName),
 			completed:  "Pod removed",
+		},
+		{
+			inProgress: "Removing image: kdn-test",
+			completed:  "Image removed",
 		},
 	}
 


### PR DESCRIPTION
When a workspace was removed, the Podman image built for it was left behind. The Remove() method now runs `podman image rm` after deleting the pod, handling image-not-found gracefully (idempotent).

Closes #238