### PR TITLE
fix(cmd): make --path and --headerTemplate optional for secret create

### DIFF
--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -39,7 +39,7 @@ The keychain backend is platform-specific: GNOME Keyring on Linux, Keychain on m
 | Type | How descriptor fields are resolved |
 |------|------------------------------------|
 | Named (e.g. `github`) | Taken from the registered `SecretService` automatically |
-| `other` | Required: `--host`, `--header`, `--env`; optional: `--path`, `--headerTemplate` |
+| `other` | Required: `--host`, `--header`; optional: `--path`, `--headerTemplate`, `--env` |
 
 ## Using the Store
 

--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -39,7 +39,7 @@ The keychain backend is platform-specific: GNOME Keyring on Linux, Keychain on m
 | Type | How descriptor fields are resolved |
 |------|------------------------------------|
 | Named (e.g. `github`) | Taken from the registered `SecretService` automatically |
-| `other` | User must supply `--host`, `--path`, `--header`, `--headerTemplate`, `--env` |
+| `other` | Required: `--host`, `--header`, `--env`; optional: `--path`, `--headerTemplate` |
 
 ## Using the Store
 

--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -13,7 +13,7 @@ The secrets system uses a two-layer architecture: a **Store** that persists secr
 - Secret **values** live exclusively in the system keychain — never on disk
 - Non-sensitive **metadata** (type, hosts, path, header descriptors, envs) is persisted to `<storage-dir>/secrets.json`
 - Named types (e.g. `github`) derive all their descriptor fields from a registered `SecretService`
-- The built-in `other` type requires the user to supply all descriptor fields explicitly
+- The built-in `other` type lets the user supply descriptor fields explicitly; only `--host` and `--header` are required
 
 ## Key Components
 
@@ -56,18 +56,16 @@ err := store.Create(secret.CreateParams{
 })
 ```
 
-For `other` type, also supply the descriptor fields:
+For `other` type, supply the required descriptor fields; `Path`, `HeaderTemplate`, and `Envs` are optional:
 
 ```go
 err := store.Create(secret.CreateParams{
-    Name:           "my-api-key",
-    Type:           secret.TypeOther,
-    Value:          "secret123",
-    Hosts:          []string{"api.example.com"},
-    Path:           "/v1",
-    Header:         "Authorization",
-    HeaderTemplate: "Bearer ${value}",
-    Envs:           []string{"MY_API_KEY"},
+    Name:   "my-api-key",
+    Type:   secret.TypeOther,
+    Value:  "secret123",
+    Hosts:  []string{"api.example.com"},
+    Header: "Authorization",
+    Envs:   []string{"MY_API_KEY"}, // optional
 })
 ```
 

--- a/pkg/cmd/secret_create.go
+++ b/pkg/cmd/secret_create.go
@@ -69,9 +69,6 @@ func (s *secretCreateCmd) preRun(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("header") {
 			return fmt.Errorf("--header is required when --type=%s", secret.TypeOther)
 		}
-		if len(s.envs) == 0 {
-			return fmt.Errorf("--env is required when --type=%s", secret.TypeOther)
-		}
 	} else {
 		// Descriptor flags are not valid for named types
 		if len(s.hosts) > 0 {
@@ -145,8 +142,8 @@ hosts, path, header template, envs) is persisted in the kdn storage directory.
 
 Accepted types: %s.
 
-When --type=other, the flags --host, --header, and --env are required; --path
-and --headerTemplate are optional. For any other type, these flags must not be
+When --type=other, --host and --header are required; --path, --headerTemplate,
+and --env are optional. For any other type, these flags must not be
 specified.`, typesStr),
 		Example: `# Create a GitHub token secret
 kdn secret create my-github-token --type github --value ghp_mytoken
@@ -154,8 +151,8 @@ kdn secret create my-github-token --type github --value ghp_mytoken
 # Create a custom secret (type=other) with all descriptor flags
 kdn secret create my-api-key --type other --value secret123 --host api.example.com --host dev.example.com --path /api/v1 --header Authorization --headerTemplate "Bearer ${value}" --env MY_API_KEY --env API_KEY
 
-# Create a custom secret (type=other) without optional flags
-kdn secret create my-api-key --type other --value secret123 --host api.example.com --header Authorization --env MY_API_KEY`,
+# Create a custom secret (type=other) with only required flags
+kdn secret create my-api-key --type other --value secret123 --host api.example.com --header Authorization`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -171,7 +168,7 @@ kdn secret create my-api-key --type other --value secret123 --host api.example.c
 	cmd.Flags().StringVar(&c.path, "path", "", "URL path restriction (optional for --type=other)")
 	cmd.Flags().StringVar(&c.header, "header", "", "HTTP header name (required for --type=other)")
 	cmd.Flags().StringVar(&c.headerTemplate, "headerTemplate", "", "HTTP header value template using ${value} as placeholder (optional for --type=other)")
-	cmd.Flags().StringArrayVar(&c.envs, "env", nil, "Environment variable name to expose the secret value (required for --type=other, can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&c.envs, "env", nil, "Environment variable name to expose the secret value (optional for --type=other, can be specified multiple times)")
 
 	return cmd
 }

--- a/pkg/cmd/secret_create.go
+++ b/pkg/cmd/secret_create.go
@@ -63,18 +63,11 @@ func (s *secretCreateCmd) preRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if s.secretType == secret.TypeOther {
-		// All descriptor flags are mandatory for type=other
 		if len(s.hosts) == 0 {
 			return fmt.Errorf("--host is required when --type=%s", secret.TypeOther)
 		}
-		if !cmd.Flags().Changed("path") {
-			return fmt.Errorf("--path is required when --type=%s", secret.TypeOther)
-		}
 		if !cmd.Flags().Changed("header") {
 			return fmt.Errorf("--header is required when --type=%s", secret.TypeOther)
-		}
-		if !cmd.Flags().Changed("headerTemplate") {
-			return fmt.Errorf("--headerTemplate is required when --type=%s", secret.TypeOther)
 		}
 		if len(s.envs) == 0 {
 			return fmt.Errorf("--env is required when --type=%s", secret.TypeOther)
@@ -152,13 +145,17 @@ hosts, path, header template, envs) is persisted in the kdn storage directory.
 
 Accepted types: %s.
 
-When --type=other, the flags --host, --path, --header, --headerTemplate, and
---env are all required. For any other type, these flags must not be specified.`, typesStr),
+When --type=other, the flags --host, --header, and --env are required; --path
+and --headerTemplate are optional. For any other type, these flags must not be
+specified.`, typesStr),
 		Example: `# Create a GitHub token secret
 kdn secret create my-github-token --type github --value ghp_mytoken
 
-# Create a custom secret (type=other) with all required descriptor flags
-kdn secret create my-api-key --type other --value secret123 --host api.example.com --host dev.example.com --path /api/v1 --header Authorization --headerTemplate "Bearer ${value}" --env MY_API_KEY --env API_KEY`,
+# Create a custom secret (type=other) with all descriptor flags
+kdn secret create my-api-key --type other --value secret123 --host api.example.com --host dev.example.com --path /api/v1 --header Authorization --headerTemplate "Bearer ${value}" --env MY_API_KEY --env API_KEY
+
+# Create a custom secret (type=other) without optional flags
+kdn secret create my-api-key --type other --value secret123 --host api.example.com --header Authorization --env MY_API_KEY`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -171,9 +168,9 @@ kdn secret create my-api-key --type other --value secret123 --host api.example.c
 	cmd.Flags().StringVar(&c.value, "value", "", "Secret value to store in the system keychain")
 	cmd.Flags().StringVar(&c.description, "description", "", "Optional human-readable description of the secret")
 	cmd.Flags().StringArrayVar(&c.hosts, "host", nil, "Host pattern (required for --type=other, can be specified multiple times)")
-	cmd.Flags().StringVar(&c.path, "path", "", "URL path restriction (required for --type=other)")
+	cmd.Flags().StringVar(&c.path, "path", "", "URL path restriction (optional for --type=other)")
 	cmd.Flags().StringVar(&c.header, "header", "", "HTTP header name (required for --type=other)")
-	cmd.Flags().StringVar(&c.headerTemplate, "headerTemplate", "", "HTTP header value template using ${value} as placeholder (required for --type=other)")
+	cmd.Flags().StringVar(&c.headerTemplate, "headerTemplate", "", "HTTP header value template using ${value} as placeholder (optional for --type=other)")
 	cmd.Flags().StringArrayVar(&c.envs, "env", nil, "Environment variable name to expose the secret value (required for --type=other, can be specified multiple times)")
 
 	return cmd

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -208,24 +208,10 @@ func TestSecretCreateCmd_PreRun(t *testing.T) {
 		}
 	})
 
-	t.Run("other without --env", func(t *testing.T) {
+	t.Run("other with only required flags succeeds", func(t *testing.T) {
 		t.Parallel()
 
 		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, validTypes: testValidTypes}
-		cmd := buildPreRunCmd(t.TempDir())
-		if err := cmd.Flags().Set("header", "Authorization"); err != nil {
-			t.Fatal(err)
-		}
-		err := c.preRun(cmd, []string{"name"})
-		if err == nil || !strings.Contains(err.Error(), "--env is required when --type=other") {
-			t.Errorf("expected '--env is required' error, got: %v", err)
-		}
-	})
-
-	t.Run("other without --path and --headerTemplate succeeds", func(t *testing.T) {
-		t.Parallel()
-
-		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, envs: []string{"MY_KEY"}, validTypes: testValidTypes}
 		cmd := buildPreRunCmd(t.TempDir())
 		if err := cmd.Flags().Set("header", "Authorization"); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -86,7 +86,7 @@ func TestSecretCreateCmd_Examples(t *testing.T) {
 		t.Fatalf("failed to parse examples: %v", err)
 	}
 
-	expectedCount := 2
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
 	}
@@ -197,45 +197,14 @@ func TestSecretCreateCmd_PreRun(t *testing.T) {
 		}
 	})
 
-	t.Run("other without --path", func(t *testing.T) {
-		t.Parallel()
-
-		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, validTypes: testValidTypes}
-		cmd := buildPreRunCmd(t.TempDir())
-		err := c.preRun(cmd, []string{"name"})
-		if err == nil || !strings.Contains(err.Error(), "--path is required when --type=other") {
-			t.Errorf("expected '--path is required' error, got: %v", err)
-		}
-	})
-
 	t.Run("other without --header", func(t *testing.T) {
 		t.Parallel()
 
 		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, validTypes: testValidTypes}
 		cmd := buildPreRunCmd(t.TempDir())
-		if err := cmd.Flags().Set("path", "/"); err != nil {
-			t.Fatal(err)
-		}
 		err := c.preRun(cmd, []string{"name"})
 		if err == nil || !strings.Contains(err.Error(), "--header is required when --type=other") {
 			t.Errorf("expected '--header is required' error, got: %v", err)
-		}
-	})
-
-	t.Run("other without --headerTemplate", func(t *testing.T) {
-		t.Parallel()
-
-		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, validTypes: testValidTypes}
-		cmd := buildPreRunCmd(t.TempDir())
-		if err := cmd.Flags().Set("path", "/"); err != nil {
-			t.Fatal(err)
-		}
-		if err := cmd.Flags().Set("header", "Authorization"); err != nil {
-			t.Fatal(err)
-		}
-		err := c.preRun(cmd, []string{"name"})
-		if err == nil || !strings.Contains(err.Error(), "--headerTemplate is required when --type=other") {
-			t.Errorf("expected '--headerTemplate is required' error, got: %v", err)
 		}
 	})
 
@@ -244,18 +213,25 @@ func TestSecretCreateCmd_PreRun(t *testing.T) {
 
 		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, validTypes: testValidTypes}
 		cmd := buildPreRunCmd(t.TempDir())
-		if err := cmd.Flags().Set("path", "/"); err != nil {
-			t.Fatal(err)
-		}
 		if err := cmd.Flags().Set("header", "Authorization"); err != nil {
-			t.Fatal(err)
-		}
-		if err := cmd.Flags().Set("headerTemplate", "Bearer ${value}"); err != nil {
 			t.Fatal(err)
 		}
 		err := c.preRun(cmd, []string{"name"})
 		if err == nil || !strings.Contains(err.Error(), "--env is required when --type=other") {
 			t.Errorf("expected '--env is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("other without --path and --headerTemplate succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretCreateCmd{secretType: "other", value: "v", hosts: []string{"example.com"}, envs: []string{"MY_KEY"}, validTypes: testValidTypes}
+		cmd := buildPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("header", "Authorization"); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.preRun(cmd, []string{"name"}); err != nil {
+			t.Errorf("unexpected error: %v", err)
 		}
 	})
 


### PR DESCRIPTION
When --type=other, --path and --headerTemplate are now optional. Only --host, --header, and --env remain required, matching the SecretService interface where both Path() and HeaderTemplate() return empty strings when unset.

Closes #327