### PR TITLE
fix(runtime/podman): use fully-qualified postgres image name

### DIFF
--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -8,7 +8,7 @@ spec:
   restartPolicy: Always
   containers:
     - name: postgres
-      image: postgres:18-alpine
+      image: docker.io/library/postgres:18-alpine
       env:
         - name: POSTGRES_USER
           value: "onecli"


### PR DESCRIPTION
## Summary
- Use `docker.io/library/postgres:18-alpine` instead of the short name `postgres:18-alpine` in the onecli pod YAML template
- Podman enforces short-name resolution and cannot prompt for the registry when running non-interactively (e.g., `--output json`), causing `kube play` to fail with exit status 125

Fixes https://github.com/openkaiden/kdn/issues/292

## Test plan
- [x] Verified `kdn init` with `--output json` succeeds after the fix
- [x] All existing tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)