### PR TITLE
fix(runtime/podman): capture stderr on failure and serialize integration test builds

### DIFF
--- a/pkg/cmd/integration_test.go
+++ b/pkg/cmd/integration_test.go
@@ -28,10 +28,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 )
+
+// initMu serializes "kdn init" calls so that only one podman build runs at a
+// time. Podman's rootless storage driver uses file locks that are unreliable
+// under concurrent builds, causing sporadic "exit status 125" failures.
+var initMu sync.Mutex
 
 // containerSourcesPath is the mount point for project sources inside the container.
 const containerSourcesPath = "/workspace/sources"
@@ -135,7 +141,10 @@ func integrationInit(t *testing.T, storageDir, sourcesDir, name, agent string, e
 	rootCmd.SetOut(stdout)
 	rootCmd.SetArgs(args)
 
-	if err := rootCmd.Execute(); err != nil {
+	initMu.Lock()
+	err := rootCmd.Execute()
+	initMu.Unlock()
+	if err != nil {
 		t.Fatalf("init failed: %v", err)
 	}
 
@@ -183,7 +192,10 @@ func integrationInitTextMode(t *testing.T, storageDir, sourcesDir, name, agent s
 	rootCmd.SetErr(stderrBuf)
 	rootCmd.SetArgs(args)
 
-	if err := rootCmd.Execute(); err != nil {
+	initMu.Lock()
+	err := rootCmd.Execute()
+	initMu.Unlock()
+	if err != nil {
 		t.Fatalf("init failed: %v\nStderr: %s", err, stderrBuf.String())
 	}
 

--- a/pkg/runtime/podman/exec/exec.go
+++ b/pkg/runtime/podman/exec/exec.go
@@ -16,10 +16,13 @@
 package exec
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // Executor provides an interface for executing podman commands.
@@ -51,19 +54,37 @@ func New() Executor {
 }
 
 // Run executes a podman command, writing stdout and stderr to the provided writers.
+// On failure, the error includes podman's stderr output for diagnostics,
+// even when the caller passes io.Discard as the stderr writer.
 func (e *executor) Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
+	var stderrBuf bytes.Buffer
 	cmd := exec.CommandContext(ctx, "podman", args...)
 	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	return cmd.Run()
+	cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderrBuf.String()); msg != "" {
+			return fmt.Errorf("%w\nPodman stderr:\n%s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 // Output executes a podman command and returns its standard output.
 // Stderr is written to the provided writer.
+// On failure, the error includes podman's stderr output for diagnostics.
 func (e *executor) Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error) {
+	var stderrBuf bytes.Buffer
 	cmd := exec.CommandContext(ctx, "podman", args...)
-	cmd.Stderr = stderr
-	return cmd.Output()
+	cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderrBuf.String()); msg != "" {
+			return out, fmt.Errorf("%w\nPodman stderr:\n%s", err, msg)
+		}
+		return out, err
+	}
+	return out, nil
 }
 
 // RunInteractive executes a podman command with stdin/stdout/stderr connected to the terminal.


### PR DESCRIPTION
- Include podman's stderr output in error messages when commands fail. Previously, stderr was routed through the logger which discards output by default, so failures like "exit status 125" gave no diagnostics.
- Serialize "kdn init" calls in integration tests with a mutex to prevent concurrent podman builds from racing on rootless storage locks.