### PR TITLE
feat(podman): install devcontainer features during image build

### DIFF
--- a/.agents/skills/working-with-devcontainers/SKILL.md
+++ b/.agents/skills/working-with-devcontainers/SKILL.md
@@ -41,7 +41,7 @@ feats, userOptions, err := features.FromMap(cfg.Features, workspaceConfigDir)
 // Phase 2 – download each feature into the build context.
 metadata := make(map[string]features.FeatureMetadata, len(feats))
 for i, feat := range feats {
-    destDir := filepath.Join(buildContextDir, "features", strconv.Itoa(i))
+    destDir := filepath.Join(buildContextDir, "features", fmt.Sprintf("feature-%d", i))
     meta, err := feat.Download(ctx, destDir)
     metadata[feat.ID()] = meta
 }

--- a/.agents/skills/working-with-devcontainers/SKILL.md
+++ b/.agents/skills/working-with-devcontainers/SKILL.md
@@ -289,20 +289,28 @@ type featureInstallInfo struct {
 
 ### Containerfile layout
 
-Feature instructions appear **immediately after `FROM`**, before `RUN dnf install -y` — while the image is still root. No `USER` switches are needed.
+Feature instructions are placed **after user creation** (`useradd -m agent`) but **before `USER agent:agent`**. Features still run as root so they can install system-wide tools, but `/home/agent` and the `agent` account already exist — allowing install scripts to `chown` files, write dotfiles, and `su` to the target user. `_REMOTE_USER` and `_REMOTE_USER_HOME` are exported as `ENV` immediately before the feature block so scripts can resolve the target user by name.
 
 ```dockerfile
 FROM registry.fedoraproject.org/fedora:latest
+
+ARG UID=1000
+ARG GID=1000
+
+RUN dnf install -y …
+
+RUN … groupadd … && useradd -m agent
+COPY sudoers …
+RUN chmod 0440 …
+
+ENV _REMOTE_USER="agent"
+ENV _REMOTE_USER_HOME="/home/agent"
 
 COPY features/feature-0/ /tmp/feature-install/feature-0/
 RUN chmod +x /tmp/feature-install/feature-0/install.sh && VERSION="1.21" /tmp/feature-install/feature-0/install.sh
 ENV GOROOT="/usr/local/go"
 ENV GOPATH="/home/agent/go"
 
-RUN dnf install -y …
-
-ARG UID=1000
-…
 USER agent:agent
 …
 ```

--- a/.agents/skills/working-with-devcontainers/SKILL.md
+++ b/.agents/skills/working-with-devcontainers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: working-with-devcontainers
-description: Guide to the devcontainers features package including the Feature/FeatureMetadata/FeatureOptions interfaces, OCI and local feature implementations, and the two-phase FromMap→Download→Order workflow
+description: Guide to the devcontainers features package including the Feature/FeatureMetadata/FeatureOptions interfaces, OCI and local feature implementations, the FromMap→Download→Order workflow, and how the Podman runtime integrates features into Containerfile generation
 argument-hint: ""
 ---
 
@@ -259,3 +259,56 @@ go test -tags integration -run TestIntegration_ -timeout 2m ./pkg/devcontainers/
 ```
 
 Real-registry tests live in `pkg/devcontainers/features/oci_integration_test.go`.
+
+## Podman Runtime Integration
+
+The Podman runtime (`pkg/runtime/podman/create.go`) drives the full workflow when `WorkspaceConfig.Features` is non-empty.
+
+### prepareFeatures
+
+```go
+func (p *podmanRuntime) prepareFeatures(ctx context.Context, instanceDir string, params runtime.CreateParams) ([]featureInstallInfo, error)
+```
+
+1. Returns `nil, nil` early if `params.WorkspaceConfig.Features` is nil or empty.
+2. Calls `features.FromMap(*params.WorkspaceConfig.Features, params.WorkspaceConfigDir)` — `WorkspaceConfigDir` from `CreateParams` is required to resolve local `./…` feature paths.
+3. Downloads each feature into `<instanceDir>/features/feature-{i}/` where `i` is the index into `FromMap`'s sorted output (stable names before `Order` shuffles them).
+4. Calls `features.Order` for topological sort.
+5. Calls `FeatureOptions.Merge(userOpts[feat.ID()])` per feature.
+6. Returns `[]featureInstallInfo` — one entry per ordered feature.
+
+### featureInstallInfo
+
+```go
+type featureInstallInfo struct {
+    dirName string            // "feature-0", "feature-1", …
+    options map[string]string // merged normalised env vars (e.g. "VERSION" → "1.21")
+    envVars map[string]string // containerEnv entries from devcontainer-feature.json
+}
+```
+
+### Containerfile layout
+
+Feature instructions appear **immediately after `FROM`**, before `RUN dnf install -y` — while the image is still root. No `USER` switches are needed.
+
+```dockerfile
+FROM registry.fedoraproject.org/fedora:latest
+
+COPY features/feature-0/ /tmp/feature-install/feature-0/
+RUN chmod +x /tmp/feature-install/feature-0/install.sh && VERSION="1.21" /tmp/feature-install/feature-0/install.sh
+ENV GOROOT="/usr/local/go"
+ENV GOPATH="/home/agent/go"
+
+RUN dnf install -y …
+
+ARG UID=1000
+…
+USER agent:agent
+…
+```
+
+Options are passed as inline env var assignments (`KEY="value"`) before the script path. Double quotes in values are escaped (`\"`). Keys are sorted alphabetically for deterministic output. `chmod +x` is always emitted because local feature copy uses `0644` permissions.
+
+### Config merger requirement
+
+`pkg/config/merger.go` must explicitly handle every `WorkspaceConfiguration` field. The `Features` field is wired via `mergeFeatures()` / `copyFeatures()`. When adding new fields to `WorkspaceConfiguration`, always add the corresponding merge and copy logic — omitted fields are silently dropped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ The `pkg/devcontainers/features` package models, downloads, and orders Dev Conta
 - Features are downloaded into `<instanceDir>/features/feature-{i}/` (stable names based on `FromMap`'s sorted output)
 - Each feature becomes a `featureInstallInfo{dirName, options, envVars}` passed to `generateContainerfile()`
 - `WorkspaceConfigDir` is required in `CreateParams` so `FromMap` can resolve `./local-feature` paths
-- In the Containerfile, feature `COPY`/`RUN`/`ENV` instructions are placed immediately after `FROM` (before `RUN dnf install`), while the image is still root — no `USER` switches needed
+- In the Containerfile, feature `COPY`/`RUN`/`ENV` instructions are placed after user creation (`useradd -m agent`) but before `USER agent:agent` — features still run as root so they can install system-wide tools, but `/home/agent` and the `agent` account exist so install scripts can `chown`, write dotfiles, and `su` to the target user. `_REMOTE_USER` and `_REMOTE_USER_HOME` are exported as `ENV` immediately before the feature block
 
 **Config merger requirement:** The `pkg/config/merger.go` `Merge()` and `copyConfig()` functions must explicitly handle every field of `WorkspaceConfiguration`. Fields not wired in are silently dropped. `Features` is handled via `mergeFeatures()` / `copyFeatures()`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,15 @@ The `pkg/devcontainers/features` package models, downloads, and orders Dev Conta
 
 **Typical call sequence:** `FromMap` → `Feature.Download` (parallel) → `Order` → `FeatureOptions.Merge` per feature.
 
+**Podman runtime integration** (`pkg/runtime/podman/create.go`):
+- `prepareFeatures()` drives the full sequence when `WorkspaceConfig.Features` is non-empty
+- Features are downloaded into `<instanceDir>/features/feature-{i}/` (stable names based on `FromMap`'s sorted output)
+- Each feature becomes a `featureInstallInfo{dirName, options, envVars}` passed to `generateContainerfile()`
+- `WorkspaceConfigDir` is required in `CreateParams` so `FromMap` can resolve `./local-feature` paths
+- In the Containerfile, feature `COPY`/`RUN`/`ENV` instructions are placed immediately after `FROM` (before `RUN dnf install`), while the image is still root — no `USER` switches needed
+
+**Config merger requirement:** The `pkg/config/merger.go` `Merge()` and `copyConfig()` functions must explicitly handle every field of `WorkspaceConfiguration`. Fields not wired in are silently dropped. `Features` is handled via `mergeFeatures()` / `copyFeatures()`.
+
 **For full implementation details, use:** `/working-with-devcontainers`
 
 ### StepLogger System

--- a/README.md
+++ b/README.md
@@ -1563,7 +1563,11 @@ The `workspace.json` file uses a nested JSON structure:
     "mode": "deny",
     "hosts": ["api.github.com"]
   },
-  "secrets": ["my-github-token", "my-api-key"]
+  "secrets": ["my-github-token", "my-api-key"],
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {"version": "1.23"},
+    "./tools/my-feature": {}
+  }
 }
 ```
 
@@ -1779,6 +1783,49 @@ Configure secrets to inject into the workspace. Each entry is the name of a secr
 **Validation Rules:**
 - Secret names cannot be empty
 - Duplicate names within the list are rejected
+
+### Dev Container Features
+
+Install [Dev Container Features](https://containers.dev/implementors/features/) into the workspace image at build time. Features are reusable environment components that add languages, runtimes, and tools to your workspace.
+
+**Structure:**
+```json
+{
+  "features": {
+    "<feature-id>": {},
+    "<feature-id>": {"<option>": "<value>"}
+  }
+}
+```
+
+Each key is a feature ID — either an OCI reference (`ghcr.io/org/repo/feature:tag`) or a relative path to a local directory (`./my-feature`). Each value is a map of options that override the feature's defaults; use an empty object `{}` to accept all defaults.
+
+**Fields:**
+- Feature ID (required) — OCI reference or relative path to a local directory
+- Options (required, can be empty) — key/value pairs that customise the feature
+
+**Validation Rules:**
+- Feature IDs must be OCI references or relative paths (`./…`); `https://` tarball URIs are not supported
+- Local paths are resolved relative to the workspace configuration directory (e.g. `.kaiden/`)
+
+**Example — install Go and Node.js:**
+```json
+{
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {"version": "1.23"},
+    "ghcr.io/devcontainers/features/node:1": {"version": "20"}
+  }
+}
+```
+
+**Example — use a local feature:**
+```json
+{
+  "features": {
+    "./tools/my-feature": {}
+  }
+}
+```
 
 ### Configuration Validation
 

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -78,6 +78,9 @@ func (m *merger) Merge(base, override *workspace.WorkspaceConfiguration) *worksp
 	// Merge network configuration
 	result.Network = mergeNetwork(base.Network, override.Network)
 
+	// Merge features
+	result.Features = mergeFeatures(base.Features, override.Features)
+
 	return result
 }
 
@@ -551,5 +554,60 @@ func copyConfig(cfg *workspace.WorkspaceConfiguration) *workspace.WorkspaceConfi
 	// Copy network configuration
 	result.Network = copyNetwork(cfg.Network)
 
+	// Copy features
+	result.Features = copyFeatures(cfg.Features)
+
 	return result
+}
+
+// copyFeatureOptions creates a shallow copy of a feature options map.
+// Values are JSON-derived primitives (string, bool, float64), so a shallow copy is sufficient.
+func copyFeatureOptions(opts map[string]interface{}) map[string]interface{} {
+	if opts == nil {
+		return nil
+	}
+	result := make(map[string]interface{}, len(opts))
+	for k, v := range opts {
+		result[k] = v
+	}
+	return result
+}
+
+// copyFeatures creates a deep copy of a features map.
+func copyFeatures(feats *map[string]map[string]interface{}) *map[string]map[string]interface{} {
+	if feats == nil {
+		return nil
+	}
+	result := make(map[string]map[string]interface{}, len(*feats))
+	for id, opts := range *feats {
+		result[id] = copyFeatureOptions(opts)
+	}
+	return &result
+}
+
+// mergeFeatures merges two features maps, with override taking precedence by feature ID.
+// Base features are included first; override entries replace base entries with the same ID.
+func mergeFeatures(base, override *map[string]map[string]interface{}) *map[string]map[string]interface{} {
+	if base == nil && override == nil {
+		return nil
+	}
+
+	result := make(map[string]map[string]interface{})
+
+	if base != nil {
+		for id, opts := range *base {
+			result[id] = copyFeatureOptions(opts)
+		}
+	}
+
+	if override != nil {
+		for id, opts := range *override {
+			result[id] = copyFeatureOptions(opts)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return &result
 }

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -1438,3 +1438,121 @@ func TestMerger_Merge_MCP_PreservesOtherFields(t *testing.T) {
 		t.Error("Servers from override were not added")
 	}
 }
+
+func TestMerger_Features(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+
+	t.Run("base features preserved when override has none", func(t *testing.T) {
+		t.Parallel()
+
+		baseFeats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/go:1": {"version": "1.21"},
+		}
+		base := &workspace.WorkspaceConfiguration{Features: &baseFeats}
+
+		result := merger.Merge(base, &workspace.WorkspaceConfiguration{})
+		if result.Features == nil {
+			t.Fatal("Expected Features to be preserved from base")
+		}
+		if _, ok := (*result.Features)["ghcr.io/devcontainers/features/go:1"]; !ok {
+			t.Error("Expected go feature to be present in merged result")
+		}
+	})
+
+	t.Run("override features added when base has none", func(t *testing.T) {
+		t.Parallel()
+
+		overrideFeats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/node:1": {"version": "lts"},
+		}
+		override := &workspace.WorkspaceConfiguration{Features: &overrideFeats}
+
+		result := merger.Merge(&workspace.WorkspaceConfiguration{}, override)
+		if result.Features == nil {
+			t.Fatal("Expected Features to be present from override")
+		}
+		if _, ok := (*result.Features)["ghcr.io/devcontainers/features/node:1"]; !ok {
+			t.Error("Expected node feature to be present in merged result")
+		}
+	})
+
+	t.Run("override feature options replace base for same ID", func(t *testing.T) {
+		t.Parallel()
+
+		baseFeats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/go:1": {"version": "1.20"},
+		}
+		overrideFeats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/go:1": {"version": "1.21"},
+		}
+		base := &workspace.WorkspaceConfiguration{Features: &baseFeats}
+		override := &workspace.WorkspaceConfiguration{Features: &overrideFeats}
+
+		result := merger.Merge(base, override)
+		if result.Features == nil {
+			t.Fatal("Expected Features to be present")
+		}
+		opts, ok := (*result.Features)["ghcr.io/devcontainers/features/go:1"]
+		if !ok {
+			t.Fatal("Expected go feature to be present")
+		}
+		if opts["version"] != "1.21" {
+			t.Errorf("Expected version 1.21 (override wins), got %v", opts["version"])
+		}
+	})
+
+	t.Run("features from both base and override are combined", func(t *testing.T) {
+		t.Parallel()
+
+		baseFeats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/go:1": {"version": "1.21"},
+		}
+		overrideFeats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/node:1": {"version": "lts"},
+		}
+		base := &workspace.WorkspaceConfiguration{Features: &baseFeats}
+		override := &workspace.WorkspaceConfiguration{Features: &overrideFeats}
+
+		result := merger.Merge(base, override)
+		if result.Features == nil {
+			t.Fatal("Expected Features to be present")
+		}
+		if len(*result.Features) != 2 {
+			t.Errorf("Expected 2 features, got %d", len(*result.Features))
+		}
+		if _, ok := (*result.Features)["ghcr.io/devcontainers/features/go:1"]; !ok {
+			t.Error("Expected go feature from base to be present")
+		}
+		if _, ok := (*result.Features)["ghcr.io/devcontainers/features/node:1"]; !ok {
+			t.Error("Expected node feature from override to be present")
+		}
+	})
+
+	t.Run("nil features on both sides returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		result := merger.Merge(&workspace.WorkspaceConfiguration{}, &workspace.WorkspaceConfiguration{})
+		if result.Features != nil {
+			t.Error("Expected nil Features when both sides have none")
+		}
+	})
+
+	t.Run("copyConfig preserves features", func(t *testing.T) {
+		t.Parallel()
+
+		feats := map[string]map[string]interface{}{
+			"ghcr.io/devcontainers/features/go:1": {"version": "1.21"},
+		}
+		cfg := &workspace.WorkspaceConfiguration{Features: &feats}
+
+		result := merger.Merge(cfg, nil)
+		if result.Features == nil {
+			t.Fatal("Expected Features to be copied")
+		}
+		if _, ok := (*result.Features)["ghcr.io/devcontainers/features/go:1"]; !ok {
+			t.Error("Expected go feature to survive copyConfig")
+		}
+	})
+}

--- a/pkg/devcontainers/features/features.go
+++ b/pkg/devcontainers/features/features.go
@@ -123,7 +123,11 @@ func Order(feats []Feature, metadata map[string]FeatureMetadata) ([]Feature, err
 	featByBase := make(map[string]Feature, len(feats))
 	for _, f := range feats {
 		featMap[f.ID()] = f
-		featByBase[featureBaseID(f.ID())] = f
+		base := featureBaseID(f.ID())
+		if existing, ok := featByBase[base]; ok {
+			return nil, fmt.Errorf("features %q and %q share base ID %q; declare only one variant", existing.ID(), f.ID(), base)
+		}
+		featByBase[base] = f
 	}
 
 	// Kahn's topological sort.

--- a/pkg/devcontainers/features/features_test.go
+++ b/pkg/devcontainers/features/features_test.go
@@ -415,7 +415,7 @@ func TestFeatureOptions_Merge_UnsupportedTypeReturnsError(t *testing.T) {
 		"count": "3",
 	})
 	if err == nil {
-		t.Error("expected error for unsupported option type, got nil")
+		t.Fatal("expected error for unsupported option type, got nil")
 	}
 	if !strings.Contains(err.Error(), "unsupported type") {
 		t.Errorf("error = %q, want to contain 'unsupported type'", err.Error())
@@ -514,7 +514,7 @@ func TestLocalFeature_Download_InvalidJSON(t *testing.T) {
 
 	_, err = feats[0].Download(context.Background(), t.TempDir())
 	if err == nil {
-		t.Error("expected error for invalid JSON, got nil")
+		t.Fatal("expected error for invalid JSON, got nil")
 	}
 	if !strings.Contains(err.Error(), "parsing") {
 		t.Errorf("error = %q, want to contain 'parsing'", err.Error())

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -332,13 +332,14 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 
 	// Create runtime instance with merged configuration
 	runtimeInfo, err := rt.Create(ctx, runtime.CreateParams{
-		Name:            name,
-		SourcePath:      inst.GetSourceDir(),
-		WorkspaceConfig: mergedConfig,
-		Agent:           opts.Agent,
-		AgentSettings:   agentSettings,
-		OnecliSecrets:   onecliSecrets,
-		SecretEnvVars:   secretEnvVars,
+		Name:               name,
+		SourcePath:         inst.GetSourceDir(),
+		WorkspaceConfig:    mergedConfig,
+		WorkspaceConfigDir: inst.GetConfigDir(),
+		Agent:              opts.Agent,
+		AgentSettings:      agentSettings,
+		OnecliSecrets:      onecliSecrets,
+		SecretEnvVars:      secretEnvVars,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)

--- a/pkg/runtime/podman/containerfile.go
+++ b/pkg/runtime/podman/containerfile.go
@@ -82,8 +82,10 @@ func generateSudoers(sudoBinaries []string) string {
 // generateContainerfile generates the Containerfile content from image and agent configurations.
 // If hasAgentSettings is true, a COPY instruction is added to embed the agent-settings
 // directory (written to the build context) into the agent user's home directory.
-// If featureInfos is non-empty, each feature is installed as root between the user setup
-// and the custom RUN commands, with containerEnv variables set after each install.
+// If featureInfos is non-empty, features are installed as root after user creation so
+// that install scripts can chown files, write to /home/agent, and su to the target user.
+// _REMOTE_USER and _REMOTE_USER_HOME are exported before the feature block so install
+// scripts can resolve the target user by name. USER agent:agent is set after all features.
 func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, hasAgentSettings bool, featureInfos []featureInstallInfo) string {
 	if imageConfig == nil {
 		return ""
@@ -99,11 +101,41 @@ func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.
 	lines = append(lines, fmt.Sprintf("FROM %s", baseImage))
 	lines = append(lines, "")
 
+	// Build args for UID/GID declared early so they are available for user creation
+	// and remain in scope for the rest of the stage.
+	lines = append(lines, "ARG UID=1000")
+	lines = append(lines, "ARG GID=1000")
+	lines = append(lines, "")
+
+	// Merge packages from image and agent configs
+	allPackages := append([]string{}, imageConfig.Packages...)
+	allPackages = append(allPackages, agentConfig.Packages...)
+
+	// Install packages if any
+	if len(allPackages) > 0 {
+		lines = append(lines, fmt.Sprintf("RUN dnf install -y %s", strings.Join(allPackages, " ")))
+		lines = append(lines, "")
+	}
+
+	// User and group setup — done before feature installation so the agent user and
+	// /home/agent exist when feature install scripts run.
+	lines = append(lines, `RUN GROUPNAME=$(grep $GID /etc/group | cut -d: -f1); [ -n "$GROUPNAME" ] && groupdel $GROUPNAME || true`)
+	lines = append(lines, fmt.Sprintf(`RUN groupadd -g "${GID}" %s && useradd -u "${UID}" -g "${GID}" -m %s`, constants.ContainerGroup, constants.ContainerUser))
+	lines = append(lines, fmt.Sprintf("COPY sudoers /etc/sudoers.d/%s", constants.ContainerUser))
+	lines = append(lines, fmt.Sprintf("RUN chmod 0440 /etc/sudoers.d/%s", constants.ContainerUser))
+	lines = append(lines, "")
+
 	// Devcontainer feature installation section.
-	// Features run first, while the image is still root, to avoid USER switches.
+	// Features still run as root (USER switch comes after) so they can install
+	// system-wide tools. The agent user and /home/agent now exist so install scripts
+	// can chown files, write to the home directory, and su to the target user.
+	// _REMOTE_USER/_REMOTE_USER_HOME tell scripts which user to configure.
 	// containerEnv vars from each feature are set immediately after installation so
 	// subsequent features can reference them during their own install.
 	if len(featureInfos) > 0 {
+		lines = append(lines, fmt.Sprintf(`ENV _REMOTE_USER="%s"`, constants.ContainerUser))
+		lines = append(lines, fmt.Sprintf(`ENV _REMOTE_USER_HOME="/home/%s"`, constants.ContainerUser))
+		lines = append(lines, "")
 		for _, f := range featureInfos {
 			installPath := fmt.Sprintf("/tmp/feature-install/%s", f.dirName)
 			lines = append(lines, fmt.Sprintf("COPY features/%s/ %s/", f.dirName, installPath))
@@ -124,23 +156,7 @@ func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.
 		lines = append(lines, "")
 	}
 
-	// Merge packages from image and agent configs
-	allPackages := append([]string{}, imageConfig.Packages...)
-	allPackages = append(allPackages, agentConfig.Packages...)
-
-	// Install packages if any
-	if len(allPackages) > 0 {
-		lines = append(lines, fmt.Sprintf("RUN dnf install -y %s", strings.Join(allPackages, " ")))
-		lines = append(lines, "")
-	}
-
-	// User and group setup (hardcoded)
-	lines = append(lines, "ARG UID=1000")
-	lines = append(lines, "ARG GID=1000")
-	lines = append(lines, `RUN GROUPNAME=$(grep $GID /etc/group | cut -d: -f1); [ -n "$GROUPNAME" ] && groupdel $GROUPNAME || true`)
-	lines = append(lines, fmt.Sprintf(`RUN groupadd -g "${GID}" %s && useradd -u "${UID}" -g "${GID}" -m %s`, constants.ContainerGroup, constants.ContainerUser))
-	lines = append(lines, fmt.Sprintf("COPY sudoers /etc/sudoers.d/%s", constants.ContainerUser))
-	lines = append(lines, fmt.Sprintf("RUN chmod 0440 /etc/sudoers.d/%s", constants.ContainerUser))
+	// Switch to the agent user for all subsequent steps.
 	lines = append(lines, fmt.Sprintf("USER %s:%s", constants.ContainerUser, constants.ContainerGroup))
 	lines = append(lines, "")
 

--- a/pkg/runtime/podman/containerfile.go
+++ b/pkg/runtime/podman/containerfile.go
@@ -16,11 +16,48 @@ package podman
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/constants"
 )
+
+// featureInstallInfo holds the information needed to install a devcontainer feature in the image.
+type featureInstallInfo struct {
+	// dirName is the directory name under instanceDir/features/ (e.g. "feature-0").
+	dirName string
+	// options contains merged and normalized option env vars for the install.sh invocation.
+	options map[string]string
+	// envVars contains containerEnv entries to bake into the image after installation.
+	envVars map[string]string
+}
+
+// buildFeatureInstallCmd builds the RUN instruction body for installing a devcontainer feature.
+// Options are passed as inline environment variable assignments before the install.sh invocation.
+// Values are always double-quoted to handle spaces and special characters.
+func buildFeatureInstallCmd(options map[string]string, installPath string) string {
+	scriptPath := installPath + "/install.sh"
+
+	if len(options) == 0 {
+		return fmt.Sprintf("chmod +x %s && %s", scriptPath, scriptPath)
+	}
+
+	keys := make([]string, 0, len(options))
+	for k := range options {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var envParts []string
+	for _, k := range keys {
+		// Escape embedded double quotes in the value.
+		v := strings.ReplaceAll(options[k], `"`, `\"`)
+		envParts = append(envParts, fmt.Sprintf(`%s="%s"`, k, v))
+	}
+
+	return fmt.Sprintf("chmod +x %s && %s %s", scriptPath, strings.Join(envParts, " "), scriptPath)
+}
 
 // generateSudoers generates the sudoers file content from a list of allowed binaries.
 // It creates a single ALLOWED command alias and sets up sudo rules.
@@ -45,7 +82,9 @@ func generateSudoers(sudoBinaries []string) string {
 // generateContainerfile generates the Containerfile content from image and agent configurations.
 // If hasAgentSettings is true, a COPY instruction is added to embed the agent-settings
 // directory (written to the build context) into the agent user's home directory.
-func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, hasAgentSettings bool) string {
+// If featureInfos is non-empty, each feature is installed as root between the user setup
+// and the custom RUN commands, with containerEnv variables set after each install.
+func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, hasAgentSettings bool, featureInfos []featureInstallInfo) string {
 	if imageConfig == nil {
 		return ""
 	}
@@ -59,6 +98,31 @@ func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.
 	baseImage := fmt.Sprintf("%s:%s", constants.BaseImageRegistry, imageConfig.Version)
 	lines = append(lines, fmt.Sprintf("FROM %s", baseImage))
 	lines = append(lines, "")
+
+	// Devcontainer feature installation section.
+	// Features run first, while the image is still root, to avoid USER switches.
+	// containerEnv vars from each feature are set immediately after installation so
+	// subsequent features can reference them during their own install.
+	if len(featureInfos) > 0 {
+		for _, f := range featureInfos {
+			installPath := fmt.Sprintf("/tmp/feature-install/%s", f.dirName)
+			lines = append(lines, fmt.Sprintf("COPY features/%s/ %s/", f.dirName, installPath))
+			lines = append(lines, fmt.Sprintf("RUN %s", buildFeatureInstallCmd(f.options, installPath)))
+			// Set containerEnv vars sorted for deterministic output.
+			if len(f.envVars) > 0 {
+				envKeys := make([]string, 0, len(f.envVars))
+				for k := range f.envVars {
+					envKeys = append(envKeys, k)
+				}
+				sort.Strings(envKeys)
+				for _, k := range envKeys {
+					v := strings.ReplaceAll(f.envVars[k], `"`, `\"`)
+					lines = append(lines, fmt.Sprintf(`ENV %s="%s"`, k, v))
+				}
+			}
+		}
+		lines = append(lines, "")
+	}
 
 	// Merge packages from image and agent configs
 	allPackages := append([]string{}, imageConfig.Packages...)
@@ -80,8 +144,9 @@ func generateContainerfile(imageConfig *config.ImageConfig, agentConfig *config.
 	lines = append(lines, fmt.Sprintf("USER %s:%s", constants.ContainerUser, constants.ContainerGroup))
 	lines = append(lines, "")
 
-	// Environment PATH
-	lines = append(lines, fmt.Sprintf("ENV PATH=/home/%s/.local/bin:/usr/local/bin:/usr/bin", constants.ContainerUser))
+	// Environment PATH — prepend agent-local and system bins while preserving any
+	// PATH additions made by devcontainer features installed above.
+	lines = append(lines, fmt.Sprintf("ENV PATH=/home/%s/.local/bin:/usr/local/bin:/usr/bin:$PATH", constants.ContainerUser))
 	lines = append(lines, "")
 
 	// Copy Containerfile to home directory for reference

--- a/pkg/runtime/podman/containerfile_test.go
+++ b/pkg/runtime/podman/containerfile_test.go
@@ -407,12 +407,12 @@ func TestGenerateContainerfile_WithFeatures(t *testing.T) {
 			t.Error("Expected RUN install.sh without options")
 		}
 
-		// Features run before user setup — no USER switches needed
+		// No USER root switch — features still run as root but after user creation.
 		if strings.Contains(result, "USER root") {
-			t.Error("Expected no 'USER root' instruction: features run before user creation")
+			t.Error("Expected no 'USER root' instruction")
 		}
 
-		// Feature section appears before the USER agent:agent line
+		// Feature COPY appears before USER agent:agent (features run as root).
 		featureCopyPos := strings.Index(result, "COPY features/feature-0/")
 		userAgentPos := strings.Index(result, "USER agent:agent")
 		if featureCopyPos == -1 || userAgentPos == -1 {
@@ -420,6 +420,16 @@ func TestGenerateContainerfile_WithFeatures(t *testing.T) {
 		}
 		if featureCopyPos > userAgentPos {
 			t.Error("Expected feature COPY to appear before 'USER agent:agent'")
+		}
+
+		// User must be created before features so install scripts can reference the account.
+		useradd := "useradd"
+		useraddPos := strings.Index(result, useradd)
+		if useraddPos == -1 {
+			t.Fatal("Expected useradd instruction")
+		}
+		if useraddPos > featureCopyPos {
+			t.Error("Expected useradd to appear before feature COPY")
 		}
 	})
 
@@ -516,6 +526,48 @@ func TestGenerateContainerfile_WithFeatures(t *testing.T) {
 		}
 		if strings.Contains(result, "/tmp/feature-install/") {
 			t.Errorf("Expected no feature install paths\nGot:\n%s", result)
+		}
+	})
+
+	t.Run("_REMOTE_USER and _REMOTE_USER_HOME are set before feature installation", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{dirName: "feature-0", options: nil, envVars: nil},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false, infos)
+
+		if !strings.Contains(result, `ENV _REMOTE_USER="agent"`) {
+			t.Errorf("Expected ENV _REMOTE_USER=\"agent\"\nGot:\n%s", result)
+		}
+		if !strings.Contains(result, `ENV _REMOTE_USER_HOME="/home/agent"`) {
+			t.Errorf("Expected ENV _REMOTE_USER_HOME=\"/home/agent\"\nGot:\n%s", result)
+		}
+
+		// Both vars must appear before the feature COPY instruction.
+		remoteUserPos := strings.Index(result, `ENV _REMOTE_USER="agent"`)
+		remoteUserHomePos := strings.Index(result, `ENV _REMOTE_USER_HOME="/home/agent"`)
+		featureCopyPos := strings.Index(result, "COPY features/feature-0/")
+
+		if remoteUserPos == -1 || remoteUserHomePos == -1 || featureCopyPos == -1 {
+			t.Fatal("Expected _REMOTE_USER, _REMOTE_USER_HOME, and feature COPY to be present")
+		}
+		if remoteUserPos > featureCopyPos {
+			t.Error("Expected _REMOTE_USER to appear before feature COPY")
+		}
+		if remoteUserHomePos > featureCopyPos {
+			t.Error("Expected _REMOTE_USER_HOME to appear before feature COPY")
+		}
+	})
+
+	t.Run("_REMOTE_USER and _REMOTE_USER_HOME are not set when no features", func(t *testing.T) {
+		t.Parallel()
+
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
+
+		if strings.Contains(result, "_REMOTE_USER") {
+			t.Errorf("Expected no _REMOTE_USER when no features\nGot:\n%s", result)
 		}
 	})
 

--- a/pkg/runtime/podman/containerfile_test.go
+++ b/pkg/runtime/podman/containerfile_test.go
@@ -96,7 +96,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		// Check for FROM line with correct base image
 		expectedFrom := "FROM registry.fedoraproject.org/fedora:latest"
@@ -130,9 +130,9 @@ func TestGenerateContainerfile(t *testing.T) {
 			t.Error("Expected RUN chmod for sudoers")
 		}
 
-		// Check for PATH environment
-		if !strings.Contains(result, "ENV PATH=/home/agent/.local/bin:/usr/local/bin:/usr/bin") {
-			t.Error("Expected PATH environment variable")
+		// Check for PATH environment — must preserve $PATH so feature additions are not lost
+		if !strings.Contains(result, "ENV PATH=/home/agent/.local/bin:/usr/local/bin:/usr/bin:$PATH") {
+			t.Error("Expected PATH environment variable preserving $PATH")
 		}
 
 		// Check for Containerfile copy
@@ -161,7 +161,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		expectedFrom := "FROM registry.fedoraproject.org/fedora:40"
 		if !strings.Contains(result, expectedFrom) {
@@ -184,7 +184,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		// Should have all packages in a single RUN command
 		if !strings.Contains(result, "RUN dnf install -y package1 package2 package3 package4") {
@@ -207,7 +207,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		// Should not have dnf install line
 		if strings.Contains(result, "dnf install") {
@@ -231,7 +231,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		// Should have both RUN commands
 		if !strings.Contains(result, "RUN echo 'image setup'") {
@@ -257,7 +257,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, true)
+		result := generateContainerfile(imageConfig, agentConfig, true, nil)
 
 		expected := "COPY --chown=agent:agent agent-settings/. /home/agent/"
 		if !strings.Contains(result, expected) {
@@ -290,7 +290,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		if strings.Contains(result, "agent-settings") {
 			t.Errorf("Expected no agent-settings COPY line, got:\n%s", result)
@@ -313,7 +313,7 @@ func TestGenerateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		result := generateContainerfile(imageConfig, agentConfig, false)
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
 
 		// Find positions
 		imagePos := strings.Index(result, "RUN echo 'image'")
@@ -325,6 +325,217 @@ func TestGenerateContainerfile(t *testing.T) {
 
 		if imagePos > agentPos {
 			t.Error("Image RUN commands should come before agent RUN commands")
+		}
+	})
+}
+
+func TestBuildFeatureInstallCmd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no options produces simple chmod and run", func(t *testing.T) {
+		t.Parallel()
+
+		result := buildFeatureInstallCmd(nil, "/tmp/feature-install/feature-0")
+		expected := "chmod +x /tmp/feature-install/feature-0/install.sh && /tmp/feature-install/feature-0/install.sh"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("single option is inlined before script", func(t *testing.T) {
+		t.Parallel()
+
+		result := buildFeatureInstallCmd(map[string]string{"VERSION": "1.0"}, "/tmp/feature-install/feature-0")
+		expected := `chmod +x /tmp/feature-install/feature-0/install.sh && VERSION="1.0" /tmp/feature-install/feature-0/install.sh`
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("multiple options are sorted alphabetically", func(t *testing.T) {
+		t.Parallel()
+
+		result := buildFeatureInstallCmd(
+			map[string]string{"VERSION": "1.0", "INSTALL": "true"},
+			"/tmp/feature-install/feature-0",
+		)
+		expected := `chmod +x /tmp/feature-install/feature-0/install.sh && INSTALL="true" VERSION="1.0" /tmp/feature-install/feature-0/install.sh`
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("double quotes in value are escaped", func(t *testing.T) {
+		t.Parallel()
+
+		result := buildFeatureInstallCmd(map[string]string{"KEY": `val"ue`}, "/tmp/feature-install/feature-0")
+		expected := `chmod +x /tmp/feature-install/feature-0/install.sh && KEY="val\"ue" /tmp/feature-install/feature-0/install.sh`
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+}
+
+func TestGenerateContainerfile_WithFeatures(t *testing.T) {
+	t.Parallel()
+
+	imageConfig := &config.ImageConfig{
+		Version:     "latest",
+		Packages:    []string{},
+		Sudo:        []string{},
+		RunCommands: []string{"echo 'image setup'"},
+	}
+	agentConfig := &config.AgentConfig{
+		Packages:        []string{},
+		RunCommands:     []string{"echo 'agent setup'"},
+		TerminalCommand: []string{"claude"},
+	}
+
+	t.Run("single feature without options or containerEnv", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{dirName: "feature-0", options: nil, envVars: nil},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false, infos)
+
+		if !strings.Contains(result, "COPY features/feature-0/ /tmp/feature-install/feature-0/") {
+			t.Error("Expected COPY instruction for feature-0")
+		}
+		if !strings.Contains(result, "RUN chmod +x /tmp/feature-install/feature-0/install.sh && /tmp/feature-install/feature-0/install.sh") {
+			t.Error("Expected RUN install.sh without options")
+		}
+
+		// Features run before user setup — no USER switches needed
+		if strings.Contains(result, "USER root") {
+			t.Error("Expected no 'USER root' instruction: features run before user creation")
+		}
+
+		// Feature section appears before the USER agent:agent line
+		featureCopyPos := strings.Index(result, "COPY features/feature-0/")
+		userAgentPos := strings.Index(result, "USER agent:agent")
+		if featureCopyPos == -1 || userAgentPos == -1 {
+			t.Fatal("Expected both feature COPY and 'USER agent:agent'")
+		}
+		if featureCopyPos > userAgentPos {
+			t.Error("Expected feature COPY to appear before 'USER agent:agent'")
+		}
+	})
+
+	t.Run("feature with options includes inline env assignments", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{dirName: "feature-0", options: map[string]string{"VERSION": "1.21", "INSTALL": "true"}, envVars: nil},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false, infos)
+
+		expected := `RUN chmod +x /tmp/feature-install/feature-0/install.sh && INSTALL="true" VERSION="1.21" /tmp/feature-install/feature-0/install.sh`
+		if !strings.Contains(result, expected) {
+			t.Errorf("Expected RUN with sorted options\nWant: %q\nGot:\n%s", expected, result)
+		}
+	})
+
+	t.Run("feature with containerEnv sets ENV instructions", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{
+				dirName: "feature-0",
+				options: nil,
+				envVars: map[string]string{"GOPATH": "/home/agent/go", "GOROOT": "/usr/local/go"},
+			},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false, infos)
+
+		if !strings.Contains(result, `ENV GOPATH="/home/agent/go"`) {
+			t.Errorf("Expected ENV GOPATH instruction\nGot:\n%s", result)
+		}
+		if !strings.Contains(result, `ENV GOROOT="/usr/local/go"`) {
+			t.Errorf("Expected ENV GOROOT instruction\nGot:\n%s", result)
+		}
+	})
+
+	t.Run("feature section appears before custom RUN commands", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{dirName: "feature-0", options: nil, envVars: nil},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false, infos)
+
+		featureCopyPos := strings.Index(result, "COPY features/feature-0/")
+		imageRunPos := strings.Index(result, "RUN echo 'image setup'")
+		agentRunPos := strings.Index(result, "RUN echo 'agent setup'")
+
+		if featureCopyPos == -1 {
+			t.Fatal("Expected feature COPY instruction")
+		}
+		if featureCopyPos > imageRunPos || featureCopyPos > agentRunPos {
+			t.Error("Expected feature COPY to appear before image/agent RUN commands")
+		}
+	})
+
+	t.Run("multiple features installed in declaration order with containerEnv between them", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{dirName: "feature-0", options: nil, envVars: map[string]string{"FIRST_VAR": "first"}},
+			{dirName: "feature-1", options: nil, envVars: nil},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, false, infos)
+
+		feature0Pos := strings.Index(result, "COPY features/feature-0/")
+		feature1Pos := strings.Index(result, "COPY features/feature-1/")
+		envPos := strings.Index(result, `ENV FIRST_VAR="first"`)
+
+		if feature0Pos == -1 || feature1Pos == -1 {
+			t.Fatal("Expected both feature COPY instructions")
+		}
+		if feature0Pos > feature1Pos {
+			t.Error("Expected feature-0 to be installed before feature-1")
+		}
+		// containerEnv from feature-0 should appear before feature-1 install
+		if envPos == -1 || envPos > feature1Pos {
+			t.Error("Expected containerEnv from feature-0 to appear before feature-1 COPY")
+		}
+	})
+
+	t.Run("no feature instructions when featureInfos is nil", func(t *testing.T) {
+		t.Parallel()
+
+		result := generateContainerfile(imageConfig, agentConfig, false, nil)
+
+		if strings.Contains(result, "COPY features/") {
+			t.Errorf("Expected no feature COPY instructions\nGot:\n%s", result)
+		}
+		if strings.Contains(result, "/tmp/feature-install/") {
+			t.Errorf("Expected no feature install paths\nGot:\n%s", result)
+		}
+	})
+
+	t.Run("feature section appears before agent-settings COPY", func(t *testing.T) {
+		t.Parallel()
+
+		infos := []featureInstallInfo{
+			{dirName: "feature-0", options: nil, envVars: nil},
+		}
+
+		result := generateContainerfile(imageConfig, agentConfig, true, infos)
+
+		featureCopyPos := strings.Index(result, "COPY features/feature-0/")
+		agentSettingsPos := strings.Index(result, "COPY --chown=agent:agent agent-settings/.")
+
+		if featureCopyPos == -1 || agentSettingsPos == -1 {
+			t.Fatal("Expected both feature COPY and agent-settings COPY")
+		}
+		if featureCopyPos > agentSettingsPos {
+			t.Error("Expected feature COPY to appear before agent-settings COPY")
 		}
 	})
 }

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -25,6 +25,7 @@ import (
 	"text/template"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/devcontainers/features"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -69,7 +70,9 @@ func (p *podmanRuntime) createInstanceDirectory(name string) (string, error) {
 // createContainerfile creates a Containerfile in the instance directory using the provided configs.
 // If settings is non-empty, the files are written to an agent-settings/ subdirectory of instanceDir
 // so they can be embedded in the image via a COPY instruction.
-func (p *podmanRuntime) createContainerfile(instanceDir string, imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, settings map[string][]byte) error {
+// If featureInfos is non-empty, the features have already been downloaded to instanceDir/features/
+// and the Containerfile will include instructions to install them.
+func (p *podmanRuntime) createContainerfile(instanceDir string, imageConfig *config.ImageConfig, agentConfig *config.AgentConfig, settings map[string][]byte, featureInfos []featureInstallInfo) error {
 	// Generate sudoers content
 	sudoersContent := generateSudoers(imageConfig.Sudo)
 	sudoersPath := filepath.Join(instanceDir, "sudoers")
@@ -95,13 +98,82 @@ func (p *podmanRuntime) createContainerfile(instanceDir string, imageConfig *con
 	}
 
 	// Generate Containerfile content
-	containerfileContent := generateContainerfile(imageConfig, agentConfig, len(settings) > 0)
+	containerfileContent := generateContainerfile(imageConfig, agentConfig, len(settings) > 0, featureInfos)
 	containerfilePath := filepath.Join(instanceDir, "Containerfile")
 	if err := os.WriteFile(containerfilePath, []byte(containerfileContent), 0644); err != nil {
 		return fmt.Errorf("failed to write Containerfile: %w", err)
 	}
 
 	return nil
+}
+
+// prepareFeatures downloads, orders, and merges options for devcontainer features declared in params.
+// Feature directories are written to instanceDir/features/{dirName}/.
+// Returns nil if no features are configured.
+func (p *podmanRuntime) prepareFeatures(ctx context.Context, instanceDir string, params runtime.CreateParams) ([]featureInstallInfo, error) {
+	if params.WorkspaceConfig == nil || params.WorkspaceConfig.Features == nil || len(*params.WorkspaceConfig.Features) == 0 {
+		return nil, nil
+	}
+
+	feats, userOpts, err := features.FromMap(*params.WorkspaceConfig.Features, params.WorkspaceConfigDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse features: %w", err)
+	}
+
+	if len(feats) == 0 {
+		return nil, nil
+	}
+
+	// Assign a stable directory name to each feature based on sorted order.
+	dirNames := make(map[string]string, len(feats))
+	for i, f := range feats {
+		dirNames[f.ID()] = fmt.Sprintf("feature-%d", i)
+	}
+
+	// Create the features directory in the build context.
+	featuresDir := filepath.Join(instanceDir, "features")
+	if err := os.MkdirAll(featuresDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create features directory: %w", err)
+	}
+
+	// Download each feature into its designated subdirectory.
+	metadata := make(map[string]features.FeatureMetadata, len(feats))
+	for _, f := range feats {
+		destDir := filepath.Join(featuresDir, dirNames[f.ID()])
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create directory for feature %q: %w", f.ID(), err)
+		}
+		meta, err := f.Download(ctx, destDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download feature %q: %w", f.ID(), err)
+		}
+		metadata[f.ID()] = meta
+	}
+
+	// Topologically sort features according to their installsAfter declarations.
+	ordered, err := features.Order(feats, metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to order features: %w", err)
+	}
+
+	// Build the install info slice in installation order.
+	infos := make([]featureInstallInfo, 0, len(ordered))
+	for _, f := range ordered {
+		meta := metadata[f.ID()]
+
+		mergedOpts, err := meta.Options().Merge(userOpts[f.ID()])
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge options for feature %q: %w", f.ID(), err)
+		}
+
+		infos = append(infos, featureInstallInfo{
+			dirName: dirNames[f.ID()],
+			options: mergedOpts,
+			envVars: meta.ContainerEnv(),
+		})
+	}
+
+	return infos, nil
 }
 
 // buildImage builds a podman image for the instance.
@@ -272,9 +344,22 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load agent config: %w", err)
 	}
 
+	// Prepare devcontainer features: download, order, and merge options.
+	// Only emits a step when features are actually configured.
+	var featureInfos []featureInstallInfo
+	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Features != nil && len(*params.WorkspaceConfig.Features) > 0 {
+		stepLogger.Start("Downloading devcontainer features", "Devcontainer features downloaded")
+		var featErr error
+		featureInfos, featErr = p.prepareFeatures(ctx, instanceDir, params)
+		if featErr != nil {
+			stepLogger.Fail(featErr)
+			return runtime.RuntimeInfo{}, featErr
+		}
+	}
+
 	// Create Containerfile
 	stepLogger.Start("Generating Containerfile", "Containerfile generated")
-	if err := p.createContainerfile(instanceDir, imageConfig, agentConfig, params.AgentSettings); err != nil {
+	if err := p.createContainerfile(instanceDir, imageConfig, agentConfig, params.AgentSettings, featureInfos); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
 	}

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1171,6 +1171,170 @@ func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
 	}
 }
 
+func TestCreate_StepLogger_FailOnPrepareFeatures(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcePath := t.TempDir()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return nil
+	}
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte("container-id-123"), nil
+	}
+
+	p := &podmanRuntime{
+		system:     &fakeSystem{},
+		executor:   fakeExec,
+		storageDir: storageDir,
+		config:     &fakeConfig{},
+	}
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	// Reference a non-existent local feature to cause Download to fail.
+	featuresMap := map[string]map[string]interface{}{
+		"./nonexistent-feature": {},
+	}
+	params := runtime.CreateParams{
+		Name:               "test-workspace",
+		SourcePath:         sourcePath,
+		Agent:              "test_agent",
+		WorkspaceConfigDir: sourcePath,
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Features: &featuresMap,
+		},
+	}
+
+	_, err := p.Create(ctx, params)
+	if err == nil {
+		t.Fatal("Expected Create() to fail, got nil")
+	}
+
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+
+	// Exactly two Start calls: create dir, then download features.
+	if len(fakeLogger.startCalls) != 2 {
+		t.Fatalf("Expected 2 Start() calls, got %d", len(fakeLogger.startCalls))
+	}
+
+	expectedSteps := []string{
+		"Creating temporary build directory",
+		"Downloading devcontainer features",
+	}
+	for i, expected := range expectedSteps {
+		if fakeLogger.startCalls[i].inProgress != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, fakeLogger.startCalls[i].inProgress)
+		}
+	}
+
+	if len(fakeLogger.failCalls) != 1 {
+		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+	if fakeLogger.failCalls[0] == nil {
+		t.Error("Expected Fail() to be called with non-nil error")
+	}
+}
+
+func TestCreate_StepLogger_Success_WithFeatures(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcePath := t.TempDir()
+
+	// Set up a minimal local feature.
+	configDir := t.TempDir()
+	featureDir := filepath.Join(configDir, "my-feature")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("failed to create feature dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(featureDir, "devcontainer-feature.json"),
+		[]byte(`{"id":"my-feature","version":"1.0.0"}`),
+		0644,
+	); err != nil {
+		t.Fatalf("failed to write devcontainer-feature.json: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(featureDir, "install.sh"),
+		[]byte("#!/bin/bash\necho installed"),
+		0755,
+	); err != nil {
+		t.Fatalf("failed to write install.sh: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return nil
+	}
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte("container-id-123"), nil
+	}
+
+	p := &podmanRuntime{
+		system:     &fakeSystem{},
+		executor:   fakeExec,
+		storageDir: storageDir,
+		config:     &fakeConfig{},
+	}
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	featuresMap := map[string]map[string]interface{}{
+		"./my-feature": {},
+	}
+	params := runtime.CreateParams{
+		Name:               "test-workspace",
+		SourcePath:         sourcePath,
+		Agent:              "test_agent",
+		WorkspaceConfigDir: configDir,
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Features: &featuresMap,
+		},
+	}
+
+	_, err := p.Create(ctx, params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if fakeLogger.completeCalls != 1 {
+		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
+	}
+	if len(fakeLogger.failCalls) != 0 {
+		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
+	}
+
+	// Six steps: create dir, download features, containerfile, build, onecli services, workspace container.
+	expectedSteps := []stepCall{
+		{inProgress: "Creating temporary build directory", completed: "Temporary build directory created"},
+		{inProgress: "Downloading devcontainer features", completed: "Devcontainer features downloaded"},
+		{inProgress: "Generating Containerfile", completed: "Containerfile generated"},
+		{inProgress: "Building container image: kdn-test-workspace", completed: "Container image built"},
+		{inProgress: "Creating onecli services", completed: "Onecli services created"},
+		{inProgress: "Creating workspace container: test-workspace", completed: "Workspace container created"},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
+	}
+	for i, expected := range expectedSteps {
+		actual := fakeLogger.startCalls[i]
+		if actual.inProgress != expected.inProgress {
+			t.Errorf("Step %d: expected inProgress %q, got %q", i, expected.inProgress, actual.inProgress)
+		}
+		if actual.completed != expected.completed {
+			t.Errorf("Step %d: expected completed %q, got %q", i, expected.completed, actual.completed)
+		}
+	}
+}
+
 func TestCreate_CleansUpInstanceDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -194,7 +194,7 @@ func TestCreateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil)
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil, nil)
 		if err != nil {
 			t.Fatalf("createContainerfile() failed: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestCreateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"custom-agent"},
 		}
 
-		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil)
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil, nil)
 		if err != nil {
 			t.Fatalf("createContainerfile() failed: %v", err)
 		}
@@ -311,7 +311,7 @@ func TestCreateContainerfile(t *testing.T) {
 			".gitconfig":            []byte("[user]\n\tname = Agent\n"),
 		}
 
-		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, settings)
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, settings, nil)
 		if err != nil {
 			t.Fatalf("createContainerfile() failed: %v", err)
 		}
@@ -371,7 +371,7 @@ func TestCreateContainerfile(t *testing.T) {
 			TerminalCommand: []string{"claude"},
 		}
 
-		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil)
+		err := p.createContainerfile(instanceDir, imageConfig, agentConfig, nil, nil)
 		if err != nil {
 			t.Fatalf("createContainerfile() failed: %v", err)
 		}
@@ -1276,6 +1276,140 @@ func (f *fakeExecutor) Output(ctx context.Context, stderr io.Writer, args ...str
 
 func (f *fakeExecutor) RunInteractive(ctx context.Context, args ...string) error {
 	return f.runErr
+}
+
+func TestPrepareFeatures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when WorkspaceConfig is nil", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		instanceDir := t.TempDir()
+		params := runtime.CreateParams{}
+
+		infos, err := p.prepareFeatures(context.Background(), instanceDir, params)
+		if err != nil {
+			t.Fatalf("prepareFeatures() returned unexpected error: %v", err)
+		}
+		if infos != nil {
+			t.Errorf("Expected nil infos, got %v", infos)
+		}
+	})
+
+	t.Run("returns nil when Features map is nil", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		instanceDir := t.TempDir()
+		params := runtime.CreateParams{
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{},
+		}
+
+		infos, err := p.prepareFeatures(context.Background(), instanceDir, params)
+		if err != nil {
+			t.Fatalf("prepareFeatures() returned unexpected error: %v", err)
+		}
+		if infos != nil {
+			t.Errorf("Expected nil infos, got %v", infos)
+		}
+	})
+
+	t.Run("returns nil when Features map is empty", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		instanceDir := t.TempDir()
+		empty := map[string]map[string]interface{}{}
+		params := runtime.CreateParams{
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{Features: &empty},
+		}
+
+		infos, err := p.prepareFeatures(context.Background(), instanceDir, params)
+		if err != nil {
+			t.Fatalf("prepareFeatures() returned unexpected error: %v", err)
+		}
+		if infos != nil {
+			t.Errorf("Expected nil infos, got %v", infos)
+		}
+	})
+
+	t.Run("downloads local feature and returns install info", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a local feature directory with required files.
+		configDir := t.TempDir()
+		featureDir := filepath.Join(configDir, "my-feature")
+		if err := os.MkdirAll(featureDir, 0755); err != nil {
+			t.Fatalf("failed to create feature dir: %v", err)
+		}
+
+		featureJSON := `{
+			"id": "my-feature",
+			"version": "1.0.0",
+			"options": {
+				"version": {"type": "string", "default": "latest"}
+			},
+			"containerEnv": {
+				"MY_FEATURE_HOME": "/opt/my-feature"
+			}
+		}`
+		if err := os.WriteFile(filepath.Join(featureDir, "devcontainer-feature.json"), []byte(featureJSON), 0644); err != nil {
+			t.Fatalf("failed to write devcontainer-feature.json: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(featureDir, "install.sh"), []byte("#!/usr/bin/env bash\necho installed"), 0755); err != nil {
+			t.Fatalf("failed to write install.sh: %v", err)
+		}
+
+		instanceDir := t.TempDir()
+		featureID := "./my-feature"
+		featuresMap := map[string]map[string]interface{}{
+			featureID: {"version": "1.21"},
+		}
+		params := runtime.CreateParams{
+			WorkspaceConfigDir: configDir,
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Features: &featuresMap,
+			},
+		}
+
+		p := &podmanRuntime{}
+		infos, err := p.prepareFeatures(context.Background(), instanceDir, params)
+		if err != nil {
+			t.Fatalf("prepareFeatures() failed: %v", err)
+		}
+
+		if len(infos) != 1 {
+			t.Fatalf("Expected 1 featureInstallInfo, got %d", len(infos))
+		}
+
+		info := infos[0]
+		if info.dirName == "" {
+			t.Error("Expected non-empty dirName")
+		}
+
+		// Verify the feature directory was created in the build context.
+		featureBuildDir := filepath.Join(instanceDir, "features", info.dirName)
+		if _, err := os.Stat(featureBuildDir); os.IsNotExist(err) {
+			t.Errorf("Expected feature build directory %s to exist", featureBuildDir)
+		}
+
+		// Verify install.sh was copied.
+		installSh := filepath.Join(featureBuildDir, "install.sh")
+		if _, err := os.Stat(installSh); os.IsNotExist(err) {
+			t.Error("Expected install.sh to be copied into build context")
+		}
+
+		// Verify user-supplied option was merged.
+		if info.options["VERSION"] != "1.21" {
+			t.Errorf("Expected VERSION=1.21, got %q", info.options["VERSION"])
+		}
+
+		// Verify containerEnv was returned.
+		if info.envVars["MY_FEATURE_HOME"] != "/opt/my-feature" {
+			t.Errorf("Expected MY_FEATURE_HOME=/opt/my-feature, got %q", info.envVars["MY_FEATURE_HOME"])
+		}
+	})
 }
 
 // assertDirectoryRemoved checks that a directory has been removed.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -85,6 +85,11 @@ type CreateParams struct {
 	// for the "github" secret type) and injected into the workspace container so
 	// that CLI tools detect a configured credential. Real auth goes through OneCLI proxy.
 	SecretEnvVars map[string]string
+
+	// WorkspaceConfigDir is the directory containing the workspace configuration file.
+	// Used to resolve relative paths for local devcontainer features (e.g. "./my-feature").
+	// Can be empty if no workspace configuration exists.
+	WorkspaceConfigDir string
 }
 
 // RuntimeInfo contains information about a runtime instance.


### PR DESCRIPTION
Wire the existing pkg/devcontainers/features package into the Podman runtime so features declared in workspace.json are installed at image build time, but after user creation and home directory creation. ENV _REMOTE_USER and _REMOTE_USER_HOME are now set immediately before the block so scripts can resolve the target user by name even while still
running as root. Features run immediately after FROM while the image is still root, avoiding USER switches. ENV PATH preserves any path additions made by features.

Also fixes a bug where the config merger silently dropped the Features field when merging workspace/project/agent configurations.

Fixes #318

(built on top of PR #319)

Tested with node feature in demo repo https://github.com/openkaiden/kaiden-demo-app:

`.kaiden/workspace.json`
```
{
  "features": {
    "ghcr.io/devcontainers/features/node:1": {
      "version": "22"
    },
    "ghcr.io/devcontainers/features/common-utils:2": {}
  }
}
```