### PR TITLE
feat(cmd): add `kdn secret list` command

### DIFF
--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -77,7 +77,7 @@ To retrieve all stored secrets (metadata only — no secret values):
 
 ```go
 items, err := store.List()
-// items is []secret.ListItem{Name, Type, Description}
+// items is []secret.ListItem{Name, Type, Description, Hosts, Path, Header, HeaderTemplate, Envs}
 ```
 
 ## Adding a New Named Secret Type

--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -17,7 +17,7 @@ The secrets system uses a two-layer architecture: a **Store** that persists secr
 
 ## Key Components
 
-- **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error` — the only operation currently exposed
+- **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error` and `List() ([]ListItem, error)`
 - **Store implementation** (`pkg/secret/store.go`): writes the value to the keychain, metadata to `secrets.json`
 - **SecretService interface** (`pkg/secretservice/secretservice.go`): describes a named type — host pattern, path, header name, header template, env vars
 - **Registry** (`pkg/secretservice/registry.go`): maps names to `SecretService` implementations
@@ -72,6 +72,13 @@ err := store.Create(secret.CreateParams{
 ```
 
 `Create` checks for a duplicate name before touching the keychain. `ErrSecretAlreadyExists` is returned if the name is already taken.
+
+To retrieve all stored secrets (metadata only — no secret values):
+
+```go
+items, err := store.List()
+// items is []secret.ListItem{Name, Type, Description}
+```
 
 ## Adding a New Named Secret Type
 
@@ -145,4 +152,16 @@ c := &secretCreateCmd{
     value:      "ghp_token",
     validTypes: []string{"github", secret.TypeOther},
 }
+```
+
+For commands that call `store.List()`, implement a fake that satisfies the full `Store` interface:
+
+```go
+type fakeListStore struct {
+    items []secret.ListItem
+    err   error
+}
+
+func (f *fakeListStore) Create(params secret.CreateParams) error { return nil }
+func (f *fakeListStore) List() ([]secret.ListItem, error)        { return f.items, f.err }
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.1
 require (
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.3.0
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.3.0
+	github.com/openkaiden/kdn-api/cli/go v0.4.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.4.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/openkaiden/kdn-api/cli/go v0.3.0 h1:2RuELs2lZPv/zTxBxjZ1H7ixvd1F5SMm1mlTIoFK9xA=
-github.com/openkaiden/kdn-api/cli/go v0.3.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.3.0 h1:CVwBtTm06tdFD9CXCcWppjSrjMT3UlxjHdFT8iBWCsA=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.3.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.4.0 h1:Z7sF+bsz85sby2iH97lvvPzqf02K2I3k1ovSrCzwreQ=
+github.com/openkaiden/kdn-api/cli/go v0.4.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.4.0 h1:zASComTK9z6T30jn+KD2KWUaNt8gF7DDzkW5n+LOG7U=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.4.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=

--- a/pkg/cmd/secret.go
+++ b/pkg/cmd/secret.go
@@ -41,6 +41,7 @@ func NewSecretCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewSecretCreateCmd())
+	cmd.AddCommand(NewSecretListCmd())
 
 	return cmd
 }

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -39,6 +39,10 @@ func (f *fakeStore) Create(params secret.CreateParams) error {
 	return f.err
 }
 
+func (f *fakeStore) List() ([]secret.ListItem, error) {
+	return nil, nil
+}
+
 // buildPreRunCmd creates a cobra.Command that mirrors the flag set seen by
 // preRun when called through the real command tree.
 func buildPreRunCmd(storageDir string) *cobra.Command {

--- a/pkg/cmd/secret_list.go
+++ b/pkg/cmd/secret_list.go
@@ -19,27 +19,38 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 
 	"github.com/fatih/color"
+	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
 )
 
 type secretListCmd struct {
-	store secret.Store
+	store  secret.Store
+	output string
 }
 
 func (s *secretListCmd) preRun(cmd *cobra.Command, args []string) error {
+	if s.output != "" && s.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", s.output)
+	}
+
+	if s.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
 	storageDir, err := cmd.Flags().GetString("storage")
 	if err != nil {
-		return fmt.Errorf("failed to read --storage flag: %w", err)
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to read --storage flag: %w", err))
 	}
 	absStorageDir, err := filepath.Abs(storageDir)
 	if err != nil {
-		return fmt.Errorf("failed to resolve storage directory path: %w", err)
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to resolve storage directory path: %w", err))
 	}
 
 	s.store = secret.NewStore(absStorageDir)
@@ -49,9 +60,17 @@ func (s *secretListCmd) preRun(cmd *cobra.Command, args []string) error {
 func (s *secretListCmd) run(cmd *cobra.Command, args []string) error {
 	items, err := s.store.List()
 	if err != nil {
-		return fmt.Errorf("failed to list secrets: %w", err)
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to list secrets: %w", err))
 	}
 
+	if s.output == "json" {
+		return s.outputJSON(cmd, items)
+	}
+
+	return s.displayTable(cmd, items)
+}
+
+func (s *secretListCmd) displayTable(cmd *cobra.Command, items []secret.ListItem) error {
 	out := cmd.OutOrStdout()
 	if len(items) == 0 {
 		fmt.Fprintln(out, "No secrets found")
@@ -73,6 +92,41 @@ func (s *secretListCmd) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func (s *secretListCmd) outputJSON(cmd *cobra.Command, items []secret.ListItem) error {
+	secrets := make([]api.SecretInfo, 0, len(items))
+	for _, item := range items {
+		info := api.SecretInfo{
+			Name:        item.Name,
+			Type:        item.Type,
+			Description: item.Description,
+		}
+		if len(item.Hosts) > 0 {
+			hosts := item.Hosts
+			info.Hosts = &hosts
+		}
+		if item.Path != "" {
+			info.Path = &item.Path
+		}
+		if item.Header != "" {
+			info.Header = &item.Header
+		}
+		if item.HeaderTemplate != "" {
+			info.HeaderTemplate = &item.HeaderTemplate
+		}
+		secrets = append(secrets, info)
+	}
+
+	response := api.SecretsList{Items: secrets}
+
+	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to marshal secrets to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
 func NewSecretListCmd() *cobra.Command {
 	c := &secretListCmd{}
 
@@ -81,11 +135,20 @@ func NewSecretListCmd() *cobra.Command {
 		Short: "List all secrets",
 		Long:  "List all secrets stored in the kdn storage directory",
 		Example: `# List all secrets
-kdn secret list`,
+kdn secret list
+
+# List secrets in JSON format
+kdn secret list --output json
+
+# List using short flag
+kdn secret list -o json`,
 		Args:    cobra.NoArgs,
 		PreRunE: c.preRun,
 		RunE:    c.run,
 	}
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
 	return cmd
 }

--- a/pkg/cmd/secret_list.go
+++ b/pkg/cmd/secret_list.go
@@ -1,0 +1,91 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/fatih/color"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+)
+
+type secretListCmd struct {
+	store secret.Store
+}
+
+func (s *secretListCmd) preRun(cmd *cobra.Command, args []string) error {
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return fmt.Errorf("failed to read --storage flag: %w", err)
+	}
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve storage directory path: %w", err)
+	}
+
+	s.store = secret.NewStore(absStorageDir)
+	return nil
+}
+
+func (s *secretListCmd) run(cmd *cobra.Command, args []string) error {
+	items, err := s.store.List()
+	if err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No secrets found")
+		return nil
+	}
+
+	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+	columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+	tbl := table.New("NAME", "TYPE", "DESCRIPTION")
+	tbl.WithWriter(out)
+	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+	for _, item := range items {
+		tbl.AddRow(item.Name, item.Type, item.Description)
+	}
+
+	tbl.Print()
+	return nil
+}
+
+func NewSecretListCmd() *cobra.Command {
+	c := &secretListCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all secrets",
+		Long:  "List all secrets stored in the kdn storage directory",
+		Example: `# List all secrets
+kdn secret list`,
+		Args:    cobra.NoArgs,
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	return cmd
+}

--- a/pkg/cmd/secret_list.go
+++ b/pkg/cmd/secret_list.go
@@ -113,6 +113,10 @@ func (s *secretListCmd) outputJSON(cmd *cobra.Command, items []secret.ListItem) 
 		if item.HeaderTemplate != "" {
 			info.HeaderTemplate = &item.HeaderTemplate
 		}
+		if len(item.Envs) > 0 {
+			envs := item.Envs
+			info.Envs = &envs
+		}
 		secrets = append(secrets, info)
 	}
 

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -35,6 +35,8 @@ type fakeListStore struct {
 	err   error
 }
 
+var _ secret.Store = (*fakeListStore)(nil)
+
 func (f *fakeListStore) Create(params secret.CreateParams) error { return nil }
 
 func (f *fakeListStore) List() ([]secret.ListItem, error) {

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -68,7 +68,7 @@ func TestSecretListCmd_Examples(t *testing.T) {
 		t.Fatalf("failed to parse examples: %v", err)
 	}
 
-	expectedCount := 1
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
 	}
@@ -91,6 +91,18 @@ func TestSecretListCmd_PreRun(t *testing.T) {
 	}
 	if c.store == nil {
 		t.Error("expected store to be initialised")
+	}
+}
+
+func TestSecretListCmd_PreRun_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &secretListCmd{output: "xml"}
+	cmd := &cobra.Command{}
+	cmd.Flags().String("storage", t.TempDir(), "")
+
+	if err := c.preRun(cmd, []string{}); err == nil {
+		t.Fatal("expected error for unsupported output format")
 	}
 }
 
@@ -144,13 +156,74 @@ func TestSecretListCmd_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("json output contains all fields", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretListCmd{
+			output: "json",
+			store: &fakeListStore{
+				items: []secret.ListItem{
+					{
+						Name:           "my-token",
+						Type:           "other",
+						Description:    "My token",
+						Hosts:          []string{"api.example.com"},
+						Path:           "/v1",
+						Header:         "Authorization",
+						HeaderTemplate: "Bearer ${value}",
+					},
+				},
+			},
+		}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		for _, want := range []string{`"items"`, `"my-token"`, `"other"`, `"My token"`, `"api.example.com"`, `"/v1"`, `"Authorization"`, `"Bearer ${value}"`} {
+			if !strings.Contains(output, want) {
+				t.Errorf("expected %q in JSON output, got: %s", want, output)
+			}
+		}
+	})
+
+	t.Run("json output empty list returns items array", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretListCmd{output: "json", store: &fakeListStore{}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		if !strings.Contains(out.String(), `"items"`) {
+			t.Errorf("expected JSON with items key, got: %s", out.String())
+		}
+	})
+
 	t.Run("store error propagates", func(t *testing.T) {
 		t.Parallel()
 
-		c := &secretListCmd{store: &fakeListStore{err: errors.New("store error")}}
+		sentinel := errors.New("store error")
+		c := &secretListCmd{store: &fakeListStore{err: sentinel}}
+		var out bytes.Buffer
 		cmd := &cobra.Command{}
-		if err := c.run(cmd, []string{}); err == nil {
+		cmd.SetOut(&out)
+		err := c.run(cmd, []string{})
+		if err == nil {
 			t.Fatal("expected error when store fails")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected error to wrap sentinel, got: %v", err)
 		}
 	})
 }

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -171,6 +171,7 @@ func TestSecretListCmd_Run(t *testing.T) {
 						Path:           "/v1",
 						Header:         "Authorization",
 						HeaderTemplate: "Bearer ${value}",
+						Envs:           []string{"MY_TOKEN"},
 					},
 				},
 			},
@@ -185,7 +186,7 @@ func TestSecretListCmd_Run(t *testing.T) {
 			t.Fatalf("run() failed: %v", err)
 		}
 		output := out.String()
-		for _, want := range []string{`"items"`, `"my-token"`, `"other"`, `"My token"`, `"api.example.com"`, `"/v1"`, `"Authorization"`, `"Bearer ${value}"`} {
+		for _, want := range []string{`"items"`, `"my-token"`, `"other"`, `"My token"`, `"api.example.com"`, `"/v1"`, `"Authorization"`, `"Bearer ${value}"`, `"MY_TOKEN"`} {
 			if !strings.Contains(output, want) {
 				t.Errorf("expected %q in JSON output, got: %s", want, output)
 			}

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -1,0 +1,154 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/spf13/cobra"
+)
+
+// fakeListStore is a Store implementation that returns a fixed list for testing.
+type fakeListStore struct {
+	items []secret.ListItem
+	err   error
+}
+
+func (f *fakeListStore) Create(params secret.CreateParams) error { return nil }
+
+func (f *fakeListStore) List() ([]secret.ListItem, error) {
+	return f.items, f.err
+}
+
+func TestSecretListCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewSecretListCmd()
+	if cmd == nil {
+		t.Fatal("NewSecretListCmd() returned nil")
+	}
+	if cmd.Use != "list" {
+		t.Errorf("expected Use %q, got %q", "list", cmd.Use)
+	}
+}
+
+func TestSecretListCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewSecretListCmd()
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("failed to parse examples: %v", err)
+	}
+
+	expectedCount := 1
+	if len(commands) != expectedCount {
+		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	if err := testutil.ValidateCommandExamples(rootCmd, cmd.Example); err != nil {
+		t.Errorf("example validation failed: %v", err)
+	}
+}
+
+func TestSecretListCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	c := &secretListCmd{}
+	cmd := &cobra.Command{}
+	cmd.Flags().String("storage", t.TempDir(), "")
+
+	if err := c.preRun(cmd, []string{}); err != nil {
+		t.Fatalf("preRun() failed: %v", err)
+	}
+	if c.store == nil {
+		t.Error("expected store to be initialised")
+	}
+}
+
+func TestSecretListCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("displays empty message when no secrets", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretListCmd{store: &fakeListStore{}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		if !strings.Contains(out.String(), "No secrets found") {
+			t.Errorf("expected 'No secrets found' in output, got: %s", out.String())
+		}
+	})
+
+	t.Run("table output contains secret fields", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretListCmd{store: &fakeListStore{
+			items: []secret.ListItem{
+				{Name: "my-token", Type: "github", Description: "My GitHub token"},
+			},
+		}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		if !strings.Contains(output, "my-token") {
+			t.Errorf("expected 'my-token' in output, got: %s", output)
+		}
+		if !strings.Contains(output, "github") {
+			t.Errorf("expected 'github' in output, got: %s", output)
+		}
+		if !strings.Contains(output, "My GitHub token") {
+			t.Errorf("expected description in output, got: %s", output)
+		}
+	})
+
+	t.Run("store error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretListCmd{store: &fakeListStore{err: errors.New("store error")}}
+		cmd := &cobra.Command{}
+		if err := c.run(cmd, []string{}); err == nil {
+			t.Fatal("expected error when store fails")
+		}
+	})
+}

--- a/pkg/cmd/secret_test.go
+++ b/pkg/cmd/secret_test.go
@@ -41,14 +41,20 @@ func TestSecretCmd(t *testing.T) {
 	}
 
 	foundCreate := false
+	foundList := false
 	for _, sub := range subCmds {
-		if sub.Use == "create <name>" {
+		switch sub.Use {
+		case "create <name>":
 			foundCreate = true
-			break
+		case "list":
+			foundList = true
 		}
 	}
 	if !foundCreate {
 		t.Error("expected secret command to have 'create' subcommand")
+	}
+	if !foundList {
+		t.Error("expected secret command to have 'list' subcommand")
 	}
 }
 

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -40,9 +40,13 @@ type CreateParams struct {
 
 // ListItem holds the metadata fields returned by List.
 type ListItem struct {
-	Name        string
-	Type        string
-	Description string
+	Name           string
+	Type           string
+	Description    string
+	Hosts          []string
+	Path           string
+	Header         string
+	HeaderTemplate string
 }
 
 // Store manages persistent storage of secrets.

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -47,6 +47,7 @@ type ListItem struct {
 	Path           string
 	Header         string
 	HeaderTemplate string
+	Envs           []string
 }
 
 // Store manages persistent storage of secrets.

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -38,9 +38,18 @@ type CreateParams struct {
 	Envs           []string
 }
 
+// ListItem holds the metadata fields returned by List.
+type ListItem struct {
+	Name        string
+	Type        string
+	Description string
+}
+
 // Store manages persistent storage of secrets.
 type Store interface {
 	// Create stores the secret value in the system keychain and persists
 	// the remaining metadata to the storage directory.
 	Create(params CreateParams) error
+	// List returns the metadata for all stored secrets.
+	List() ([]ListItem, error)
 }

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -116,9 +116,13 @@ func (s *store) List() ([]ListItem, error) {
 	items := make([]ListItem, 0, len(sf.Secrets))
 	for _, rec := range sf.Secrets {
 		items = append(items, ListItem{
-			Name:        rec.Name,
-			Type:        rec.Type,
-			Description: rec.Description,
+			Name:           rec.Name,
+			Type:           rec.Type,
+			Description:    rec.Description,
+			Hosts:          rec.Hosts,
+			Path:           rec.Path,
+			Header:         rec.Header,
+			HeaderTemplate: rec.HeaderTemplate,
 		})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	gokeyring "github.com/zalando/go-keyring"
 )
@@ -120,6 +121,7 @@ func (s *store) List() ([]ListItem, error) {
 			Description: rec.Description,
 		})
 	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
 	return items, nil
 }
 

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -123,6 +123,7 @@ func (s *store) List() ([]ListItem, error) {
 			Path:           rec.Path,
 			Header:         rec.Header,
 			HeaderTemplate: rec.HeaderTemplate,
+			Envs:           rec.Envs,
 		})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -106,6 +106,23 @@ func (s *store) Create(params CreateParams) error {
 	return s.appendAndSave(sf, params)
 }
 
+// List reads secrets.json and returns metadata for all stored secrets.
+func (s *store) List() ([]ListItem, error) {
+	sf, err := s.loadSecretsFile()
+	if err != nil {
+		return nil, err
+	}
+	items := make([]ListItem, 0, len(sf.Secrets))
+	for _, rec := range sf.Secrets {
+		items = append(items, ListItem{
+			Name:        rec.Name,
+			Type:        rec.Type,
+			Description: rec.Description,
+		})
+	}
+	return items, nil
+}
+
 // loadSecretsFile reads and parses secrets.json, returning an empty struct when
 // the file does not yet exist.
 func (s *store) loadSecretsFile() (secretsFile, error) {

--- a/pkg/secret/store_test.go
+++ b/pkg/secret/store_test.go
@@ -207,7 +207,9 @@ func TestStore_List(t *testing.T) {
 		if items[0].Name != "tok1" || items[0].Type != "github" || items[0].Description != "first" {
 			t.Errorf("unexpected item[0]: %+v", items[0])
 		}
-		if items[1].Name != "tok2" || items[1].Type != TypeOther {
+		if items[1].Name != "tok2" || items[1].Type != TypeOther ||
+			len(items[1].Hosts) != 1 || items[1].Hosts[0] != "example.com" ||
+			items[1].Path != "/" || items[1].Header != "X-Key" || items[1].HeaderTemplate != "${value}" {
 			t.Errorf("unexpected item[1]: %+v", items[1])
 		}
 	})

--- a/pkg/secret/store_test.go
+++ b/pkg/secret/store_test.go
@@ -166,6 +166,53 @@ func TestStore_Create_ErrorsOnDuplicate(t *testing.T) {
 	}
 }
 
+func TestStore_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty when no secrets exist", func(t *testing.T) {
+		t.Parallel()
+
+		st := newStoreWithKeyring(t.TempDir(), &fakeKeyring{})
+		items, err := st.List()
+		if err != nil {
+			t.Fatalf("List() failed: %v", err)
+		}
+		if len(items) != 0 {
+			t.Errorf("expected 0 items, got %d", len(items))
+		}
+	})
+
+	t.Run("returns name, type, description for each secret", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		st := newStoreWithKeyring(dir, &fakeKeyring{})
+
+		if err := st.Create(CreateParams{Name: "tok1", Type: "github", Description: "first", Value: "v1"}); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+		if err := st.Create(CreateParams{Name: "tok2", Type: TypeOther, Value: "v2",
+			Hosts: []string{"example.com"}, Path: "/", Header: "X-Key", HeaderTemplate: "${value}"}); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		items, err := st.List()
+		if err != nil {
+			t.Fatalf("List() failed: %v", err)
+		}
+		if len(items) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(items))
+		}
+
+		if items[0].Name != "tok1" || items[0].Type != "github" || items[0].Description != "first" {
+			t.Errorf("unexpected item[0]: %+v", items[0])
+		}
+		if items[1].Name != "tok2" || items[1].Type != TypeOther {
+			t.Errorf("unexpected item[1]: %+v", items[1])
+		}
+	})
+}
+
 func TestStore_Create_KeychainError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds a List() method to the Store interface (returns name, type, description for each secret) and implements it in the store. The new `kdn secret list` subcommand displays stored secrets in a formatted table; prints "No secrets found" when the store is empty.

Closes #300