### PR TITLE
chore(build): disable goreleaser checksum file generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,6 +66,9 @@ changelog:
       - "^ci:"
       - "^chore:"
 
+checksum:
+  disable: true
+
 release:
   github:
     owner: openkaiden


### PR DESCRIPTION
GitHub natively provides SHA digests for release artifacts, making the separate checksums.txt file redundant.

Closes #143