### PR TITLE
feat(cmd): add --env flag to `kdn secret create`

### DIFF
--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -11,7 +11,7 @@ The secrets system uses a two-layer architecture: a **Store** that persists secr
 ## Overview
 
 - Secret **values** live exclusively in the system keychain — never on disk
-- Non-sensitive **metadata** (type, hosts, path, header descriptors) is persisted to `<storage-dir>/secrets.json`
+- Non-sensitive **metadata** (type, hosts, path, header descriptors, envs) is persisted to `<storage-dir>/secrets.json`
 - Named types (e.g. `github`) derive all their descriptor fields from a registered `SecretService`
 - The built-in `other` type requires the user to supply all descriptor fields explicitly
 
@@ -39,7 +39,7 @@ The keychain backend is platform-specific: GNOME Keyring on Linux, Keychain on m
 | Type | How descriptor fields are resolved |
 |------|------------------------------------|
 | Named (e.g. `github`) | Taken from the registered `SecretService` automatically |
-| `other` | User must supply `--host`, `--path`, `--header`, `--headerTemplate` |
+| `other` | User must supply `--host`, `--path`, `--header`, `--headerTemplate`, `--env` |
 
 ## Using the Store
 
@@ -67,6 +67,7 @@ err := store.Create(secret.CreateParams{
     Path:           "/v1",
     Header:         "Authorization",
     HeaderTemplate: "Bearer ${value}",
+    Envs:           []string{"MY_API_KEY"},
 })
 ```
 

--- a/pkg/cmd/secret_create.go
+++ b/pkg/cmd/secret_create.go
@@ -37,6 +37,7 @@ type secretCreateCmd struct {
 	path           string
 	header         string
 	headerTemplate string
+	envs           []string
 	store          secret.Store
 	validTypes     []string
 }
@@ -75,6 +76,9 @@ func (s *secretCreateCmd) preRun(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("headerTemplate") {
 			return fmt.Errorf("--headerTemplate is required when --type=%s", secret.TypeOther)
 		}
+		if len(s.envs) == 0 {
+			return fmt.Errorf("--env is required when --type=%s", secret.TypeOther)
+		}
 	} else {
 		// Descriptor flags are not valid for named types
 		if len(s.hosts) > 0 {
@@ -88,6 +92,9 @@ func (s *secretCreateCmd) preRun(cmd *cobra.Command, args []string) error {
 		}
 		if cmd.Flags().Changed("headerTemplate") {
 			return fmt.Errorf("--headerTemplate is only valid when --type=%s", secret.TypeOther)
+		}
+		if len(s.envs) > 0 {
+			return fmt.Errorf("--env is only valid when --type=%s", secret.TypeOther)
 		}
 	}
 
@@ -117,6 +124,7 @@ func (s *secretCreateCmd) run(cmd *cobra.Command, args []string) error {
 		Path:           s.path,
 		Header:         s.header,
 		HeaderTemplate: s.headerTemplate,
+		Envs:           s.envs,
 	}); err != nil {
 		return fmt.Errorf("failed to create secret: %w", err)
 	}
@@ -140,20 +148,17 @@ func NewSecretCreateCmd() *cobra.Command {
 
 The secret value is stored securely in the system keychain (GNOME Keyring on
 Linux, Keychain on macOS, DPAPI on Windows). Non-sensitive metadata (type,
-hosts, path, header template) is persisted in the kdn storage directory.
+hosts, path, header template, envs) is persisted in the kdn storage directory.
 
 Accepted types: %s.
 
-When --type=other, the flags --host, --path, --header, and --headerTemplate
-are all required. For any other type, these flags must not be specified.`, typesStr),
+When --type=other, the flags --host, --path, --header, --headerTemplate, and
+--env are all required. For any other type, these flags must not be specified.`, typesStr),
 		Example: `# Create a GitHub token secret
 kdn secret create my-github-token --type github --value ghp_mytoken
 
 # Create a custom secret (type=other) with all required descriptor flags
-kdn secret create my-api-key --type other --value secret123 --host api.example.com --path /api/v1 --header Authorization --headerTemplate "Bearer ${value}"
-
-# Create a custom secret with multiple hosts
-kdn secret create my-api-key --type other --value secret123 --host api.example.com --host dev.example.com --path / --header Authorization --headerTemplate "Bearer ${value}"`,
+kdn secret create my-api-key --type other --value secret123 --host api.example.com --host dev.example.com --path /api/v1 --header Authorization --headerTemplate "Bearer ${value}" --env MY_API_KEY --env API_KEY`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -169,6 +174,7 @@ kdn secret create my-api-key --type other --value secret123 --host api.example.c
 	cmd.Flags().StringVar(&c.path, "path", "", "URL path restriction (required for --type=other)")
 	cmd.Flags().StringVar(&c.header, "header", "", "HTTP header name (required for --type=other)")
 	cmd.Flags().StringVar(&c.headerTemplate, "headerTemplate", "", "HTTP header value template using ${value} as placeholder (required for --type=other)")
+	cmd.Flags().StringArrayVar(&c.envs, "env", nil, "Environment variable name to expose the secret value (required for --type=other, can be specified multiple times)")
 
 	return cmd
 }

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -50,6 +50,7 @@ func buildPreRunCmd(storageDir string) *cobra.Command {
 	cmd.Flags().String("header", "", "")
 	cmd.Flags().String("headerTemplate", "", "")
 	cmd.Flags().StringArray("host", nil, "")
+	cmd.Flags().StringArray("env", nil, "")
 	return cmd
 }
 
@@ -81,7 +82,7 @@ func TestSecretCreateCmd_Examples(t *testing.T) {
 		t.Fatalf("failed to parse examples: %v", err)
 	}
 
-	expectedCount := 3
+	expectedCount := 2
 	if len(commands) != expectedCount {
 		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
 	}
@@ -234,6 +235,37 @@ func TestSecretCreateCmd_PreRun(t *testing.T) {
 		}
 	})
 
+	t.Run("other without --env", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, validTypes: testValidTypes}
+		cmd := buildPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("path", "/"); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Flags().Set("header", "Authorization"); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Flags().Set("headerTemplate", "Bearer ${value}"); err != nil {
+			t.Fatal(err)
+		}
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--env is required when --type=other") {
+			t.Errorf("expected '--env is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("github with --env rejected", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretCreateCmd{secretType: "github", value: "v", envs: []string{"MY_TOKEN"}, validTypes: testValidTypes}
+		cmd := buildPreRunCmd(t.TempDir())
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--env is only valid when --type=other") {
+			t.Errorf("expected '--env is only valid' error, got: %v", err)
+		}
+	})
+
 	t.Run("valid github params", func(t *testing.T) {
 		t.Parallel()
 
@@ -263,6 +295,7 @@ func TestSecretCreateCmd_Run(t *testing.T) {
 			path:           "/api",
 			header:         "Authorization",
 			headerTemplate: "Bearer ${value}",
+			envs:           []string{"MY_API_KEY", "API_KEY"},
 			store:          fs,
 			validTypes:     testValidTypes,
 		}
@@ -291,6 +324,9 @@ func TestSecretCreateCmd_Run(t *testing.T) {
 		}
 		if len(fs.params.Hosts) != 1 || fs.params.Hosts[0] != "api.example.com" {
 			t.Errorf("Hosts: want [api.example.com], got %v", fs.params.Hosts)
+		}
+		if len(fs.params.Envs) != 2 || fs.params.Envs[0] != "MY_API_KEY" || fs.params.Envs[1] != "API_KEY" {
+			t.Errorf("Envs: want [MY_API_KEY API_KEY], got %v", fs.params.Envs)
 		}
 	})
 

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -35,6 +35,7 @@ type CreateParams struct {
 	Path           string
 	Header         string
 	HeaderTemplate string
+	Envs           []string
 }
 
 // Store manages persistent storage of secrets.

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -77,6 +77,7 @@ type secretRecord struct {
 	Path           string   `json:"path,omitempty"`
 	Header         string   `json:"header,omitempty"`
 	HeaderTemplate string   `json:"headerTemplate,omitempty"`
+	Envs           []string `json:"envs,omitempty"`
 }
 
 type secretsFile struct {
@@ -132,6 +133,7 @@ func (s *store) appendAndSave(sf secretsFile, params CreateParams) error {
 		Path:           params.Path,
 		Header:         params.Header,
 		HeaderTemplate: params.HeaderTemplate,
+		Envs:           params.Envs,
 	})
 
 	jsonData, err := json.MarshalIndent(sf, "", "  ")


### PR DESCRIPTION
Adds --env (repeatable) to `secret create --type=other`. The flag is required for type=other (alongside --host, --path, --header, --headerTemplate) and rejected for named types. Env names are stored in the new Envs field of secrets.json.

Closes #316