### PR TITLE
feat(devcontainers): implement features package for OCI and local resolution

### DIFF
--- a/.agents/skills/working-with-devcontainers/SKILL.md
+++ b/.agents/skills/working-with-devcontainers/SKILL.md
@@ -75,9 +75,14 @@ for i, feat := range ordered {
 
 **Version-stripped matching:** `installsAfter` values are always versionless per the spec (e.g. `ghcr.io/devcontainers/features/common-utils`). `Order` strips the version tag from registered feature IDs when resolving dependencies, so a feature registered as `…/common-utils:2` is correctly matched by an `installsAfter` entry of `…/common-utils`.
 
+**Soft-dependency semantics:** Per the Dev Container spec, `installsAfter` is a hint — not a hard requirement. An `installsAfter` value that refers to a feature not present in `feats` (e.g. a feature the user didn't select, or one from a different layer) is silently ignored. This is intentional and distinct from a _missing metadata entry_, which is always an error because it means `Download` was not called before `Order`.
+
 ```go
 ordered, err := features.Order(feats, metadata)
-// err is non-nil on cycle or missing metadata entry
+// err is non-nil on:
+//   - a cycle in installsAfter dependencies
+//   - a feature in feats with no corresponding metadata entry
+// installsAfter references to features not in feats are silently ignored
 ```
 
 ## FeatureOptions.Merge
@@ -166,7 +171,7 @@ For IDs beginning with `./` or `../`, `Download`:
 
 | Capability | Status |
 |---|---|
-| `installsAfter` soft-dependency ordering | ✅ implemented, with version-stripped ID matching |
+| `installsAfter` soft-dependency ordering | ✅ implemented, with version-stripped ID matching; references to features not in `feats` are silently ignored per spec |
 | Cycle detection | ✅ implemented |
 | `dependsOn` hard-dependency ordering | ❌ not implemented |
 | `overrideFeatureInstallOrder` priority-based sorting | ❌ not implemented |

--- a/.agents/skills/working-with-devcontainers/SKILL.md
+++ b/.agents/skills/working-with-devcontainers/SKILL.md
@@ -84,7 +84,7 @@ ordered, err := features.Order(feats, metadata)
 
 Key normalisation: keys are uppercased and runs of non-alphanumeric characters replaced with `_`.
 
-```
+```text
 "install-tools" → "INSTALL_TOOLS"
 "go.version"    → "GO_VERSION"
 ```

--- a/.agents/skills/working-with-devcontainers/SKILL.md
+++ b/.agents/skills/working-with-devcontainers/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: working-with-devcontainers
+description: Guide to the devcontainers features package including the Feature/FeatureMetadata/FeatureOptions interfaces, OCI and local feature implementations, and the two-phase FromMap→Download→Order workflow
+argument-hint: ""
+---
+
+# Working with Dev Container Features
+
+The `pkg/devcontainers/features` package models, downloads, and orders Dev Container Features as defined by the [Dev Container spec](https://containers.dev/implementors/features/). A feature is a reusable environment component distributed as a directory containing `install.sh` and `devcontainer-feature.json`.
+
+## Interfaces
+
+All public types are interfaces; implementations are unexported.
+
+```go
+// Feature models a single feature that can be resolved to a local directory.
+type Feature interface {
+    ID() string
+    Download(ctx context.Context, destDir string) (FeatureMetadata, error)
+}
+
+// FeatureMetadata holds data parsed from devcontainer-feature.json.
+type FeatureMetadata interface {
+    ContainerEnv() map[string]string  // env vars baked into the image
+    Options() FeatureOptions
+    InstallsAfter() []string          // always versionless IDs per spec
+}
+
+// FeatureOptions validates and merges user options with spec defaults.
+type FeatureOptions interface {
+    Merge(userOptions map[string]interface{}) (map[string]string, error)
+}
+```
+
+## Two-Phase Workflow
+
+```go
+// Phase 1 – construct Feature instances (no I/O).
+feats, userOptions, err := features.FromMap(cfg.Features, workspaceConfigDir)
+
+// Phase 2 – download each feature into the build context.
+metadata := make(map[string]features.FeatureMetadata, len(feats))
+for i, feat := range feats {
+    destDir := filepath.Join(buildContextDir, "features", strconv.Itoa(i))
+    meta, err := feat.Download(ctx, destDir)
+    metadata[feat.ID()] = meta
+}
+
+// Phase 3 – order for installation.
+ordered, err := features.Order(feats, metadata)
+
+// Phase 4 – emit Containerfile instructions using ordered features.
+for i, feat := range ordered {
+    merged, err := metadata[feat.ID()].Options().Merge(userOptions[feat.ID()])
+    // COPY features/<i>/ /tmp/feature-<i>/
+    // RUN for each merged env var + install.sh
+}
+```
+
+## FromMap
+
+`FromMap` classifies each feature ID and returns a deterministically sorted slice:
+
+| ID pattern | Implementation | Notes |
+|---|---|---|
+| `./…` or `../…` | `localFeature` | resolved relative to `workspaceConfigDir` |
+| `https?://…` | — | returns `"feature Tgz URI is not supported: <id>"` |
+| anything else | `ociFeature` | OCI registry artifact |
+
+`FromMap` does **no** network I/O. The returned slice is sorted by ID so behaviour is deterministic before `Order` runs.
+
+## Order
+
+`Order` runs Kahn's topological sort on `installsAfter` dependencies. Every feature in `feats` must have an entry in `metadata` (i.e. all features must be downloaded first).
+
+**Version-stripped matching:** `installsAfter` values are always versionless per the spec (e.g. `ghcr.io/devcontainers/features/common-utils`). `Order` strips the version tag from registered feature IDs when resolving dependencies, so a feature registered as `…/common-utils:2` is correctly matched by an `installsAfter` entry of `…/common-utils`.
+
+```go
+ordered, err := features.Order(feats, metadata)
+// err is non-nil on cycle or missing metadata entry
+```
+
+## FeatureOptions.Merge
+
+Key normalisation: keys are uppercased and runs of non-alphanumeric characters replaced with `_`.
+
+```
+"install-tools" → "INSTALL_TOOLS"
+"go.version"    → "GO_VERSION"
+```
+
+Type rules:
+- `"string"` — value must be a Go `string`; validated against `enum` if present
+- `"boolean"` — value is `bool` or `"true"`/`"false"` string; coerced to `"true"`/`"false"` in output
+- Defaults from `devcontainer-feature.json` are applied before user options
+
+```go
+merged, err := meta.Options().Merge(map[string]interface{}{
+    "version":       "20",
+    "install-tools": true,
+})
+// merged["VERSION"] == "20"
+// merged["INSTALL_TOOLS"] == "true"
+```
+
+## OCI Feature Implementation
+
+`Download` on an `ociFeature`:
+
+1. Parses the OCI reference — `[registry/]repository[:tag|@digest]`. First component is a registry if it contains `.` or `:` or equals `localhost`; otherwise defaults to `ghcr.io`.
+2. Fetches the manifest (`application/vnd.oci.image.manifest.v1+json`). On HTTP 401 it parses the `WWW-Authenticate: Bearer` challenge and fetches an anonymous token from the realm URL.
+3. Downloads each layer blob and extracts it via `extractTar`: peeks at the first two bytes — `0x1f 0x8b` → gzip-compressed tar, otherwise plain tar. (`application/vnd.devcontainers.layer.v1+tar` blobs are plain tar despite the name.)
+4. Sanitises extracted paths against directory traversal.
+5. Parses `devcontainer-feature.json` from `destDir` and returns it as `FeatureMetadata`.
+
+The bearer token is reused for all subsequent blob fetches within the same `Download` call.
+
+## Local Feature Implementation
+
+For IDs beginning with `./` or `../`, `Download`:
+
+1. Resolves the path relative to `workspaceConfigDir` using `filepath.FromSlash` for cross-platform safety.
+2. Copies the directory tree into `destDir`.
+3. Parses `devcontainer-feature.json` from `destDir`.
+
+## Spec Coverage
+
+### Feature ID formats
+
+| Format | Status |
+|---|---|
+| OCI registry artifact (`ghcr.io/org/repo/feature:1`) | ✅ implemented |
+| Local file tree (`./…`, `../…`) | ✅ implemented |
+| HTTPS tarball URI (`https://…`) | ❌ not supported — `FromMap` returns an explicit error |
+
+### devcontainer-feature.json fields
+
+| Field | Status |
+|---|---|
+| `containerEnv` | ✅ parsed, returned via `ContainerEnv()` |
+| `options` (type, default, enum) | ✅ parsed, returned via `Options()` |
+| `installsAfter` | ✅ parsed, used by `Order()` |
+| `id`, `version`, `name`, `description`, `documentationURL` | parsed by `devcontainerFeatureJSON` but not exposed in `FeatureMetadata` |
+| `options.proposals` | parsed but not enforced — proposals are free-form UI hints, not a strict enum |
+| `mounts` | ❌ not parsed — planned in a follow-up issue |
+| `privileged` | ❌ not parsed — planned in a follow-up issue |
+| `capAdd`, `securityOpt`, `init`, `entrypoint` | ❌ not parsed |
+| `dependsOn` | ❌ not parsed — hard dependencies are not yet modelled; only `installsAfter` (soft) is used |
+| `overrideFeatureInstallOrder` | ❌ not parsed — priority-based round ordering is not implemented |
+| `customizations`, `legacyIds`, `deprecated`, `keywords`, `licenseURL` | ❌ not parsed |
+
+### OCI support
+
+| Capability | Status |
+|---|---|
+| Tag references (`:1`, `:latest`) | ✅ implemented |
+| Digest references (`@sha256:…`) | ✅ implemented |
+| Anonymous Bearer token auth (via `WWW-Authenticate` challenge) | ✅ implemented |
+| Gzip-compressed tar layers (`0x1f 0x8b` magic) | ✅ implemented |
+| Plain tar layers (`application/vnd.devcontainers.layer.v1+tar`) | ✅ implemented |
+| Private / authenticated registries (username + password) | ❌ not implemented |
+| OCI image index / multi-platform manifests | ❌ not implemented — `Download` will fail if the registry returns an index instead of a single manifest |
+| Docker manifest v2 (`application/vnd.docker.distribution.manifest.v2+json`) | ❌ not implemented — only `application/vnd.oci.image.manifest.v1+json` is requested |
+
+### Ordering
+
+| Capability | Status |
+|---|---|
+| `installsAfter` soft-dependency ordering | ✅ implemented, with version-stripped ID matching |
+| Cycle detection | ✅ implemented |
+| `dependsOn` hard-dependency ordering | ❌ not implemented |
+| `overrideFeatureInstallOrder` priority-based sorting | ❌ not implemented |
+
+### Out of scope for this package
+
+Lifecycle hooks (`onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`) and `customizations` are container-orchestration concerns handled outside this package and are not modelled here.
+
+## Testing
+
+### Unit tests — local features as fixtures
+
+Use a local feature directory in `t.TempDir()` to test `FeatureOptions.Merge` without network I/O:
+
+```go
+featureDir := filepath.Join(workspaceDir, "my-feature")
+os.MkdirAll(featureDir, 0755)
+data, _ := json.Marshal(map[string]interface{}{
+    "options": map[string]interface{}{
+        "version": map[string]interface{}{"type": "string", "default": "latest"},
+    },
+})
+os.WriteFile(filepath.Join(featureDir, "devcontainer-feature.json"), data, 0644)
+
+feats, _, _ := features.FromMap(
+    map[string]map[string]interface{}{"./my-feature": nil},
+    workspaceDir,
+)
+meta, _ := feats[0].Download(context.Background(), t.TempDir())
+result, _ := meta.Options().Merge(nil)
+// result["VERSION"] == "latest"
+```
+
+### Unit tests — Order with fakes
+
+Implement the `Feature` and `FeatureMetadata` interfaces inline:
+
+```go
+type fakeFeature struct{ id string }
+func (f *fakeFeature) ID() string { return f.id }
+func (f *fakeFeature) Download(_ context.Context, _ string) (features.FeatureMetadata, error) {
+    return nil, nil
+}
+
+type fakeMetadata struct{ installsAfter []string }
+func (m *fakeMetadata) ContainerEnv() map[string]string  { return nil }
+func (m *fakeMetadata) Options() features.FeatureOptions { return nil }
+func (m *fakeMetadata) InstallsAfter() []string          { return m.installsAfter }
+```
+
+### Integration tests — OCI with httptest
+
+To test OCI download without hitting a real registry, inject a custom `*http.Client` via `features.NewOCIFeatureWithClient` and redirect `https://` to a local `httptest.NewServer`:
+
+```go
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // serve manifest and blobs
+}))
+defer srv.Close()
+
+host := strings.TrimPrefix(srv.URL, "http://")
+feat := features.NewOCIFeatureWithClient(host+"/repo/feature:tag", &http.Client{
+    Transport: &rewriteTransport{host: host},
+})
+meta, err := feat.Download(ctx, destDir)
+```
+
+```go
+type rewriteTransport struct{ host string }
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    u := *req.URL
+    u.Scheme, u.Host = "http", rt.host
+    req2 := req.Clone(req.Context())
+    req2.URL = &u
+    return http.DefaultTransport.RoundTrip(req2)
+}
+```
+
+### Integration tests against the real registry
+
+Tag the file `//go:build integration` and name tests `TestIntegration_*`. Run with:
+
+```bash
+go test -tags integration -run TestIntegration_ -timeout 2m ./pkg/devcontainers/features/...
+```
+
+Real-registry tests live in `pkg/devcontainers/features/oci_integration_test.go`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,21 @@ The secret service system provides a pluggable architecture for managing secret 
 
 **For detailed guidance on the full secrets abstraction (Store, registry, adding new types), use:** `/working-with-secrets`
 
+### Dev Container Features
+
+The `pkg/devcontainers/features` package models, downloads, and orders Dev Container Features (OCI registry artifacts or local file trees) prior to container image generation.
+
+**Key Components:**
+- **`Feature` interface** (`pkg/devcontainers/features/features.go`): `ID()` + `Download(ctx, destDir) (FeatureMetadata, error)`
+- **`FeatureMetadata` interface**: exposes `ContainerEnv()`, `Options()`, `InstallsAfter()` parsed from `devcontainer-feature.json`
+- **`FeatureOptions` interface**: `Merge(userOptions) (map[string]string, error)` — normalises keys (uppercase, non-alphanumeric → `_`), applies defaults, validates types and enums
+- **`FromMap`**: classifies IDs (`./…` → local, `https?://` → error, otherwise → OCI), returns a sorted `[]Feature` slice plus the user-options map — no I/O
+- **`Order`**: topological sort (Kahn's algorithm) on `installsAfter` fields; matches versionless `installsAfter` IDs against versioned registered IDs by stripping the tag
+
+**Typical call sequence:** `FromMap` → `Feature.Download` (parallel) → `Order` → `FeatureOptions.Merge` per feature.
+
+**For full implementation details, use:** `/working-with-devcontainers`
+
 ### StepLogger System
 
 The StepLogger system provides user-facing progress feedback during runtime operations with spinners and completion messages.

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-integration: ## Run integration tests (requires Podman)
 		--junitfile-testsuite-name short \
 		--junitfile-testcase-classname short \
 		--format testdox \
-		-- -tags integration -run TestIntegration_ -timeout 30m -count=1 -parallel 2 ./pkg/cmd/
+		-- -tags integration -run TestIntegration_ -timeout 30m -count=1 -parallel 2 ./...
 
 test-coverage: ## Run tests with coverage report
 	@echo "Running tests with coverage..."

--- a/pkg/devcontainers/features/features.go
+++ b/pkg/devcontainers/features/features.go
@@ -74,7 +74,7 @@ func FromMap(m map[string]map[string]interface{}, workspaceConfigDir string) ([]
 		case strings.HasPrefix(id, "./") || strings.HasPrefix(id, "../"):
 			feats = append(feats, &localFeature{id: id, dir: workspaceConfigDir})
 		case strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://"):
-			return nil, nil, fmt.Errorf("feature Tgz URI is not supported: %s", id)
+			return nil, nil, fmt.Errorf("direct HTTP(S) feature sources are not supported: %s", id)
 		default:
 			feats = append(feats, &ociFeature{id: id})
 		}
@@ -104,8 +104,11 @@ func featureBaseID(id string) string {
 
 // Order returns features in the correct installation order, respecting the
 // installsAfter fields read from each feature's devcontainer-feature.json.
-// metadata must contain an entry for every feature in feats.
-// Returns an error if a cycle is detected or a referenced feature is missing.
+// metadata must contain an entry for every feature in feats; an error is
+// returned if any entry is missing.
+// Per the Dev Container spec, installsAfter is a hint: references to IDs not
+// present in feats are silently ignored.
+// Returns an error if a cycle is detected.
 func Order(feats []Feature, metadata map[string]FeatureMetadata) ([]Feature, error) {
 	for _, f := range feats {
 		if _, ok := metadata[f.ID()]; !ok {

--- a/pkg/devcontainers/features/features.go
+++ b/pkg/devcontainers/features/features.go
@@ -1,0 +1,176 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package features implements backend-agnostic modeling, downloading, and ordering
+// of Dev Container Features as described in https://containers.dev/implementors/features/.
+package features
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FeatureOptions provides access to a feature's option specifications.
+type FeatureOptions interface {
+	// Merge merges user-supplied options with the spec defaults, validates
+	// user values (type, enum membership), and normalizes keys per spec:
+	// uppercased, non-alphanumeric chars replaced with '_'.
+	// (e.g. "install-tools" → "INSTALL_TOOLS", "go.version" → "GO_VERSION")
+	// Returns a map of normalized key → string value, or an error if any
+	// user-supplied value is invalid (wrong type, not in enum, etc.).
+	Merge(userOptions map[string]interface{}) (map[string]string, error)
+}
+
+// FeatureMetadata holds data parsed from devcontainer-feature.json.
+type FeatureMetadata interface {
+	// ContainerEnv returns persistent environment variables to set in the image
+	// after the feature is installed. Values may use ${VAR} expansion.
+	ContainerEnv() map[string]string
+	// Options returns the feature's option specifications with merge/validation.
+	Options() FeatureOptions
+	// InstallsAfter returns the IDs of features that must be installed before this one.
+	InstallsAfter() []string
+}
+
+// Feature models a devcontainer feature that can be resolved to a local directory.
+type Feature interface {
+	// ID returns the feature identifier as declared in the workspace config.
+	ID() string
+	// Download resolves the feature into destDir (fetching from a registry or
+	// copying from the local file tree) and returns the parsed metadata.
+	Download(ctx context.Context, destDir string) (FeatureMetadata, error)
+}
+
+// FromMap converts the workspace Features map (feature ID → user options) to:
+//   - a slice of Feature instances sorted by ID (deterministic, pre-ordering)
+//   - the user-supplied options map, keyed by feature ID
+//
+// workspaceConfigDir is the directory containing workspace.json; it is used to
+// resolve relative paths for local features.
+// Returns an error if any ID is an unsupported Tgz URI.
+func FromMap(m map[string]map[string]interface{}, workspaceConfigDir string) ([]Feature, map[string]map[string]interface{}, error) {
+	feats := make([]Feature, 0, len(m))
+	userOpts := make(map[string]map[string]interface{}, len(m))
+
+	for id, opts := range m {
+		switch {
+		case strings.HasPrefix(id, "./") || strings.HasPrefix(id, "../"):
+			feats = append(feats, &localFeature{id: id, dir: workspaceConfigDir})
+		case strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://"):
+			return nil, nil, fmt.Errorf("feature Tgz URI is not supported: %s", id)
+		default:
+			feats = append(feats, &ociFeature{id: id})
+		}
+		userOpts[id] = opts
+	}
+
+	sort.Slice(feats, func(i, j int) bool {
+		return feats[i].ID() < feats[j].ID()
+	})
+
+	return feats, userOpts, nil
+}
+
+// featureBaseID returns the feature ID with its version tag or digest stripped.
+// Per the Dev Container spec, installsAfter values are always versionless IDs,
+// so this is used to match them against registered feature IDs that may carry a tag.
+func featureBaseID(id string) string {
+	if i := strings.Index(id, "@"); i >= 0 {
+		return id[:i]
+	}
+	firstSlash := strings.Index(id, "/")
+	if i := strings.LastIndex(id, ":"); i > firstSlash {
+		return id[:i]
+	}
+	return id
+}
+
+// Order returns features in the correct installation order, respecting the
+// installsAfter fields read from each feature's devcontainer-feature.json.
+// metadata must contain an entry for every feature in feats.
+// Returns an error if a cycle is detected or a referenced feature is missing.
+func Order(feats []Feature, metadata map[string]FeatureMetadata) ([]Feature, error) {
+	for _, f := range feats {
+		if _, ok := metadata[f.ID()]; !ok {
+			return nil, fmt.Errorf("missing metadata for feature %q", f.ID())
+		}
+	}
+
+	featMap := make(map[string]Feature, len(feats))
+	// featByBase allows installsAfter values (always versionless per spec) to
+	// resolve a feature registered with a version tag, e.g.
+	// "…/common-utils" matches "…/common-utils:2".
+	featByBase := make(map[string]Feature, len(feats))
+	for _, f := range feats {
+		featMap[f.ID()] = f
+		featByBase[featureBaseID(f.ID())] = f
+	}
+
+	// Kahn's topological sort.
+	// A.installsAfter = [B] means B must be installed before A: edge B → A.
+	inDegree := make(map[string]int, len(feats))
+	dependents := make(map[string][]string, len(feats))
+	for _, f := range feats {
+		id := f.ID()
+		if _, exists := inDegree[id]; !exists {
+			inDegree[id] = 0
+		}
+		for _, dep := range metadata[id].InstallsAfter() {
+			resolved, ok := featByBase[dep]
+			if !ok {
+				// dep is not in our feature set; ignore it
+				continue
+			}
+			dependents[resolved.ID()] = append(dependents[resolved.ID()], id)
+			inDegree[id]++
+		}
+	}
+
+	queue := make([]string, 0, len(feats))
+	for id, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, id)
+		}
+	}
+	sort.Strings(queue)
+
+	ordered := make([]Feature, 0, len(feats))
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		ordered = append(ordered, featMap[id])
+
+		deps := append([]string(nil), dependents[id]...)
+		sort.Strings(deps)
+		for _, dep := range deps {
+			inDegree[dep]--
+			if inDegree[dep] == 0 {
+				queue = append(queue, dep)
+				sort.Strings(queue)
+			}
+		}
+	}
+
+	if len(ordered) != len(feats) {
+		return nil, fmt.Errorf("cycle detected in feature installsAfter dependencies")
+	}
+
+	return ordered, nil
+}

--- a/pkg/devcontainers/features/features_test.go
+++ b/pkg/devcontainers/features/features_test.go
@@ -94,6 +94,36 @@ func (m *fakeMetadata) ContainerEnv() map[string]string  { return nil }
 func (m *fakeMetadata) Options() features.FeatureOptions { return nil }
 func (m *fakeMetadata) InstallsAfter() []string          { return m.installsAfter }
 
+// --- FeatureMetadata tests ---
+
+func TestFeatureMetadata_InstallsAfter(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"installsAfter": []string{"ghcr.io/devcontainers/features/common-utils"},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	got := meta.InstallsAfter()
+	if len(got) != 1 || got[0] != "ghcr.io/devcontainers/features/common-utils" {
+		t.Errorf("InstallsAfter() = %v, want [ghcr.io/devcontainers/features/common-utils]", got)
+	}
+}
+
+func TestFeatureMetadata_InstallsAfter_Empty(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	got := meta.InstallsAfter()
+	if len(got) != 0 {
+		t.Errorf("InstallsAfter() = %v, want []", got)
+	}
+}
+
 // --- FeatureOptions.Merge tests ---
 
 func TestFeatureOptions_Merge_DefaultsUsedWhenNoUserOpts(t *testing.T) {
@@ -242,6 +272,154 @@ func TestFeatureOptions_Merge_WrongTypeReturnsError(t *testing.T) {
 	}
 }
 
+func TestFeatureOptions_Merge_UnknownOptionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"version": map[string]interface{}{"type": "string", "default": "latest"},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	_, err := meta.Options().Merge(map[string]interface{}{
+		"unknown-key": "value",
+	})
+	if err == nil {
+		t.Error("expected error for unknown option, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown option") {
+		t.Errorf("error = %q, want to contain 'unknown option'", err.Error())
+	}
+}
+
+func TestFeatureOptions_Merge_BooleanUserOptionTrue(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{"type": "boolean", "default": false},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(map[string]interface{}{
+		"install-tools": true,
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := result["INSTALL_TOOLS"]; got != "true" {
+		t.Errorf("INSTALL_TOOLS = %q, want %q", got, "true")
+	}
+}
+
+func TestFeatureOptions_Merge_BooleanUserOptionFalse(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{"type": "boolean", "default": true},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(map[string]interface{}{
+		"install-tools": false,
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := result["INSTALL_TOOLS"]; got != "false" {
+		t.Errorf("INSTALL_TOOLS = %q, want %q", got, "false")
+	}
+}
+
+func TestFeatureOptions_Merge_BooleanStringValueAccepted(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{"type": "boolean", "default": false},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(map[string]interface{}{
+		"install-tools": "true",
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := result["INSTALL_TOOLS"]; got != "true" {
+		t.Errorf("INSTALL_TOOLS = %q, want %q", got, "true")
+	}
+}
+
+func TestFeatureOptions_Merge_BooleanInvalidStringReturnsError(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{"type": "boolean", "default": false},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	_, err := meta.Options().Merge(map[string]interface{}{
+		"install-tools": "yes",
+	})
+	if err == nil {
+		t.Error("expected error for invalid boolean string, got nil")
+	}
+}
+
+func TestFeatureOptions_Merge_BooleanWrongTypeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{"type": "boolean", "default": false},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	_, err := meta.Options().Merge(map[string]interface{}{
+		"install-tools": 42,
+	})
+	if err == nil {
+		t.Error("expected error for wrong type for boolean option, got nil")
+	}
+}
+
+func TestFeatureOptions_Merge_UnsupportedTypeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"count": map[string]interface{}{"type": "integer", "default": 1},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	_, err := meta.Options().Merge(map[string]interface{}{
+		"count": "3",
+	})
+	if err == nil {
+		t.Error("expected error for unsupported option type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported type") {
+		t.Errorf("error = %q, want to contain 'unsupported type'", err.Error())
+	}
+}
+
 // --- FromMap tests ---
 
 func TestFromMap_EmptyMap(t *testing.T) {
@@ -309,6 +487,35 @@ func TestFromMap_LocalRelativePath(t *testing.T) {
 	_, err = feats[0].Download(context.Background(), t.TempDir())
 	if err != nil {
 		t.Errorf("Download: %v", err)
+	}
+}
+
+func TestLocalFeature_Download_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	featureDir := filepath.Join(workspaceDir, "my-feature")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(featureDir, "devcontainer-feature.json"), []byte("{not valid json"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing") {
+		t.Errorf("error = %q, want to contain 'parsing'", err.Error())
 	}
 }
 

--- a/pkg/devcontainers/features/features_test.go
+++ b/pkg/devcontainers/features/features_test.go
@@ -604,7 +604,12 @@ func TestOrder_MultipleWithInstallsAfterChain(t *testing.T) {
 func TestOrder_InstallsAfterExternalFeatureIgnored(t *testing.T) {
 	t.Parallel()
 
-	// A.installsAfter references a feature not in feats — should be ignored.
+	// Per the Dev Container spec, installsAfter is a soft ordering hint.
+	// References to features not present in feats (e.g. features from a
+	// different layer or not selected by the user) must be silently ignored,
+	// not treated as errors. This is distinct from a missing metadata entry
+	// (which is always an error because it means a feature in feats was not
+	// downloaded before Order was called).
 	feats := []features.Feature{&fakeFeature{id: "A"}}
 	metadata := map[string]features.FeatureMetadata{
 		"A": &fakeMetadata{installsAfter: []string{"external-feature"}},

--- a/pkg/devcontainers/features/features_test.go
+++ b/pkg/devcontainers/features/features_test.go
@@ -289,7 +289,7 @@ func TestFeatureOptions_Merge_UnknownOptionReturnsError(t *testing.T) {
 		"unknown-key": "value",
 	})
 	if err == nil {
-		t.Error("expected error for unknown option, got nil")
+		t.Fatal("expected error for unknown option, got nil")
 	}
 	if !strings.Contains(err.Error(), "unknown option") {
 		t.Errorf("error = %q, want to contain 'unknown option'", err.Error())
@@ -531,7 +531,7 @@ func TestFromMap_TgzURIReturnsError(t *testing.T) {
 		t.TempDir(),
 	)
 	if err == nil {
-		t.Error("expected error for Tgz URI, got nil")
+		t.Fatal("expected error for Tgz URI, got nil")
 	}
 	if !strings.Contains(err.Error(), "not supported") {
 		t.Errorf("error = %q, want to contain 'not supported'", err.Error())
@@ -641,7 +641,7 @@ func TestOrder_CycleDetectedReturnsError(t *testing.T) {
 
 	_, err := features.Order(feats, metadata)
 	if err == nil {
-		t.Error("expected error for cycle, got nil")
+		t.Fatal("expected error for cycle, got nil")
 	}
 	if !strings.Contains(err.Error(), "cycle") {
 		t.Errorf("error = %q, want to contain 'cycle'", err.Error())
@@ -677,7 +677,9 @@ func TestOCIFeature_Download(t *testing.T) {
 	tw := tar.NewWriter(&tarBuf)
 	addTarFile(t, tw, "devcontainer-feature.json", featureJSONBytes)
 	addTarFile(t, tw, "install.sh", []byte("#!/bin/sh\necho hello"))
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing plain tar writer: %v", err)
+	}
 	plainTarBytes := tarBuf.Bytes()
 
 	// Gzip tar layer containing extra.txt.
@@ -685,8 +687,12 @@ func TestOCIFeature_Download(t *testing.T) {
 	gw := gzip.NewWriter(&gzBuf)
 	tw2 := tar.NewWriter(gw)
 	addTarFile(t, tw2, "extra.txt", []byte("extra"))
-	tw2.Close()
-	gw.Close()
+	if err := tw2.Close(); err != nil {
+		t.Fatalf("closing gzip tar writer: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("closing gzip writer: %v", err)
+	}
 	gzipTarBytes := gzBuf.Bytes()
 
 	h1 := sha256.Sum256(plainTarBytes)
@@ -712,7 +718,7 @@ func TestOCIFeature_Download(t *testing.T) {
 		switch {
 		case strings.Contains(r.URL.Path, "/manifests/"):
 			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-			w.Write(manifestBytes)
+			_, _ = w.Write(manifestBytes)
 		case strings.Contains(r.URL.Path, "/blobs/"):
 			parts := strings.SplitAfter(r.URL.Path, "/blobs/")
 			digest := parts[len(parts)-1]
@@ -721,7 +727,7 @@ func TestOCIFeature_Download(t *testing.T) {
 				http.NotFound(w, r)
 				return
 			}
-			w.Write(data)
+			_, _ = w.Write(data)
 		default:
 			http.NotFound(w, r)
 		}

--- a/pkg/devcontainers/features/features_test.go
+++ b/pkg/devcontainers/features/features_test.go
@@ -23,7 +23,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -687,8 +689,10 @@ func TestOCIFeature_Download(t *testing.T) {
 	gw.Close()
 	gzipTarBytes := gzBuf.Bytes()
 
-	const digest1 = "sha256:aaaa"
-	const digest2 = "sha256:bbbb"
+	h1 := sha256.Sum256(plainTarBytes)
+	digest1 := fmt.Sprintf("sha256:%x", h1)
+	h2 := sha256.Sum256(gzipTarBytes)
+	digest2 := fmt.Sprintf("sha256:%x", h2)
 
 	manifest := map[string]interface{}{
 		"schemaVersion": 2,

--- a/pkg/devcontainers/features/features_test.go
+++ b/pkg/devcontainers/features/features_test.go
@@ -1,0 +1,591 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/devcontainers/features"
+)
+
+// --- helpers ---
+
+func writeFeatureJSON(t *testing.T, dir string, content map[string]interface{}) {
+	t.Helper()
+	data, err := json.Marshal(content)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "devcontainer-feature.json"), data, 0644); err != nil {
+		t.Fatalf("write devcontainer-feature.json: %v", err)
+	}
+}
+
+// makeLocalFeatureDir creates workspaceDir/<relPath>/devcontainer-feature.json with the given spec.
+func makeLocalFeatureDir(t *testing.T, workspaceDir, relPath string, spec map[string]interface{}) {
+	t.Helper()
+	featureDir := filepath.Join(workspaceDir, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFeatureJSON(t, featureDir, spec)
+}
+
+// metadataFromLocalFeature downloads a local feature and returns its metadata.
+func metadataFromLocalFeature(t *testing.T, workspaceDir, featureID string) features.FeatureMetadata {
+	t.Helper()
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{featureID: nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	destDir := t.TempDir()
+	meta, err := feats[0].Download(context.Background(), destDir)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	return meta
+}
+
+// --- fakes for Order tests ---
+
+type fakeFeature struct {
+	id string
+}
+
+func (f *fakeFeature) ID() string { return f.id }
+func (f *fakeFeature) Download(_ context.Context, _ string) (features.FeatureMetadata, error) {
+	return nil, nil
+}
+
+type fakeMetadata struct {
+	installsAfter []string
+}
+
+func (m *fakeMetadata) ContainerEnv() map[string]string  { return nil }
+func (m *fakeMetadata) Options() features.FeatureOptions { return nil }
+func (m *fakeMetadata) InstallsAfter() []string          { return m.installsAfter }
+
+// --- FeatureOptions.Merge tests ---
+
+func TestFeatureOptions_Merge_DefaultsUsedWhenNoUserOpts(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"version": map[string]interface{}{
+				"type":    "string",
+				"default": "latest",
+			},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(nil)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := result["VERSION"]; got != "latest" {
+		t.Errorf("VERSION = %q, want %q", got, "latest")
+	}
+}
+
+func TestFeatureOptions_Merge_UserOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"version": map[string]interface{}{
+				"type":    "string",
+				"default": "latest",
+			},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(map[string]interface{}{
+		"version": "1.21",
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := result["VERSION"]; got != "1.21" {
+		t.Errorf("VERSION = %q, want %q", got, "1.21")
+	}
+}
+
+func TestFeatureOptions_Merge_BooleanDefaultCoercedToString(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{
+				"type":    "boolean",
+				"default": true,
+			},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(nil)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := result["INSTALL_TOOLS"]; got != "true" {
+		t.Errorf("INSTALL_TOOLS = %q, want %q", got, "true")
+	}
+}
+
+func TestFeatureOptions_Merge_KeyNormalization(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"install-tools": map[string]interface{}{
+				"type":    "boolean",
+				"default": false,
+			},
+			"go.version": map[string]interface{}{
+				"type":    "string",
+				"default": "1.21",
+			},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	result, err := meta.Options().Merge(nil)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if _, ok := result["INSTALL_TOOLS"]; !ok {
+		t.Error("expected key INSTALL_TOOLS (from install-tools)")
+	}
+	if _, ok := result["GO_VERSION"]; !ok {
+		t.Error("expected key GO_VERSION (from go.version)")
+	}
+}
+
+func TestFeatureOptions_Merge_InvalidEnumReturnsError(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"flavor": map[string]interface{}{
+				"type":    "string",
+				"default": "basic",
+				"enum":    []string{"none", "basic", "full"},
+			},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	_, err := meta.Options().Merge(map[string]interface{}{
+		"flavor": "invalid",
+	})
+	if err == nil {
+		t.Error("expected error for invalid enum value, got nil")
+	}
+}
+
+func TestFeatureOptions_Merge_WrongTypeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{
+		"options": map[string]interface{}{
+			"version": map[string]interface{}{
+				"type":    "string",
+				"default": "latest",
+			},
+		},
+	})
+
+	meta := metadataFromLocalFeature(t, workspaceDir, "./my-feature")
+	_, err := meta.Options().Merge(map[string]interface{}{
+		"version": 42, // should be string
+	})
+	if err == nil {
+		t.Error("expected error for wrong type, got nil")
+	}
+}
+
+// --- FromMap tests ---
+
+func TestFromMap_EmptyMap(t *testing.T) {
+	t.Parallel()
+
+	feats, opts, err := features.FromMap(map[string]map[string]interface{}{}, t.TempDir())
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if len(feats) != 0 {
+		t.Errorf("len(feats) = %d, want 0", len(feats))
+	}
+	if len(opts) != 0 {
+		t.Errorf("len(opts) = %d, want 0", len(opts))
+	}
+}
+
+func TestFromMap_OCIFeaturesSortedByID(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]map[string]interface{}{
+		"ghcr.io/devcontainers/features/go:1":               nil,
+		"ghcr.io/devcontainers/features/common-utils":       nil,
+		"ghcr.io/devcontainers/features/docker-in-docker:2": nil,
+	}
+
+	feats, _, err := features.FromMap(m, t.TempDir())
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if len(feats) != 3 {
+		t.Fatalf("len(feats) = %d, want 3", len(feats))
+	}
+
+	ids := idsOf(feats)
+	for i := 1; i < len(ids); i++ {
+		if ids[i] < ids[i-1] {
+			t.Errorf("features not sorted by ID: %v", ids)
+			break
+		}
+	}
+}
+
+func TestFromMap_LocalRelativePath(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{})
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if len(feats) != 1 {
+		t.Fatalf("len(feats) = %d, want 1", len(feats))
+	}
+	if feats[0].ID() != "./my-feature" {
+		t.Errorf("ID = %q, want %q", feats[0].ID(), "./my-feature")
+	}
+
+	// Verify Download works for a local feature.
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err != nil {
+		t.Errorf("Download: %v", err)
+	}
+}
+
+func TestFromMap_TgzURIReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := features.FromMap(
+		map[string]map[string]interface{}{
+			"https://example.com/feature.tgz": nil,
+		},
+		t.TempDir(),
+	)
+	if err == nil {
+		t.Error("expected error for Tgz URI, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error = %q, want to contain 'not supported'", err.Error())
+	}
+}
+
+func TestFromMap_UserOptionsPreserved(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]map[string]interface{}{
+		"ghcr.io/devcontainers/features/go:1": {"version": "1.21"},
+	}
+
+	_, opts, err := features.FromMap(m, t.TempDir())
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	v, ok := opts["ghcr.io/devcontainers/features/go:1"]
+	if !ok {
+		t.Fatal("user options missing for feature")
+	}
+	if v["version"] != "1.21" {
+		t.Errorf("version = %v, want %q", v["version"], "1.21")
+	}
+}
+
+// --- Order tests ---
+
+func TestOrder_SingleFeatureNoInstallsAfter(t *testing.T) {
+	t.Parallel()
+
+	feats := []features.Feature{&fakeFeature{id: "A"}}
+	metadata := map[string]features.FeatureMetadata{
+		"A": &fakeMetadata{},
+	}
+
+	ordered, err := features.Order(feats, metadata)
+	if err != nil {
+		t.Fatalf("Order: %v", err)
+	}
+	if len(ordered) != 1 || ordered[0].ID() != "A" {
+		t.Errorf("ordered = %v, want [A]", idsOf(ordered))
+	}
+}
+
+func TestOrder_MultipleWithInstallsAfterChain(t *testing.T) {
+	t.Parallel()
+
+	// C.installsAfter = [B], B.installsAfter = [A]  →  correct order: A, B, C
+	feats := []features.Feature{
+		&fakeFeature{id: "C"},
+		&fakeFeature{id: "A"},
+		&fakeFeature{id: "B"},
+	}
+	metadata := map[string]features.FeatureMetadata{
+		"A": &fakeMetadata{},
+		"B": &fakeMetadata{installsAfter: []string{"A"}},
+		"C": &fakeMetadata{installsAfter: []string{"B"}},
+	}
+
+	ordered, err := features.Order(feats, metadata)
+	if err != nil {
+		t.Fatalf("Order: %v", err)
+	}
+	got := idsOf(ordered)
+	want := []string{"A", "B", "C"}
+	if !equalSlices(got, want) {
+		t.Errorf("ordered = %v, want %v", got, want)
+	}
+}
+
+func TestOrder_InstallsAfterExternalFeatureIgnored(t *testing.T) {
+	t.Parallel()
+
+	// A.installsAfter references a feature not in feats — should be ignored.
+	feats := []features.Feature{&fakeFeature{id: "A"}}
+	metadata := map[string]features.FeatureMetadata{
+		"A": &fakeMetadata{installsAfter: []string{"external-feature"}},
+	}
+
+	ordered, err := features.Order(feats, metadata)
+	if err != nil {
+		t.Fatalf("Order: %v", err)
+	}
+	if len(ordered) != 1 || ordered[0].ID() != "A" {
+		t.Errorf("ordered = %v, want [A]", idsOf(ordered))
+	}
+}
+
+func TestOrder_CycleDetectedReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// A.installsAfter = [B] and B.installsAfter = [A] → cycle
+	feats := []features.Feature{
+		&fakeFeature{id: "A"},
+		&fakeFeature{id: "B"},
+	}
+	metadata := map[string]features.FeatureMetadata{
+		"A": &fakeMetadata{installsAfter: []string{"B"}},
+		"B": &fakeMetadata{installsAfter: []string{"A"}},
+	}
+
+	_, err := features.Order(feats, metadata)
+	if err == nil {
+		t.Error("expected error for cycle, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error = %q, want to contain 'cycle'", err.Error())
+	}
+}
+
+func TestOrder_MissingMetadataReturnsError(t *testing.T) {
+	t.Parallel()
+
+	feats := []features.Feature{&fakeFeature{id: "A"}}
+	metadata := map[string]features.FeatureMetadata{} // A missing
+
+	_, err := features.Order(feats, metadata)
+	if err == nil {
+		t.Error("expected error for missing metadata, got nil")
+	}
+}
+
+// --- OCI download test using httptest ---
+
+func TestOCIFeature_Download(t *testing.T) {
+	t.Parallel()
+
+	featureJSON := map[string]interface{}{
+		"id":            "go",
+		"containerEnv":  map[string]string{"GOPATH": "/go"},
+		"installsAfter": []string{},
+	}
+	featureJSONBytes, _ := json.Marshal(featureJSON)
+
+	// Plain tar layer containing devcontainer-feature.json and install.sh.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	addTarFile(t, tw, "devcontainer-feature.json", featureJSONBytes)
+	addTarFile(t, tw, "install.sh", []byte("#!/bin/sh\necho hello"))
+	tw.Close()
+	plainTarBytes := tarBuf.Bytes()
+
+	// Gzip tar layer containing extra.txt.
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	tw2 := tar.NewWriter(gw)
+	addTarFile(t, tw2, "extra.txt", []byte("extra"))
+	tw2.Close()
+	gw.Close()
+	gzipTarBytes := gzBuf.Bytes()
+
+	const digest1 = "sha256:aaaa"
+	const digest2 = "sha256:bbbb"
+
+	manifest := map[string]interface{}{
+		"schemaVersion": 2,
+		"layers": []map[string]interface{}{
+			{"digest": digest1, "mediaType": "application/vnd.devcontainers.layer.v1+tar"},
+			{"digest": digest2, "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"},
+		},
+	}
+	manifestBytes, _ := json.Marshal(manifest)
+
+	blobs := map[string][]byte{
+		digest1: plainTarBytes,
+		digest2: gzipTarBytes,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Write(manifestBytes)
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			parts := strings.SplitAfter(r.URL.Path, "/blobs/")
+			digest := parts[len(parts)-1]
+			data, ok := blobs[digest]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	// The test server host (e.g. "127.0.0.1:PORT") contains ":" → treated as registry.
+	host := strings.TrimPrefix(srv.URL, "http://")
+	featureID := host + "/test/feature:latest"
+
+	// Inject a transport that rewrites https:// to http:// for the test server.
+	feat := features.NewOCIFeatureWithClient(featureID, &http.Client{
+		Transport: &rewriteTransport{host: host},
+	})
+
+	destDir := t.TempDir()
+	meta, err := feat.Download(context.Background(), destDir)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+
+	if got := meta.ContainerEnv()["GOPATH"]; got != "/go" {
+		t.Errorf("ContainerEnv GOPATH = %q, want %q", got, "/go")
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "install.sh")); err != nil {
+		t.Errorf("install.sh not found: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "extra.txt")); err != nil {
+		t.Errorf("extra.txt not found: %v", err)
+	}
+}
+
+// rewriteTransport rewrites https:// requests to http:// on the same host.
+type rewriteTransport struct {
+	host string
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := *req.URL
+	u.Scheme = "http"
+	u.Host = rt.host
+	req2 := req.Clone(req.Context())
+	req2.URL = &u
+	return http.DefaultTransport.RoundTrip(req2)
+}
+
+// --- test helpers ---
+
+func addTarFile(t *testing.T, tw *tar.Writer, name string, content []byte) {
+	t.Helper()
+	hdr := &tar.Header{
+		Name: name,
+		Mode: 0644,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("tar WriteHeader: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("tar Write: %v", err)
+	}
+}
+
+func idsOf(feats []features.Feature) []string {
+	ids := make([]string, len(feats))
+	for i, f := range feats {
+		ids[i] = f.ID()
+	}
+	return ids
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/devcontainers/features/local.go
+++ b/pkg/devcontainers/features/local.go
@@ -57,6 +57,10 @@ func copyDir(src, dst string) error {
 			return err
 		}
 
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlinks are not supported in local features: %s", path)
+		}
+
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
@@ -66,6 +70,10 @@ func copyDir(src, dst string) error {
 
 		if d.IsDir() {
 			return os.MkdirAll(target, 0755)
+		}
+
+		if !d.Type().IsRegular() {
+			return fmt.Errorf("unsupported non-regular file in local feature: %s", path)
 		}
 
 		return copyFile(path, target)

--- a/pkg/devcontainers/features/local.go
+++ b/pkg/devcontainers/features/local.go
@@ -83,18 +83,26 @@ func copyDir(src, dst string) error {
 	})
 }
 
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (retErr error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() {
+		if err := in.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing source file: %w", err)
+		}
+	}()
 
 	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if err := out.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing destination file: %w", err)
+		}
+	}()
 
 	_, err = io.Copy(out, in)
 	return err

--- a/pkg/devcontainers/features/local.go
+++ b/pkg/devcontainers/features/local.go
@@ -38,7 +38,10 @@ var _ Feature = (*localFeature)(nil)
 func (f *localFeature) ID() string { return f.id }
 
 func (f *localFeature) Download(_ context.Context, destDir string) (FeatureMetadata, error) {
-	srcDir := filepath.Clean(filepath.Join(f.dir, filepath.FromSlash(f.id)))
+	srcDir, err := filepath.Abs(filepath.Join(f.dir, filepath.FromSlash(f.id)))
+	if err != nil {
+		return nil, err
+	}
 
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, err

--- a/pkg/devcontainers/features/local.go
+++ b/pkg/devcontainers/features/local.go
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// localFeature implements Feature for IDs beginning with "./" or "../".
+type localFeature struct {
+	id  string
+	dir string // workspaceConfigDir
+}
+
+var _ Feature = (*localFeature)(nil)
+
+func (f *localFeature) ID() string { return f.id }
+
+func (f *localFeature) Download(_ context.Context, destDir string) (FeatureMetadata, error) {
+	srcDir := filepath.Clean(filepath.Join(f.dir, filepath.FromSlash(f.id)))
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, err
+	}
+
+	if err := copyDir(srcDir, destDir); err != nil {
+		return nil, fmt.Errorf("copying feature from %s: %w", srcDir, err)
+	}
+
+	return parseMetadata(destDir)
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/pkg/devcontainers/features/local_test.go
+++ b/pkg/devcontainers/features/local_test.go
@@ -45,7 +45,7 @@ func TestLocalFeature_Download_SrcDirNotFound(t *testing.T) {
 
 	_, err = feats[0].Download(context.Background(), t.TempDir())
 	if err == nil {
-		t.Error("expected error for non-existent source directory, got nil")
+		t.Fatal("expected error for non-existent source directory, got nil")
 	}
 	if !strings.Contains(err.Error(), "copying feature from") {
 		t.Errorf("error = %q, want to contain 'copying feature from'", err.Error())
@@ -90,7 +90,11 @@ func TestLocalFeature_CopyDir_Symlink(t *testing.T) {
 	}
 	writeFeatureJSON(t, featureDir, map[string]interface{}{})
 
-	if err := os.Symlink("/etc/hosts", filepath.Join(featureDir, "z-link")); err != nil {
+	targetFile := filepath.Join(workspaceDir, "symlink-target")
+	if err := os.WriteFile(targetFile, []byte("target"), 0644); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	if err := os.Symlink(targetFile, filepath.Join(featureDir, "z-link")); err != nil {
 		t.Skipf("cannot create symlink: %v", err)
 	}
 
@@ -104,7 +108,7 @@ func TestLocalFeature_CopyDir_Symlink(t *testing.T) {
 
 	_, err = feats[0].Download(context.Background(), t.TempDir())
 	if err == nil {
-		t.Error("expected error for symlink in feature dir, got nil")
+		t.Fatal("expected error for symlink in feature dir, got nil")
 	}
 	if !strings.Contains(err.Error(), "symlinks") {
 		t.Errorf("error = %q, want to contain 'symlinks'", err.Error())

--- a/pkg/devcontainers/features/local_test.go
+++ b/pkg/devcontainers/features/local_test.go
@@ -1,0 +1,187 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/devcontainers/features"
+)
+
+// TestLocalFeature_Download_SrcDirNotFound covers the copyDir walk-error path
+// (callback receives err != nil) and the "copying feature from" error wrapping
+// in Download when the source directory does not exist.
+func TestLocalFeature_Download_SrcDirNotFound(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./nonexistent-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Error("expected error for non-existent source directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "copying feature from") {
+		t.Errorf("error = %q, want to contain 'copying feature from'", err.Error())
+	}
+}
+
+// TestLocalFeature_Download_DestIsFile covers the os.MkdirAll error path in
+// Download when destDir already exists as a regular file.
+func TestLocalFeature_Download_DestIsFile(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{})
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	destFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(destFile, []byte("file"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err = feats[0].Download(context.Background(), destFile)
+	if err == nil {
+		t.Error("expected error when destDir is a regular file, got nil")
+	}
+}
+
+// TestLocalFeature_CopyDir_Symlink covers the symlink detection branch in copyDir.
+func TestLocalFeature_CopyDir_Symlink(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	featureDir := filepath.Join(workspaceDir, "my-feature")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFeatureJSON(t, featureDir, map[string]interface{}{})
+
+	if err := os.Symlink("/etc/hosts", filepath.Join(featureDir, "z-link")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Error("expected error for symlink in feature dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlinks") {
+		t.Errorf("error = %q, want to contain 'symlinks'", err.Error())
+	}
+}
+
+// TestLocalFeature_Download_WithSubdirectory verifies that copyDir correctly
+// creates subdirectories and copies files within them.
+func TestLocalFeature_Download_WithSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	featureDir := filepath.Join(workspaceDir, "my-feature")
+	subDir := filepath.Join(featureDir, "scripts")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFeatureJSON(t, featureDir, map[string]interface{}{
+		"containerEnv": map[string]string{"FOO": "bar"},
+	})
+	if err := os.WriteFile(filepath.Join(subDir, "install.sh"), []byte("#!/bin/sh\necho hi"), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	destDir := t.TempDir()
+	meta, err := feats[0].Download(context.Background(), destDir)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if got := meta.ContainerEnv()["FOO"]; got != "bar" {
+		t.Errorf("ContainerEnv FOO = %q, want %q", got, "bar")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "scripts", "install.sh")); err != nil {
+		t.Errorf("scripts/install.sh not found: %v", err)
+	}
+}
+
+// TestLocalFeature_ParentRelativePath tests that a feature with a "../" prefix
+// is resolved correctly relative to the workspace config directory.
+func TestLocalFeature_ParentRelativePath(t *testing.T) {
+	t.Parallel()
+
+	parentDir := t.TempDir()
+	workspaceDir := filepath.Join(parentDir, "subdir")
+	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
+		t.Fatalf("MkdirAll workspaceDir: %v", err)
+	}
+	featureDir := filepath.Join(parentDir, "my-feature")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("MkdirAll featureDir: %v", err)
+	}
+	writeFeatureJSON(t, featureDir, map[string]interface{}{})
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"../my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if len(feats) != 1 {
+		t.Fatalf("len(feats) = %d, want 1", len(feats))
+	}
+	if feats[0].ID() != "../my-feature" {
+		t.Errorf("ID = %q, want %q", feats[0].ID(), "../my-feature")
+	}
+
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err != nil {
+		t.Errorf("Download: %v", err)
+	}
+}

--- a/pkg/devcontainers/features/local_unix_test.go
+++ b/pkg/devcontainers/features/local_unix_test.go
@@ -131,7 +131,7 @@ func TestLocalFeature_CopyDir_NonRegularFile(t *testing.T) {
 
 	_, err = feats[0].Download(context.Background(), t.TempDir())
 	if err == nil {
-		t.Error("expected error for non-regular file in feature dir, got nil")
+		t.Fatal("expected error for non-regular file in feature dir, got nil")
 	}
 	if !strings.Contains(err.Error(), "unsupported non-regular file") {
 		t.Errorf("error = %q, want to contain 'unsupported non-regular file'", err.Error())

--- a/pkg/devcontainers/features/local_unix_test.go
+++ b/pkg/devcontainers/features/local_unix_test.go
@@ -1,0 +1,139 @@
+//go:build !windows
+
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/devcontainers/features"
+)
+
+// TestLocalFeature_CopyFile_UnreadableSource covers the os.Open error path in
+// copyFile by including a file with no read permission in the feature directory.
+// Skipped when running as root since permissions have no effect.
+func TestLocalFeature_CopyFile_UnreadableSource(t *testing.T) {
+	t.Parallel()
+
+	if os.Getuid() == 0 {
+		t.Skip("running as root, file permissions have no effect")
+	}
+
+	workspaceDir := t.TempDir()
+	featureDir := filepath.Join(workspaceDir, "my-feature")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFeatureJSON(t, featureDir, map[string]interface{}{})
+
+	// Write a file that cannot be read (0000 permissions).
+	secretFile := filepath.Join(featureDir, "z-secret.txt")
+	if err := os.WriteFile(secretFile, []byte("secret"), 0000); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Error("expected error for unreadable source file, got nil")
+	}
+}
+
+// TestLocalFeature_CopyFile_ReadOnlyDest covers the os.OpenFile error path in
+// copyFile when the destination directory is read-only.
+// Skipped when running as root since permissions have no effect.
+func TestLocalFeature_CopyFile_ReadOnlyDest(t *testing.T) {
+	t.Parallel()
+
+	if os.Getuid() == 0 {
+		t.Skip("running as root, file permissions have no effect")
+	}
+
+	workspaceDir := t.TempDir()
+	makeLocalFeatureDir(t, workspaceDir, "my-feature", map[string]interface{}{})
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	destDir := t.TempDir()
+	if err := os.Chmod(destDir, 0555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(destDir, 0755) })
+
+	_, err = feats[0].Download(context.Background(), destDir)
+	if err == nil {
+		t.Error("expected error for read-only destDir, got nil")
+	}
+}
+
+// TestLocalFeature_CopyDir_NonRegularFile covers the non-regular-file branch in
+// copyDir using a named pipe, which is neither a directory nor a symlink nor a
+// regular file.
+func TestLocalFeature_CopyDir_NonRegularFile(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	featureDir := filepath.Join(workspaceDir, "my-feature")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFeatureJSON(t, featureDir, map[string]interface{}{})
+
+	// Named pipe — not a regular file, not a symlink, not a directory.
+	// "z-pipe" sorts after devcontainer-feature.json so WalkDir visits it last.
+	pipePath := filepath.Join(featureDir, "z-pipe")
+	if err := syscall.Mkfifo(pipePath, 0600); err != nil {
+		t.Skipf("cannot create named pipe: %v", err)
+	}
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{"./my-feature": nil},
+		workspaceDir,
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	_, err = feats[0].Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Error("expected error for non-regular file in feature dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported non-regular file") {
+		t.Errorf("error = %q, want to contain 'unsupported non-regular file'", err.Error())
+	}
+}

--- a/pkg/devcontainers/features/metadata.go
+++ b/pkg/devcontainers/features/metadata.go
@@ -68,13 +68,54 @@ func normalizeKey(k string) string {
 	return nonAlphanumRE.ReplaceAllString(strings.ToUpper(k), "_")
 }
 
+func validateOptionValue(key string, spec featureOptionSpec, val interface{}) (string, error) {
+	switch spec.Type {
+	case "boolean":
+		switch v := val.(type) {
+		case bool:
+			if v {
+				return "true", nil
+			}
+			return "false", nil
+		case string:
+			s := strings.ToLower(v)
+			if s != "true" && s != "false" {
+				return "", fmt.Errorf("option %s: expected boolean, got %q", key, v)
+			}
+			return s, nil
+		default:
+			return "", fmt.Errorf("option %s: expected boolean, got %T", key, val)
+		}
+	case "string", "":
+		s, ok := val.(string)
+		if !ok {
+			return "", fmt.Errorf("option %s: expected string, got %T", key, val)
+		}
+		if len(spec.Enum) > 0 {
+			for _, e := range spec.Enum {
+				if e == s {
+					return s, nil
+				}
+			}
+			return "", fmt.Errorf("option %s: value %q is not in enum %v", key, s, spec.Enum)
+		}
+		return s, nil
+	default:
+		return "", fmt.Errorf("option %s: unsupported type %q", key, spec.Type)
+	}
+}
+
 func (o *featureOptions) Merge(userOptions map[string]interface{}) (map[string]string, error) {
 	result := make(map[string]string, len(o.specs))
 
 	// Apply defaults first.
 	for key, spec := range o.specs {
 		if spec.Default != nil {
-			result[normalizeKey(key)] = fmt.Sprintf("%v", spec.Default)
+			value, err := validateOptionValue(key, spec, spec.Default)
+			if err != nil {
+				return nil, fmt.Errorf("invalid default for option %s: %w", key, err)
+			}
+			result[normalizeKey(key)] = value
 		}
 	}
 
@@ -84,47 +125,11 @@ func (o *featureOptions) Merge(userOptions map[string]interface{}) (map[string]s
 		if !ok {
 			return nil, fmt.Errorf("unknown option: %s", key)
 		}
-		norm := normalizeKey(key)
-
-		switch spec.Type {
-		case "boolean":
-			switch v := val.(type) {
-			case bool:
-				if v {
-					result[norm] = "true"
-				} else {
-					result[norm] = "false"
-				}
-			case string:
-				s := strings.ToLower(v)
-				if s != "true" && s != "false" {
-					return nil, fmt.Errorf("option %s: expected boolean, got %q", key, v)
-				}
-				result[norm] = s
-			default:
-				return nil, fmt.Errorf("option %s: expected boolean, got %T", key, val)
-			}
-		case "string", "":
-			s, ok := val.(string)
-			if !ok {
-				return nil, fmt.Errorf("option %s: expected string, got %T", key, val)
-			}
-			if len(spec.Enum) > 0 {
-				valid := false
-				for _, e := range spec.Enum {
-					if e == s {
-						valid = true
-						break
-					}
-				}
-				if !valid {
-					return nil, fmt.Errorf("option %s: value %q is not in enum %v", key, s, spec.Enum)
-				}
-			}
-			result[norm] = s
-		default:
-			return nil, fmt.Errorf("option %s: unsupported type %q", key, spec.Type)
+		value, err := validateOptionValue(key, spec, val)
+		if err != nil {
+			return nil, err
 		}
+		result[normalizeKey(key)] = value
 	}
 
 	return result, nil

--- a/pkg/devcontainers/features/metadata.go
+++ b/pkg/devcontainers/features/metadata.go
@@ -1,0 +1,154 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// devcontainerFeatureJSON is the raw on-disk structure of devcontainer-feature.json.
+type devcontainerFeatureJSON struct {
+	ContainerEnv  map[string]string            `json:"containerEnv"`
+	Options       map[string]featureOptionSpec `json:"options"`
+	InstallsAfter []string                     `json:"installsAfter"`
+}
+
+type featureOptionSpec struct {
+	Type    string      `json:"type"`
+	Default interface{} `json:"default"`
+	Enum    []string    `json:"enum"`
+}
+
+// featureMetadata implements FeatureMetadata.
+type featureMetadata struct {
+	containerEnv  map[string]string
+	options       FeatureOptions
+	installsAfter []string
+}
+
+var _ FeatureMetadata = (*featureMetadata)(nil)
+
+func (m *featureMetadata) ContainerEnv() map[string]string { return m.containerEnv }
+func (m *featureMetadata) Options() FeatureOptions         { return m.options }
+func (m *featureMetadata) InstallsAfter() []string         { return m.installsAfter }
+
+// featureOptions implements FeatureOptions.
+type featureOptions struct {
+	specs map[string]featureOptionSpec
+}
+
+var _ FeatureOptions = (*featureOptions)(nil)
+
+var nonAlphanumRE = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// normalizeKey converts an option key to a normalized env var name:
+// uppercased, runs of non-alphanumeric characters replaced with '_'.
+func normalizeKey(k string) string {
+	return nonAlphanumRE.ReplaceAllString(strings.ToUpper(k), "_")
+}
+
+func (o *featureOptions) Merge(userOptions map[string]interface{}) (map[string]string, error) {
+	result := make(map[string]string, len(o.specs))
+
+	// Apply defaults first.
+	for key, spec := range o.specs {
+		if spec.Default != nil {
+			result[normalizeKey(key)] = fmt.Sprintf("%v", spec.Default)
+		}
+	}
+
+	// Apply and validate user-supplied options.
+	for key, val := range userOptions {
+		spec, ok := o.specs[key]
+		if !ok {
+			return nil, fmt.Errorf("unknown option: %s", key)
+		}
+		norm := normalizeKey(key)
+
+		switch spec.Type {
+		case "boolean":
+			switch v := val.(type) {
+			case bool:
+				if v {
+					result[norm] = "true"
+				} else {
+					result[norm] = "false"
+				}
+			case string:
+				s := strings.ToLower(v)
+				if s != "true" && s != "false" {
+					return nil, fmt.Errorf("option %s: expected boolean, got %q", key, v)
+				}
+				result[norm] = s
+			default:
+				return nil, fmt.Errorf("option %s: expected boolean, got %T", key, val)
+			}
+		case "string", "":
+			s, ok := val.(string)
+			if !ok {
+				return nil, fmt.Errorf("option %s: expected string, got %T", key, val)
+			}
+			if len(spec.Enum) > 0 {
+				valid := false
+				for _, e := range spec.Enum {
+					if e == s {
+						valid = true
+						break
+					}
+				}
+				if !valid {
+					return nil, fmt.Errorf("option %s: value %q is not in enum %v", key, s, spec.Enum)
+				}
+			}
+			result[norm] = s
+		default:
+			return nil, fmt.Errorf("option %s: unsupported type %q", key, spec.Type)
+		}
+	}
+
+	return result, nil
+}
+
+// parseMetadata reads and parses devcontainer-feature.json from dir.
+func parseMetadata(dir string) (FeatureMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "devcontainer-feature.json"))
+	if err != nil {
+		return nil, fmt.Errorf("reading devcontainer-feature.json: %w", err)
+	}
+
+	var raw devcontainerFeatureJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing devcontainer-feature.json: %w", err)
+	}
+
+	if raw.Options == nil {
+		raw.Options = map[string]featureOptionSpec{}
+	}
+
+	return &featureMetadata{
+		containerEnv:  raw.ContainerEnv,
+		options:       &featureOptions{specs: raw.Options},
+		installsAfter: raw.InstallsAfter,
+	}, nil
+}

--- a/pkg/devcontainers/features/oci.go
+++ b/pkg/devcontainers/features/oci.go
@@ -283,7 +283,7 @@ func (f *ociFeature) downloadAndExtractLayer(ctx context.Context, registry, repo
 		return err
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	h := sha256.New()
 	if _, err := io.Copy(tmp, io.TeeReader(resp.Body, h)); err != nil {

--- a/pkg/devcontainers/features/oci.go
+++ b/pkg/devcontainers/features/oci.go
@@ -301,8 +301,34 @@ func extractTar(r io.Reader, destDir string) error {
 	return extractTarEntries(tr, destDir)
 }
 
+// safeTarTarget resolves name relative to destDir and verifies the result
+// stays within destDir, preventing directory-traversal attacks.
+func safeTarTarget(destDir, name string) (string, error) {
+	cleanPath := filepath.Clean(filepath.FromSlash(name))
+	if cleanPath == "." || filepath.IsAbs(cleanPath) ||
+		cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid path in tar archive: %s", name)
+	}
+
+	target := filepath.Join(destDir, cleanPath)
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", err
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(absDest, absTarget)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("invalid path in tar archive: %s", name)
+	}
+	return target, nil
+}
+
 // extractTarEntries extracts all entries from a tar reader into destDir,
-// sanitizing paths to prevent directory traversal.
+// sanitizing paths to prevent directory traversal. Symlinks and hard links
+// are rejected to avoid escaping destDir via link chains.
 func extractTarEntries(tr *tar.Reader, destDir string) error {
 	for {
 		hdr, err := tr.Next()
@@ -313,12 +339,10 @@ func extractTarEntries(tr *tar.Reader, destDir string) error {
 			return fmt.Errorf("reading tar entry: %w", err)
 		}
 
-		cleanPath := filepath.Clean(hdr.Name)
-		if strings.HasPrefix(cleanPath, "..") {
-			return fmt.Errorf("invalid path in tar archive: %s", hdr.Name)
+		target, err := safeTarTarget(destDir, hdr.Name)
+		if err != nil {
+			return err
 		}
-
-		target := filepath.Join(destDir, cleanPath)
 
 		switch hdr.Typeflag {
 		case tar.TypeDir:
@@ -338,13 +362,8 @@ func extractTarEntries(tr *tar.Reader, destDir string) error {
 				return err
 			}
 			f.Close()
-		case tar.TypeSymlink:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-				return err
-			}
-			if err := os.Symlink(hdr.Linkname, target); err != nil && !os.IsExist(err) {
-				return err
-			}
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("unsupported link in tar archive: %s", hdr.Name)
 		}
 	}
 	return nil

--- a/pkg/devcontainers/features/oci.go
+++ b/pkg/devcontainers/features/oci.go
@@ -1,0 +1,351 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ociFeature implements Feature for OCI registry references.
+type ociFeature struct {
+	id     string
+	client *http.Client
+}
+
+var _ Feature = (*ociFeature)(nil)
+
+// NewOCIFeatureWithClient returns an OCI Feature that uses the provided HTTP client.
+// Intended for testing; production code uses the Feature instances returned by FromMap.
+func NewOCIFeatureWithClient(id string, client *http.Client) Feature {
+	return &ociFeature{id: id, client: client}
+}
+
+func (f *ociFeature) ID() string { return f.id }
+
+func (f *ociFeature) httpClient() *http.Client {
+	if f.client != nil {
+		return f.client
+	}
+	return http.DefaultClient
+}
+
+func (f *ociFeature) Download(ctx context.Context, destDir string) (FeatureMetadata, error) {
+	registry, repository, ref, err := parseOCIRef(f.id)
+	if err != nil {
+		return nil, fmt.Errorf("parsing OCI reference %q: %w", f.id, err)
+	}
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, err
+	}
+
+	manifest, token, err := f.fetchManifest(ctx, registry, repository, ref)
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest: %w", err)
+	}
+
+	for _, layer := range manifest.Layers {
+		if err := f.downloadAndExtractLayer(ctx, registry, repository, layer.Digest, token, destDir); err != nil {
+			return nil, fmt.Errorf("extracting layer %s: %w", layer.Digest, err)
+		}
+	}
+
+	return parseMetadata(destDir)
+}
+
+// parseOCIRef parses an OCI reference into registry, repository, and ref (tag or digest).
+// Format: [registry/]repository[:tag|@digest]
+func parseOCIRef(id string) (registry, repository, ref string, err error) {
+	// Split off digest.
+	if i := strings.Index(id, "@"); i >= 0 {
+		ref = id[i+1:]
+		id = id[:i]
+	} else {
+		// Split off tag: last colon that appears after the first slash.
+		firstSlash := strings.Index(id, "/")
+		lastColon := strings.LastIndex(id, ":")
+		if lastColon > firstSlash {
+			ref = id[lastColon+1:]
+			id = id[:lastColon]
+		}
+	}
+	if ref == "" {
+		ref = "latest"
+	}
+
+	// Determine registry vs. repository.
+	// The first component is a registry if it contains '.' or ':' or equals "localhost".
+	parts := strings.SplitN(id, "/", 2)
+	if len(parts) == 2 {
+		first := parts[0]
+		if strings.ContainsAny(first, ".:") || first == "localhost" {
+			return first, parts[1], ref, nil
+		}
+	}
+	// No explicit registry; default to ghcr.io.
+	return "ghcr.io", id, ref, nil
+}
+
+type ociManifest struct {
+	Layers []ociDescriptor `json:"layers"`
+}
+
+type ociDescriptor struct {
+	Digest string `json:"digest"`
+}
+
+// fetchManifest fetches the OCI manifest, handling anonymous Bearer auth automatically.
+// Returns the manifest, the bearer token (may be empty), and any error.
+func (f *ociFeature) fetchManifest(ctx context.Context, registry, repository, ref string) (*ociManifest, string, error) {
+	manifestURL := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, repository, ref)
+	client := f.httpClient()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var token string
+	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
+		wwwAuth := resp.Header.Get("WWW-Authenticate")
+		token, err = fetchBearerToken(ctx, client, wwwAuth, repository)
+		if err != nil {
+			return nil, "", fmt.Errorf("fetching bearer token: %w", err)
+		}
+
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+		if err != nil {
+			return nil, "", err
+		}
+		req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err = client.Do(req)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("manifest fetch failed: %s", resp.Status)
+	}
+
+	var manifest ociManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, "", fmt.Errorf("decoding manifest: %w", err)
+	}
+
+	return &manifest, token, nil
+}
+
+// fetchBearerToken fetches an anonymous Bearer token using the WWW-Authenticate challenge.
+func fetchBearerToken(ctx context.Context, client *http.Client, wwwAuth, repository string) (string, error) {
+	realm, service, scope := parseWWWAuthenticate(wwwAuth, repository)
+	if realm == "" {
+		return "", fmt.Errorf("no realm in WWW-Authenticate: %q", wwwAuth)
+	}
+
+	tokenURL, err := url.Parse(realm)
+	if err != nil {
+		return "", fmt.Errorf("invalid realm URL: %w", err)
+	}
+
+	q := tokenURL.Query()
+	if service != "" {
+		q.Set("service", service)
+	}
+	if scope != "" {
+		q.Set("scope", scope)
+	}
+	tokenURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token fetch failed: %s", resp.Status)
+	}
+
+	var tokenData struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenData); err != nil {
+		return "", fmt.Errorf("decoding token response: %w", err)
+	}
+
+	if tokenData.Token != "" {
+		return tokenData.Token, nil
+	}
+	return tokenData.AccessToken, nil
+}
+
+// parseWWWAuthenticate parses a Bearer WWW-Authenticate header into realm, service, scope.
+func parseWWWAuthenticate(header, repository string) (realm, service, scope string) {
+	header = strings.TrimPrefix(header, "Bearer ")
+
+	params := make(map[string]string)
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) == 2 {
+			k := strings.TrimSpace(kv[0])
+			v := strings.Trim(strings.TrimSpace(kv[1]), `"`)
+			params[k] = v
+		}
+	}
+
+	realm = params["realm"]
+	service = params["service"]
+	scope = params["scope"]
+	if scope == "" {
+		scope = fmt.Sprintf("repository:%s:pull", repository)
+	}
+	return
+}
+
+// downloadAndExtractLayer downloads a blob by digest and extracts it into destDir.
+func (f *ociFeature) downloadAndExtractLayer(ctx context.Context, registry, repository, digest, token, destDir string) error {
+	blobURL := fmt.Sprintf("https://%s/v2/%s/blobs/%s", registry, repository, digest)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := f.httpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("blob fetch failed: %s", resp.Status)
+	}
+
+	return extractTar(resp.Body, destDir)
+}
+
+// extractTar extracts a tar stream (auto-detecting gzip compression) into destDir.
+// Peeks at the first two bytes: 0x1f 0x8b indicates gzip; otherwise plain tar.
+func extractTar(r io.Reader, destDir string) error {
+	peek := make([]byte, 2)
+	n, err := io.ReadFull(r, peek)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		if n == 0 {
+			return nil // empty stream
+		}
+		return err
+	}
+
+	combined := io.MultiReader(bytes.NewReader(peek[:n]), r)
+
+	var tr *tar.Reader
+	if n >= 2 && peek[0] == 0x1f && peek[1] == 0x8b {
+		gr, err := gzip.NewReader(combined)
+		if err != nil {
+			return fmt.Errorf("creating gzip reader: %w", err)
+		}
+		defer gr.Close()
+		tr = tar.NewReader(gr)
+	} else {
+		tr = tar.NewReader(combined)
+	}
+
+	return extractTarEntries(tr, destDir)
+}
+
+// extractTarEntries extracts all entries from a tar reader into destDir,
+// sanitizing paths to prevent directory traversal.
+func extractTarEntries(tr *tar.Reader, destDir string) error {
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		cleanPath := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(cleanPath, "..") {
+			return fmt.Errorf("invalid path in tar archive: %s", hdr.Name)
+		}
+
+		target := filepath.Join(destDir, cleanPath)
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdr.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			if err := os.Symlink(hdr.Linkname, target); err != nil && !os.IsExist(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/devcontainers/features/oci.go
+++ b/pkg/devcontainers/features/oci.go
@@ -23,6 +23,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -140,7 +142,7 @@ func (f *ociFeature) fetchManifest(ctx context.Context, registry, repository, re
 
 	var token string
 	if resp.StatusCode == http.StatusUnauthorized {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		wwwAuth := resp.Header.Get("WWW-Authenticate")
 		token, err = fetchBearerToken(ctx, client, wwwAuth, repository)
 		if err != nil {
@@ -159,7 +161,7 @@ func (f *ociFeature) fetchManifest(ctx context.Context, registry, repository, re
 			return nil, "", err
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("manifest fetch failed: %s", resp.Status)
@@ -203,7 +205,7 @@ func fetchBearerToken(ctx context.Context, client *http.Client, wwwAuth, reposit
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("token fetch failed: %s", resp.Status)
@@ -247,8 +249,14 @@ func parseWWWAuthenticate(header, repository string) (realm, service, scope stri
 	return
 }
 
-// downloadAndExtractLayer downloads a blob by digest and extracts it into destDir.
+// downloadAndExtractLayer downloads a blob by digest, verifies its SHA-256
+// digest, and extracts it into destDir. Extraction is only attempted after
+// the digest is confirmed to prevent processing a corrupt or tampered blob.
 func (f *ociFeature) downloadAndExtractLayer(ctx context.Context, registry, repository, digest, token, destDir string) error {
+	if !strings.HasPrefix(digest, "sha256:") {
+		return fmt.Errorf("unsupported digest algorithm: %s", digest)
+	}
+
 	blobURL := fmt.Sprintf("https://%s/v2/%s/blobs/%s", registry, repository, digest)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
@@ -263,18 +271,46 @@ func (f *ociFeature) downloadAndExtractLayer(ctx context.Context, registry, repo
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("blob fetch failed: %s", resp.Status)
 	}
 
-	return extractTar(resp.Body, destDir)
+	// Buffer the blob to a temp file while computing its SHA-256 digest in one pass.
+	tmp, err := os.CreateTemp("", "kdn-feature-blob-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	h := sha256.New()
+	if _, err := io.Copy(tmp, io.TeeReader(resp.Body, h)); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("downloading blob: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("flushing blob: %w", err)
+	}
+
+	// Verify before extracting.
+	if got := "sha256:" + hex.EncodeToString(h.Sum(nil)); got != digest {
+		return fmt.Errorf("blob digest mismatch: expected %s, got %s", digest, got)
+	}
+
+	blob, err := os.Open(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = blob.Close() }()
+
+	return extractTar(blob, destDir)
 }
 
 // extractTar extracts a tar stream (auto-detecting gzip compression) into destDir.
 // Peeks at the first two bytes: 0x1f 0x8b indicates gzip; otherwise plain tar.
-func extractTar(r io.Reader, destDir string) error {
+func extractTar(r io.Reader, destDir string) (retErr error) {
 	peek := make([]byte, 2)
 	n, err := io.ReadFull(r, peek)
 	if err != nil && err != io.ErrUnexpectedEOF {
@@ -292,7 +328,11 @@ func extractTar(r io.Reader, destDir string) error {
 		if err != nil {
 			return fmt.Errorf("creating gzip reader: %w", err)
 		}
-		defer gr.Close()
+		defer func() {
+			if err := gr.Close(); err != nil && retErr == nil {
+				retErr = fmt.Errorf("closing gzip reader: %w", err)
+			}
+		}()
 		tr = tar.NewReader(gr)
 	} else {
 		tr = tar.NewReader(combined)
@@ -305,9 +345,13 @@ func extractTar(r io.Reader, destDir string) error {
 // stays within destDir, preventing directory-traversal attacks.
 func safeTarTarget(destDir, name string) (string, error) {
 	cleanPath := filepath.Clean(filepath.FromSlash(name))
-	if cleanPath == "." || filepath.IsAbs(cleanPath) ||
+	if filepath.IsAbs(cleanPath) ||
 		cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("invalid path in tar archive: %s", name)
+	}
+	// "." represents the archive root directory — map it to destDir itself.
+	if cleanPath == "." {
+		return destDir, nil
 	}
 
 	target := filepath.Join(destDir, cleanPath)
@@ -358,10 +402,12 @@ func extractTarEntries(tr *tar.Reader, destDir string) error {
 				return err
 			}
 			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
+				_ = f.Close()
 				return err
 			}
-			f.Close()
+			if err := f.Close(); err != nil {
+				return err
+			}
 		case tar.TypeSymlink, tar.TypeLink:
 			return fmt.Errorf("unsupported link in tar archive: %s", hdr.Name)
 		}

--- a/pkg/devcontainers/features/oci_integration_test.go
+++ b/pkg/devcontainers/features/oci_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/openkaiden/kdn/pkg/devcontainers/features"
 )
@@ -50,8 +51,11 @@ func TestIntegration_OCIFeature_DownloadNode(t *testing.T) {
 		t.Fatalf("expected 1 feature, got %d", len(feats))
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	destDir := t.TempDir()
-	meta, err := feats[0].Download(context.Background(), destDir)
+	meta, err := feats[0].Download(ctx, destDir)
 	if err != nil {
 		t.Fatalf("Download(%q): %v", nodeFeatureID, err)
 	}
@@ -96,7 +100,10 @@ func TestIntegration_OCIFeature_MergeUserOptions(t *testing.T) {
 		t.Fatalf("FromMap: %v", err)
 	}
 
-	meta, err := feats[0].Download(context.Background(), t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	meta, err := feats[0].Download(ctx, t.TempDir())
 	if err != nil {
 		t.Fatalf("Download: %v", err)
 	}
@@ -124,7 +131,10 @@ func TestIntegration_OCIFeature_InvalidOptionRejected(t *testing.T) {
 		t.Fatalf("FromMap: %v", err)
 	}
 
-	meta, err := feats[0].Download(context.Background(), t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	meta, err := feats[0].Download(ctx, t.TempDir())
 	if err != nil {
 		t.Fatalf("Download: %v", err)
 	}
@@ -177,12 +187,15 @@ func TestIntegration_OCIFeature_OrderAWSCLIAfterCommonUtils(t *testing.T) {
 		err  error
 	}
 	results := make([]downloadResult, len(feats))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	var wg sync.WaitGroup
 	for i, feat := range feats {
 		wg.Add(1)
 		go func(i int, feat features.Feature) {
 			defer wg.Done()
-			meta, err := feat.Download(context.Background(), t.TempDir())
+			meta, err := feat.Download(ctx, t.TempDir())
 			results[i] = downloadResult{id: feat.ID(), meta: meta, err: err}
 		}(i, feat)
 	}

--- a/pkg/devcontainers/features/oci_integration_test.go
+++ b/pkg/devcontainers/features/oci_integration_test.go
@@ -1,0 +1,216 @@
+//go:build integration
+
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/devcontainers/features"
+)
+
+const (
+	nodeFeatureID        = "ghcr.io/devcontainers/features/node:1"
+	awsCliFeatureID      = "ghcr.io/devcontainers/features/aws-cli:1"
+	commonUtilsFeatureID = "ghcr.io/devcontainers/features/common-utils:2"
+)
+
+func TestIntegration_OCIFeature_DownloadNode(t *testing.T) {
+	t.Parallel()
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{nodeFeatureID: nil},
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if len(feats) != 1 {
+		t.Fatalf("expected 1 feature, got %d", len(feats))
+	}
+
+	destDir := t.TempDir()
+	meta, err := feats[0].Download(context.Background(), destDir)
+	if err != nil {
+		t.Fatalf("Download(%q): %v", nodeFeatureID, err)
+	}
+
+	// install.sh must be present — it is the entry point for every feature.
+	if _, err := os.Stat(filepath.Join(destDir, "install.sh")); err != nil {
+		t.Errorf("install.sh not found in extracted feature: %v", err)
+	}
+
+	if meta == nil {
+		t.Fatal("Download returned nil metadata")
+	}
+
+	// ContainerEnv should include NVM_DIR, which the node feature always sets.
+	env := meta.ContainerEnv()
+	if _, ok := env["NVM_DIR"]; !ok {
+		t.Errorf("ContainerEnv missing NVM_DIR; got %v", env)
+	}
+
+	// The node feature always declares a "version" string option with a default.
+	opts := meta.Options()
+	if opts == nil {
+		t.Fatal("Options() returned nil")
+	}
+	merged, err := opts.Merge(nil)
+	if err != nil {
+		t.Fatalf("Merge(nil): %v", err)
+	}
+	if _, ok := merged["VERSION"]; !ok {
+		t.Errorf("merged options missing VERSION key; got %v", merged)
+	}
+}
+
+func TestIntegration_OCIFeature_MergeUserOptions(t *testing.T) {
+	t.Parallel()
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{nodeFeatureID: nil},
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	meta, err := feats[0].Download(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+
+	// Override the version option; the key must be normalised to VERSION.
+	merged, err := meta.Options().Merge(map[string]interface{}{
+		"version": "20",
+	})
+	if err != nil {
+		t.Fatalf("Merge with version=20: %v", err)
+	}
+	if got := merged["VERSION"]; got != "20" {
+		t.Errorf("VERSION = %q, want %q", got, "20")
+	}
+}
+
+func TestIntegration_OCIFeature_InvalidOptionRejected(t *testing.T) {
+	t.Parallel()
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{nodeFeatureID: nil},
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+
+	meta, err := feats[0].Download(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+
+	// Supplying an integer for a string option must return an error.
+	_, err = meta.Options().Merge(map[string]interface{}{
+		"version": 9000,
+	})
+	if err == nil {
+		t.Error("expected error for wrong type (int for string option), got nil")
+	}
+}
+
+// TestIntegration_OCIFeature_OrderAWSCLIAfterCommonUtils verifies that Order
+// places common-utils:2 before aws-cli:1.
+//
+// aws-cli:1 declares installsAfter: ["ghcr.io/devcontainers/features/common-utils"]
+// (versionless, per spec). Without version-aware matching this dependency would
+// be missed because the registered ID carries a ":2" tag — and the naive
+// alphabetical order ("aws-cli" < "common-utils") would produce the wrong result.
+// This test therefore exercises both the version-stripped ID matching in Order
+// and the network download path.
+func TestIntegration_OCIFeature_OrderAWSCLIAfterCommonUtils(t *testing.T) {
+	t.Parallel()
+
+	feats, _, err := features.FromMap(
+		map[string]map[string]interface{}{
+			awsCliFeatureID:      nil,
+			commonUtilsFeatureID: nil,
+		},
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if len(feats) != 2 {
+		t.Fatalf("expected 2 features, got %d", len(feats))
+	}
+
+	// Verify that FromMap pre-sorts by ID: aws-cli < common-utils alphabetically.
+	if feats[0].ID() != awsCliFeatureID || feats[1].ID() != commonUtilsFeatureID {
+		t.Fatalf("FromMap sort: got [%s, %s], want [%s, %s]",
+			feats[0].ID(), feats[1].ID(), awsCliFeatureID, commonUtilsFeatureID)
+	}
+
+	// Download both features in parallel.
+	type downloadResult struct {
+		id   string
+		meta features.FeatureMetadata
+		err  error
+	}
+	results := make([]downloadResult, len(feats))
+	var wg sync.WaitGroup
+	for i, feat := range feats {
+		wg.Add(1)
+		go func(i int, feat features.Feature) {
+			defer wg.Done()
+			meta, err := feat.Download(context.Background(), t.TempDir())
+			results[i] = downloadResult{id: feat.ID(), meta: meta, err: err}
+		}(i, feat)
+	}
+	wg.Wait()
+
+	metadata := make(map[string]features.FeatureMetadata, len(feats))
+	for _, r := range results {
+		if r.err != nil {
+			t.Fatalf("Download(%q): %v", r.id, r.err)
+		}
+		metadata[r.id] = r.meta
+	}
+
+	t.Logf("aws-cli installsAfter:      %v", metadata[awsCliFeatureID].InstallsAfter())
+	t.Logf("common-utils installsAfter: %v", metadata[commonUtilsFeatureID].InstallsAfter())
+
+	ordered, err := features.Order(feats, metadata)
+	if err != nil {
+		t.Fatalf("Order: %v", err)
+	}
+	if len(ordered) != 2 {
+		t.Fatalf("Order returned %d features, want 2", len(ordered))
+	}
+
+	// common-utils must come first because aws-cli installsAfter it.
+	// This is the opposite of alphabetical order, proving the dependency was detected.
+	if ordered[0].ID() != commonUtilsFeatureID || ordered[1].ID() != awsCliFeatureID {
+		t.Errorf("Order: got [%s, %s], want [%s, %s]",
+			ordered[0].ID(), ordered[1].ID(), commonUtilsFeatureID, awsCliFeatureID)
+	}
+}

--- a/pkg/devcontainers/features/oci_test.go
+++ b/pkg/devcontainers/features/oci_test.go
@@ -598,15 +598,11 @@ func TestExtractTarEntries_DirectoryEntry(t *testing.T) {
 	}
 }
 
-func TestExtractTarEntries_SymlinkEntry(t *testing.T) {
+func TestExtractTarEntries_SymlinkEntryRejected(t *testing.T) {
 	t.Parallel()
 
-	// Create a target file first, then a symlink pointing at it.
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	content := []byte("target")
-	_ = tw.WriteHeader(&tar.Header{Name: "target.txt", Mode: 0644, Size: int64(len(content))})
-	_, _ = tw.Write(content)
 	_ = tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeSymlink,
 		Name:     "link.txt",
@@ -615,15 +611,8 @@ func TestExtractTarEntries_SymlinkEntry(t *testing.T) {
 	tw.Close()
 
 	destDir := t.TempDir()
-	if err := extractTarEntries(tar.NewReader(&buf), destDir); err != nil {
-		t.Fatalf("extractTarEntries: %v", err)
-	}
-	fi, err := os.Lstat(filepath.Join(destDir, "link.txt"))
-	if err != nil {
-		t.Fatalf("link.txt not found: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Error("link.txt is not a symlink")
+	if err := extractTarEntries(tar.NewReader(&buf), destDir); err == nil {
+		t.Fatal("expected error for symlink entry, got nil")
 	}
 }
 

--- a/pkg/devcontainers/features/oci_test.go
+++ b/pkg/devcontainers/features/oci_test.go
@@ -188,7 +188,7 @@ func TestFetchBearerToken_SuccessTokenField(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"token":"mytoken123"}`)
+		_, _ = fmt.Fprint(w, `{"token":"mytoken123"}`)
 	}))
 	defer srv.Close()
 
@@ -208,7 +208,7 @@ func TestFetchBearerToken_SuccessAccessTokenField(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// "access_token" field instead of "token"
-		fmt.Fprint(w, `{"access_token":"accesstok456"}`)
+		_, _ = fmt.Fprint(w, `{"access_token":"accesstok456"}`)
 	}))
 	defer srv.Close()
 
@@ -256,7 +256,7 @@ func TestFetchBearerToken_TokenEndpointBadJSON(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "not valid json")
+		_, _ = fmt.Fprint(w, "not valid json")
 	}))
 	defer srv.Close()
 
@@ -271,7 +271,7 @@ func TestFetchBearerToken_NetworkError(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("{}"))
+		_, _ = w.Write([]byte("{}"))
 	}))
 	defer srv.Close()
 
@@ -296,7 +296,7 @@ func TestFetchManifest_NoAuth(t *testing.T) {
 	manifest := `{"layers":[{"digest":"sha256:aaa"},{"digest":"sha256:bbb"}]}`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-		fmt.Fprint(w, manifest)
+		_, _ = fmt.Fprint(w, manifest)
 	}))
 	defer srv.Close()
 
@@ -338,9 +338,9 @@ func TestFetchManifest_WithBearerAuth(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-			fmt.Fprint(w, manifest)
+			_, _ = fmt.Fprint(w, manifest)
 		case r.URL.Path == "/token":
-			fmt.Fprint(w, `{"token":"tok123"}`)
+			_, _ = fmt.Fprint(w, `{"token":"tok123"}`)
 		}
 	}))
 	defer srv.Close()
@@ -385,7 +385,7 @@ func TestFetchManifest_BadJSON(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-		fmt.Fprint(w, "not json at all")
+		_, _ = fmt.Fprint(w, "not json at all")
 	}))
 	defer srv.Close()
 
@@ -476,7 +476,9 @@ func TestDownloadAndExtractLayer_WithToken(t *testing.T) {
 	content := []byte("hello")
 	_ = tw.WriteHeader(&tar.Header{Name: "hello.txt", Mode: 0644, Size: int64(len(content))})
 	_, _ = tw.Write(content)
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
 
 	tarBytes := tarBuf.Bytes()
 	h := sha256.Sum256(tarBytes)
@@ -485,7 +487,7 @@ func TestDownloadAndExtractLayer_WithToken(t *testing.T) {
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
-		w.Write(tarBytes)
+		_, _ = w.Write(tarBytes)
 	}))
 	defer srv.Close()
 
@@ -526,7 +528,9 @@ func TestExtractTar_PlainTar(t *testing.T) {
 	content := []byte("plain tar content")
 	_ = tw.WriteHeader(&tar.Header{Name: "plain.txt", Mode: 0644, Size: int64(len(content))})
 	_, _ = tw.Write(content)
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
 
 	destDir := t.TempDir()
 	if err := extractTar(&buf, destDir); err != nil {
@@ -550,8 +554,12 @@ func TestExtractTar_GzipTar(t *testing.T) {
 	content := []byte("gzip tar content")
 	_ = tw.WriteHeader(&tar.Header{Name: "gzip.txt", Mode: 0644, Size: int64(len(content))})
 	_, _ = tw.Write(content)
-	tw.Close()
-	gw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("closing gzip writer: %v", err)
+	}
 
 	destDir := t.TempDir()
 	if err := extractTar(&buf, destDir); err != nil {
@@ -573,7 +581,7 @@ func TestExtractTar_InvalidGzip(t *testing.T) {
 	data := []byte{0x1f, 0x8b, 0x00}
 	err := extractTar(bytes.NewReader(data), t.TempDir())
 	if err == nil {
-		t.Error("expected error for invalid gzip, got nil")
+		t.Fatal("expected error for invalid gzip, got nil")
 	}
 	if !strings.Contains(err.Error(), "creating gzip reader") {
 		t.Errorf("error = %q, want to contain 'creating gzip reader'", err.Error())
@@ -588,7 +596,9 @@ func TestExtractTarEntries_DirectoryEntry(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 	_ = tw.WriteHeader(&tar.Header{Typeflag: tar.TypeDir, Name: "mydir/", Mode: 0755})
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
 
 	destDir := t.TempDir()
 	if err := extractTarEntries(tar.NewReader(&buf), destDir); err != nil {
@@ -613,7 +623,9 @@ func TestExtractTarEntries_SymlinkEntryRejected(t *testing.T) {
 		Name:     "link.txt",
 		Linkname: "target.txt",
 	})
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
 
 	destDir := t.TempDir()
 	if err := extractTarEntries(tar.NewReader(&buf), destDir); err == nil {
@@ -630,7 +642,9 @@ func TestExtractTarEntries_PathTraversalRejected(t *testing.T) {
 	// Use a path that after filepath.Clean resolves to something starting with ".."
 	_ = tw.WriteHeader(&tar.Header{Name: "../evil.txt", Mode: 0644, Size: int64(len(content))})
 	_, _ = tw.Write(content)
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
 
 	err := extractTarEntries(tar.NewReader(&buf), t.TempDir())
 	if err == nil {
@@ -682,7 +696,7 @@ func TestOCIFeatureDownload_LayerExtractError(t *testing.T) {
 		switch {
 		case strings.Contains(r.URL.Path, "/manifests/"):
 			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-			fmt.Fprint(w, manifest)
+			_, _ = fmt.Fprint(w, manifest)
 		case strings.Contains(r.URL.Path, "/blobs/"):
 			http.Error(w, "blob gone", http.StatusGone)
 		}
@@ -710,7 +724,9 @@ func TestOCIFeatureDownload_MissingFeatureJSON(t *testing.T) {
 	body := []byte("just a script")
 	_ = tw.WriteHeader(&tar.Header{Name: "install.sh", Mode: 0755, Size: int64(len(body))})
 	_, _ = tw.Write(body)
-	tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
 	tarBytes := tarBuf.Bytes()
 
 	h := sha256.Sum256(tarBytes)
@@ -724,9 +740,9 @@ func TestOCIFeatureDownload_MissingFeatureJSON(t *testing.T) {
 		switch {
 		case strings.Contains(r.URL.Path, "/manifests/"):
 			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-			w.Write(manifest)
+			_, _ = w.Write(manifest)
 		case strings.Contains(r.URL.Path, "/blobs/"):
-			w.Write(tarBytes)
+			_, _ = w.Write(tarBytes)
 		}
 	}))
 	defer srv.Close()

--- a/pkg/devcontainers/features/oci_test.go
+++ b/pkg/devcontainers/features/oci_test.go
@@ -1,0 +1,747 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package features
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// httpsToHTTPTransport rewrites every https:// request to http:// on the given host.
+// Used to point OCI code (which hard-codes https://) at a plain httptest.Server.
+type httpsToHTTPTransport struct{ host string }
+
+func (t *httpsToHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := *req.URL
+	u.Scheme = "http"
+	u.Host = t.host
+	req2 := req.Clone(req.Context())
+	req2.URL = &u
+	return http.DefaultTransport.RoundTrip(req2)
+}
+
+// errTransport always returns the given error from RoundTrip.
+type errTransport struct{ err error }
+
+func (t *errTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.err
+}
+
+// ociClientFor returns an *http.Client that redirects https:// calls to the httptest server.
+func ociClientFor(srv *httptest.Server) *http.Client {
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return &http.Client{Transport: &httpsToHTTPTransport{host: host}}
+}
+
+// --- parseOCIRef ---
+
+func TestParseOCIRef(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		id         string
+		registry   string
+		repository string
+		ref        string
+	}{
+		// Explicit registry with tag
+		{"ghcr.io/org/feature:1", "ghcr.io", "org/feature", "1"},
+		// Explicit registry, no tag → latest
+		{"ghcr.io/org/feature", "ghcr.io", "org/feature", "latest"},
+		// Digest reference
+		{"ghcr.io/org/feature@sha256:abc123", "ghcr.io", "org/feature", "sha256:abc123"},
+		// Registry with port
+		{"localhost:5000/myfeature:tag", "localhost:5000", "myfeature", "tag"},
+		// "localhost" without port is still treated as registry
+		{"localhost/myfeature:tag", "localhost", "myfeature", "tag"},
+		// No explicit registry → defaults to ghcr.io
+		{"myorg/feature:1.0", "ghcr.io", "myorg/feature", "1.0"},
+		// No registry, no tag
+		{"myorg/feature", "ghcr.io", "myorg/feature", "latest"},
+		// Single bare name (no slash, no tag)
+		{"singlename", "ghcr.io", "singlename", "latest"},
+		// Registry with dot, no tag
+		{"registry.example.com/org/feature", "registry.example.com", "org/feature", "latest"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+			registry, repository, ref, err := parseOCIRef(tc.id)
+			if err != nil {
+				t.Fatalf("parseOCIRef(%q) error = %v", tc.id, err)
+			}
+			if registry != tc.registry {
+				t.Errorf("registry = %q, want %q", registry, tc.registry)
+			}
+			if repository != tc.repository {
+				t.Errorf("repository = %q, want %q", repository, tc.repository)
+			}
+			if ref != tc.ref {
+				t.Errorf("ref = %q, want %q", ref, tc.ref)
+			}
+		})
+	}
+}
+
+// --- parseWWWAuthenticate ---
+
+func TestParseWWWAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full header with realm service and scope", func(t *testing.T) {
+		t.Parallel()
+		realm, service, scope := parseWWWAuthenticate(
+			`Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:org/feature:pull"`,
+			"org/feature",
+		)
+		if realm != "https://ghcr.io/token" {
+			t.Errorf("realm = %q, want %q", realm, "https://ghcr.io/token")
+		}
+		if service != "ghcr.io" {
+			t.Errorf("service = %q, want %q", service, "ghcr.io")
+		}
+		if scope != "repository:org/feature:pull" {
+			t.Errorf("scope = %q, want %q", scope, "repository:org/feature:pull")
+		}
+	})
+
+	t.Run("no scope in header uses constructed fallback", func(t *testing.T) {
+		t.Parallel()
+		_, _, scope := parseWWWAuthenticate(
+			`Bearer realm="https://auth.example.com/token",service="example.com"`,
+			"myorg/myrepo",
+		)
+		want := "repository:myorg/myrepo:pull"
+		if scope != want {
+			t.Errorf("scope = %q, want %q", scope, want)
+		}
+	})
+
+	t.Run("no service field returns empty service", func(t *testing.T) {
+		t.Parallel()
+		_, service, _ := parseWWWAuthenticate(
+			`Bearer realm="https://auth.example.com/token"`,
+			"myrepo",
+		)
+		if service != "" {
+			t.Errorf("service = %q, want empty", service)
+		}
+	})
+
+	t.Run("empty header returns empty realm", func(t *testing.T) {
+		t.Parallel()
+		realm, _, _ := parseWWWAuthenticate("", "myrepo")
+		if realm != "" {
+			t.Errorf("realm = %q, want empty", realm)
+		}
+	})
+
+	t.Run("header without Bearer prefix is still parsed", func(t *testing.T) {
+		t.Parallel()
+		realm, service, _ := parseWWWAuthenticate(
+			`realm="https://token.example.com",service="example"`,
+			"myrepo",
+		)
+		if realm != "https://token.example.com" {
+			t.Errorf("realm = %q, want %q", realm, "https://token.example.com")
+		}
+		if service != "example" {
+			t.Errorf("service = %q, want %q", service, "example")
+		}
+	})
+}
+
+// --- fetchBearerToken ---
+
+func TestFetchBearerToken_SuccessTokenField(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"mytoken123"}`)
+	}))
+	defer srv.Close()
+
+	wwwAuth := fmt.Sprintf(`Bearer realm="%s/token",service="test"`, srv.URL)
+	token, err := fetchBearerToken(context.Background(), http.DefaultClient, wwwAuth, "org/repo")
+	if err != nil {
+		t.Fatalf("fetchBearerToken: %v", err)
+	}
+	if token != "mytoken123" {
+		t.Errorf("token = %q, want %q", token, "mytoken123")
+	}
+}
+
+func TestFetchBearerToken_SuccessAccessTokenField(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// "access_token" field instead of "token"
+		fmt.Fprint(w, `{"access_token":"accesstok456"}`)
+	}))
+	defer srv.Close()
+
+	wwwAuth := fmt.Sprintf(`Bearer realm="%s/token",service="test"`, srv.URL)
+	token, err := fetchBearerToken(context.Background(), http.DefaultClient, wwwAuth, "org/repo")
+	if err != nil {
+		t.Fatalf("fetchBearerToken: %v", err)
+	}
+	if token != "accesstok456" {
+		t.Errorf("token = %q, want %q", token, "accesstok456")
+	}
+}
+
+func TestFetchBearerToken_NoRealm(t *testing.T) {
+	t.Parallel()
+
+	_, err := fetchBearerToken(context.Background(), http.DefaultClient, "", "org/repo")
+	if err == nil {
+		t.Fatal("expected error for missing realm, got nil")
+	}
+	if !strings.Contains(err.Error(), "no realm") {
+		t.Errorf("error = %q, want to contain 'no realm'", err.Error())
+	}
+}
+
+func TestFetchBearerToken_TokenEndpointNonOK(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	wwwAuth := fmt.Sprintf(`Bearer realm="%s/token",service="test"`, srv.URL)
+	_, err := fetchBearerToken(context.Background(), http.DefaultClient, wwwAuth, "org/repo")
+	if err == nil {
+		t.Fatal("expected error for non-200 token response, got nil")
+	}
+	if !strings.Contains(err.Error(), "token fetch failed") {
+		t.Errorf("error = %q, want to contain 'token fetch failed'", err.Error())
+	}
+}
+
+func TestFetchBearerToken_TokenEndpointBadJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "not valid json")
+	}))
+	defer srv.Close()
+
+	wwwAuth := fmt.Sprintf(`Bearer realm="%s/token",service="test"`, srv.URL)
+	_, err := fetchBearerToken(context.Background(), http.DefaultClient, wwwAuth, "org/repo")
+	if err == nil {
+		t.Fatal("expected error for bad JSON, got nil")
+	}
+}
+
+func TestFetchBearerToken_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	networkErr := errors.New("simulated network failure")
+	wwwAuth := fmt.Sprintf(`Bearer realm="%s/token",service="test"`, srv.URL)
+	_, err := fetchBearerToken(
+		context.Background(),
+		&http.Client{Transport: &errTransport{err: networkErr}},
+		wwwAuth,
+		"org/repo",
+	)
+	if !errors.Is(err, networkErr) {
+		t.Errorf("error = %v, want %v", err, networkErr)
+	}
+}
+
+// --- fetchManifest ---
+
+func TestFetchManifest_NoAuth(t *testing.T) {
+	t.Parallel()
+
+	manifest := `{"layers":[{"digest":"sha256:aaa"},{"digest":"sha256:bbb"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		fmt.Fprint(w, manifest)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	m, token, err := feat.fetchManifest(context.Background(), host, "org/feat", "latest")
+	if err != nil {
+		t.Fatalf("fetchManifest: %v", err)
+	}
+	if token != "" {
+		t.Errorf("token = %q, want empty (no auth required)", token)
+	}
+	if len(m.Layers) != 2 {
+		t.Errorf("len(layers) = %d, want 2", len(m.Layers))
+	}
+}
+
+func TestFetchManifest_WithBearerAuth(t *testing.T) {
+	t.Parallel()
+
+	manifest := `{"layers":[{"digest":"sha256:abc"}]}`
+	var reqCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&reqCount, 1)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/manifests/latest"):
+			if n == 1 {
+				// First manifest request: issue Bearer challenge.
+				w.Header().Set("WWW-Authenticate",
+					fmt.Sprintf(`Bearer realm="http://%s/token",service="test"`, r.Host))
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			// Subsequent request: verify token and serve manifest.
+			if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
+				http.Error(w, "bad auth", http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			fmt.Fprint(w, manifest)
+		case r.URL.Path == "/token":
+			fmt.Fprint(w, `{"token":"tok123"}`)
+		}
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	m, token, err := feat.fetchManifest(context.Background(), host, "org/feat", "latest")
+	if err != nil {
+		t.Fatalf("fetchManifest: %v", err)
+	}
+	if token != "tok123" {
+		t.Errorf("token = %q, want %q", token, "tok123")
+	}
+	if len(m.Layers) != 1 {
+		t.Errorf("len(layers) = %d, want 1", len(m.Layers))
+	}
+}
+
+func TestFetchManifest_NonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	_, _, err := feat.fetchManifest(context.Background(), host, "org/feat", "latest")
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "manifest fetch failed") {
+		t.Errorf("error = %q, want to contain 'manifest fetch failed'", err.Error())
+	}
+}
+
+func TestFetchManifest_BadJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		fmt.Fprint(w, "not json at all")
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	_, _, err := feat.fetchManifest(context.Background(), host, "org/feat", "latest")
+	if err == nil {
+		t.Fatal("expected error for bad JSON manifest, got nil")
+	}
+	if !strings.Contains(err.Error(), "decoding manifest") {
+		t.Errorf("error = %q, want to contain 'decoding manifest'", err.Error())
+	}
+}
+
+func TestFetchManifest_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	networkErr := errors.New("dial failed")
+	feat := &ociFeature{
+		id:     "ghcr.io/org/feat:latest",
+		client: &http.Client{Transport: &errTransport{err: networkErr}},
+	}
+	_, _, err := feat.fetchManifest(context.Background(), "ghcr.io", "org/feat", "latest")
+	if !errors.Is(err, networkErr) {
+		t.Errorf("error = %v, want %v", err, networkErr)
+	}
+}
+
+func TestFetchManifest_AuthTokenFetchFails(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			// Always issue a challenge; token endpoint will fail.
+			w.Header().Set("WWW-Authenticate",
+				fmt.Sprintf(`Bearer realm="http://%s/token",service="test"`, r.Host))
+			w.WriteHeader(http.StatusUnauthorized)
+		case r.URL.Path == "/token":
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	_, _, err := feat.fetchManifest(context.Background(), host, "org/feat", "latest")
+	if err == nil {
+		t.Fatal("expected error when token fetch fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetching bearer token") {
+		t.Errorf("error = %q, want to contain 'fetching bearer token'", err.Error())
+	}
+}
+
+// --- downloadAndExtractLayer ---
+
+func TestDownloadAndExtractLayer_NonOKBlob(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	err := feat.downloadAndExtractLayer(
+		context.Background(), host, "org/feat", "sha256:missing", "", t.TempDir(),
+	)
+	if err == nil {
+		t.Fatal("expected error for 404 blob, got nil")
+	}
+	if !strings.Contains(err.Error(), "blob fetch failed") {
+		t.Errorf("error = %q, want to contain 'blob fetch failed'", err.Error())
+	}
+}
+
+func TestDownloadAndExtractLayer_WithToken(t *testing.T) {
+	t.Parallel()
+
+	// Serve a minimal plain tar containing one file.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	content := []byte("hello")
+	_ = tw.WriteHeader(&tar.Header{Name: "hello.txt", Mode: 0644, Size: int64(len(content))})
+	_, _ = tw.Write(content)
+	tw.Close()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write(tarBuf.Bytes())
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	destDir := t.TempDir()
+	err := feat.downloadAndExtractLayer(
+		context.Background(), host, "org/feat", "sha256:abc", "mytoken", destDir,
+	)
+	if err != nil {
+		t.Fatalf("downloadAndExtractLayer: %v", err)
+	}
+	if gotAuth != "Bearer mytoken" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer mytoken")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "hello.txt")); err != nil {
+		t.Errorf("hello.txt not found: %v", err)
+	}
+}
+
+// --- extractTar ---
+
+func TestExtractTar_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	err := extractTar(bytes.NewReader(nil), t.TempDir())
+	if err != nil {
+		t.Errorf("expected nil error for empty stream, got %v", err)
+	}
+}
+
+func TestExtractTar_PlainTar(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	content := []byte("plain tar content")
+	_ = tw.WriteHeader(&tar.Header{Name: "plain.txt", Mode: 0644, Size: int64(len(content))})
+	_, _ = tw.Write(content)
+	tw.Close()
+
+	destDir := t.TempDir()
+	if err := extractTar(&buf, destDir); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(destDir, "plain.txt"))
+	if err != nil {
+		t.Fatalf("reading extracted file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+}
+
+func TestExtractTar_GzipTar(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	content := []byte("gzip tar content")
+	_ = tw.WriteHeader(&tar.Header{Name: "gzip.txt", Mode: 0644, Size: int64(len(content))})
+	_, _ = tw.Write(content)
+	tw.Close()
+	gw.Close()
+
+	destDir := t.TempDir()
+	if err := extractTar(&buf, destDir); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(destDir, "gzip.txt"))
+	if err != nil {
+		t.Fatalf("reading extracted file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+}
+
+func TestExtractTar_InvalidGzip(t *testing.T) {
+	t.Parallel()
+
+	// Gzip magic bytes followed by an invalid/truncated header.
+	data := []byte{0x1f, 0x8b, 0x00}
+	err := extractTar(bytes.NewReader(data), t.TempDir())
+	if err == nil {
+		t.Error("expected error for invalid gzip, got nil")
+	}
+	if !strings.Contains(err.Error(), "creating gzip reader") {
+		t.Errorf("error = %q, want to contain 'creating gzip reader'", err.Error())
+	}
+}
+
+// --- extractTarEntries ---
+
+func TestExtractTarEntries_DirectoryEntry(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Typeflag: tar.TypeDir, Name: "mydir/", Mode: 0755})
+	tw.Close()
+
+	destDir := t.TempDir()
+	if err := extractTarEntries(tar.NewReader(&buf), destDir); err != nil {
+		t.Fatalf("extractTarEntries: %v", err)
+	}
+	fi, err := os.Stat(filepath.Join(destDir, "mydir"))
+	if err != nil {
+		t.Fatalf("mydir not found: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Error("mydir is not a directory")
+	}
+}
+
+func TestExtractTarEntries_SymlinkEntry(t *testing.T) {
+	t.Parallel()
+
+	// Create a target file first, then a symlink pointing at it.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	content := []byte("target")
+	_ = tw.WriteHeader(&tar.Header{Name: "target.txt", Mode: 0644, Size: int64(len(content))})
+	_, _ = tw.Write(content)
+	_ = tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeSymlink,
+		Name:     "link.txt",
+		Linkname: "target.txt",
+	})
+	tw.Close()
+
+	destDir := t.TempDir()
+	if err := extractTarEntries(tar.NewReader(&buf), destDir); err != nil {
+		t.Fatalf("extractTarEntries: %v", err)
+	}
+	fi, err := os.Lstat(filepath.Join(destDir, "link.txt"))
+	if err != nil {
+		t.Fatalf("link.txt not found: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("link.txt is not a symlink")
+	}
+}
+
+func TestExtractTarEntries_PathTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	content := []byte("evil")
+	// Use a path that after filepath.Clean resolves to something starting with ".."
+	_ = tw.WriteHeader(&tar.Header{Name: "../evil.txt", Mode: 0644, Size: int64(len(content))})
+	_, _ = tw.Write(content)
+	tw.Close()
+
+	err := extractTarEntries(tar.NewReader(&buf), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid path") {
+		t.Errorf("error = %q, want to contain 'invalid path'", err.Error())
+	}
+}
+
+func TestExtractTarEntries_TarReadError(t *testing.T) {
+	t.Parallel()
+
+	// Feed corrupted data that causes tar.Reader.Next() to return a non-EOF error.
+	garbage := bytes.Repeat([]byte{0xFF}, 600) // enough to pass the 512-byte header read but invalid
+	err := extractTarEntries(tar.NewReader(bytes.NewReader(garbage)), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error from corrupt tar data, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading tar entry") {
+		t.Errorf("error = %q, want to contain 'reading tar entry'", err.Error())
+	}
+}
+
+// --- ociFeature.Download error paths ---
+
+func TestOCIFeatureDownload_ManifestFetchError(t *testing.T) {
+	t.Parallel()
+
+	networkErr := errors.New("connection refused")
+	feat := &ociFeature{
+		id:     "ghcr.io/org/feat:latest",
+		client: &http.Client{Transport: &errTransport{err: networkErr}},
+	}
+	_, err := feat.Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when manifest fetch fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetching manifest") {
+		t.Errorf("error = %q, want to contain 'fetching manifest'", err.Error())
+	}
+}
+
+func TestOCIFeatureDownload_LayerExtractError(t *testing.T) {
+	t.Parallel()
+
+	manifest := `{"layers":[{"digest":"sha256:bad"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			fmt.Fprint(w, manifest)
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			http.Error(w, "blob gone", http.StatusGone)
+		}
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	_, err := feat.Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when layer extraction fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "extracting layer") {
+		t.Errorf("error = %q, want to contain 'extracting layer'", err.Error())
+	}
+}
+
+func TestOCIFeatureDownload_MissingFeatureJSON(t *testing.T) {
+	t.Parallel()
+
+	// Serve a manifest with one layer that extracts a tar containing no devcontainer-feature.json.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	body := []byte("just a script")
+	_ = tw.WriteHeader(&tar.Header{Name: "install.sh", Mode: 0755, Size: int64(len(body))})
+	_, _ = tw.Write(body)
+	tw.Close()
+	tarBytes := tarBuf.Bytes()
+
+	manifest, _ := json.Marshal(map[string]interface{}{
+		"layers": []map[string]interface{}{{"digest": "sha256:only"}},
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Write(manifest)
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			w.Write(tarBytes)
+		}
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	feat := &ociFeature{id: host + "/org/feat:latest", client: ociClientFor(srv)}
+
+	_, err := feat.Download(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when devcontainer-feature.json is absent, got nil")
+	}
+	if !strings.Contains(err.Error(), "devcontainer-feature.json") {
+		t.Errorf("error = %q, want to contain 'devcontainer-feature.json'", err.Error())
+	}
+}

--- a/pkg/devcontainers/features/oci_test.go
+++ b/pkg/devcontainers/features/oci_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -477,10 +478,14 @@ func TestDownloadAndExtractLayer_WithToken(t *testing.T) {
 	_, _ = tw.Write(content)
 	tw.Close()
 
+	tarBytes := tarBuf.Bytes()
+	h := sha256.Sum256(tarBytes)
+	digest := fmt.Sprintf("sha256:%x", h)
+
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
-		w.Write(tarBuf.Bytes())
+		w.Write(tarBytes)
 	}))
 	defer srv.Close()
 
@@ -489,7 +494,7 @@ func TestDownloadAndExtractLayer_WithToken(t *testing.T) {
 
 	destDir := t.TempDir()
 	err := feat.downloadAndExtractLayer(
-		context.Background(), host, "org/feat", "sha256:abc", "mytoken", destDir,
+		context.Background(), host, "org/feat", digest, "mytoken", destDir,
 	)
 	if err != nil {
 		t.Fatalf("downloadAndExtractLayer: %v", err)
@@ -708,8 +713,11 @@ func TestOCIFeatureDownload_MissingFeatureJSON(t *testing.T) {
 	tw.Close()
 	tarBytes := tarBuf.Bytes()
 
+	h := sha256.Sum256(tarBytes)
+	digest := fmt.Sprintf("sha256:%x", h)
+
 	manifest, _ := json.Marshal(map[string]interface{}{
-		"layers": []map[string]interface{}{{"digest": "sha256:only"}},
+		"layers": []map[string]interface{}{{"digest": digest}},
 	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Implements pkg/devcontainers/features as specified in issue #302:
- Feature, FeatureMetadata, and FeatureOptions interfaces (all unexported impls)
- OCI registry download: anonymous Bearer auth, manifest fetch, gzip/plain tar extraction, path-traversal sanitisation
- Local file tree download for ./… and ../… IDs
- FromMap classifies IDs and returns a deterministically sorted slice
- Order runs Kahn's topological sort on installsAfter; matches versionless installsAfter values against versioned feature IDs by stripping the tag
- Unit tests covering all acceptance criteria; integration tests against the real ghcr.io registry (build tag: integration)
- /working-with-devcontainers skill with spec coverage table
- Extend make test-integration target to ./... to include the new tests

Closes #302

@serbangeorge-m I have added a few integration tests and modified the make test-integration command to cover them. Please check I didn't break anything

Can be tested on PR #323 which includes this PR