### PR TITLE
feat(cmd): add --output json support to `kdn secret create`

### DIFF
--- a/.agents/skills/working-with-json-output-types/SKILL.md
+++ b/.agents/skills/working-with-json-output-types/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: working-with-json-output-types
+description: Guide to the JSON output types used by CLI commands, where they are defined, and how to find them
+argument-hint: ""
+---
+
+# Working with JSON Output Types
+
+All JSON output types for CLI commands are defined in the external module `github.com/openkaiden/kdn-api/cli/go`. This module is the single source of truth for every JSON shape that `kdn` commands emit.
+
+## Where to Find the Module
+
+The module is listed in `go.mod` — check there for the current version:
+
+```bash
+grep 'openkaiden/kdn-api/cli/go' go.mod
+```
+
+After downloading (run `make build` if you haven't yet), the source is in the Go module cache. Use the version from `go.mod` to build the path:
+
+```bash
+$(go env GOPATH)/pkg/mod/github.com/openkaiden/kdn-api/cli/go@<version>/
+```
+
+The only file that matters is `api.go` in that directory — it contains every type definition. Read it to see the exact JSON field names and which fields are optional (`omitempty`):
+
+```bash
+cat $(go env GOPATH)/pkg/mod/github.com/openkaiden/kdn-api/cli/go@$(grep 'openkaiden/kdn-api/cli/go' go.mod | awk '{print $2}')/api.go
+```
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,8 @@ The `Agent` interface (`pkg/agent/agent.go`) exposes `SkillsDir() string` which 
 
 **For advanced command patterns, use:** `/implementing-command-patterns`
 
+**For JSON output types (where they are defined and how to use them), use:** `/working-with-json-output-types`
+
 **For testing commands, use:** `/testing-commands`
 
 ### Working with the Instances Manager

--- a/pkg/cmd/secret_create.go
+++ b/pkg/cmd/secret_create.go
@@ -19,11 +19,13 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservicesetup"
 	"github.com/spf13/cobra"
@@ -38,6 +40,7 @@ type secretCreateCmd struct {
 	header         string
 	headerTemplate string
 	envs           []string
+	output         string
 	store          secret.Store
 	validTypes     []string
 }
@@ -52,50 +55,57 @@ func (s *secretCreateCmd) isValidType(t string) bool {
 }
 
 func (s *secretCreateCmd) preRun(cmd *cobra.Command, args []string) error {
+	if s.output != "" && s.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", s.output)
+	}
+	if s.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
 	if s.secretType == "" {
-		return fmt.Errorf("--type is required")
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--type is required"))
 	}
 	if !s.isValidType(s.secretType) {
-		return fmt.Errorf("invalid --type %q: must be one of %s", s.secretType, strings.Join(s.validTypes, ", "))
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("invalid --type %q: must be one of %s", s.secretType, strings.Join(s.validTypes, ", ")))
 	}
 	if s.value == "" {
-		return fmt.Errorf("--value is required")
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--value is required"))
 	}
 
 	if s.secretType == secret.TypeOther {
 		if len(s.hosts) == 0 {
-			return fmt.Errorf("--host is required when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--host is required when --type=%s", secret.TypeOther))
 		}
 		if !cmd.Flags().Changed("header") {
-			return fmt.Errorf("--header is required when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--header is required when --type=%s", secret.TypeOther))
 		}
 	} else {
 		// Descriptor flags are not valid for named types
 		if len(s.hosts) > 0 {
-			return fmt.Errorf("--host is only valid when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--host is only valid when --type=%s", secret.TypeOther))
 		}
 		if cmd.Flags().Changed("path") {
-			return fmt.Errorf("--path is only valid when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--path is only valid when --type=%s", secret.TypeOther))
 		}
 		if cmd.Flags().Changed("header") {
-			return fmt.Errorf("--header is only valid when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--header is only valid when --type=%s", secret.TypeOther))
 		}
 		if cmd.Flags().Changed("headerTemplate") {
-			return fmt.Errorf("--headerTemplate is only valid when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--headerTemplate is only valid when --type=%s", secret.TypeOther))
 		}
 		if len(s.envs) > 0 {
-			return fmt.Errorf("--env is only valid when --type=%s", secret.TypeOther)
+			return outputErrorIfJSON(cmd, s.output, fmt.Errorf("--env is only valid when --type=%s", secret.TypeOther))
 		}
 	}
 
 	storageDir, err := cmd.Flags().GetString("storage")
 	if err != nil {
-		return fmt.Errorf("failed to read --storage flag: %w", err)
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to read --storage flag: %w", err))
 	}
 
 	absStorageDir, err := filepath.Abs(storageDir)
 	if err != nil {
-		return fmt.Errorf("failed to resolve storage directory path: %w", err)
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to resolve storage directory path: %w", err))
 	}
 
 	s.store = secret.NewStore(absStorageDir)
@@ -116,10 +126,26 @@ func (s *secretCreateCmd) run(cmd *cobra.Command, args []string) error {
 		HeaderTemplate: s.headerTemplate,
 		Envs:           s.envs,
 	}); err != nil {
-		return fmt.Errorf("failed to create secret: %w", err)
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to create secret: %w", err))
+	}
+
+	if s.output == "json" {
+		return s.outputJSON(cmd, name)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Secret %q created successfully\n", name)
+	return nil
+}
+
+func (s *secretCreateCmd) outputJSON(cmd *cobra.Command, name string) error {
+	response := api.SecretName{Name: name}
+
+	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to marshal secret to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
 	return nil
 }
 
@@ -152,7 +178,10 @@ kdn secret create my-github-token --type github --value ghp_mytoken
 kdn secret create my-api-key --type other --value secret123 --host api.example.com --host dev.example.com --path /api/v1 --header Authorization --headerTemplate "Bearer ${value}" --env MY_API_KEY --env API_KEY
 
 # Create a custom secret (type=other) with only required flags
-kdn secret create my-api-key --type other --value secret123 --host api.example.com --header Authorization`,
+kdn secret create my-api-key --type other --value secret123 --host api.example.com --header Authorization
+
+# Create a GitHub token secret with JSON output
+kdn secret create my-github-token --type github --value ghp_mytoken --output json`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -169,6 +198,8 @@ kdn secret create my-api-key --type other --value secret123 --host api.example.c
 	cmd.Flags().StringVar(&c.header, "header", "", "HTTP header name (required for --type=other)")
 	cmd.Flags().StringVar(&c.headerTemplate, "headerTemplate", "", "HTTP header value template using ${value} as placeholder (optional for --type=other)")
 	cmd.Flags().StringArrayVar(&c.envs, "env", nil, "Environment variable name to expose the secret value (optional for --type=other, can be specified multiple times)")
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
 	return cmd
 }

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -245,6 +245,19 @@ func TestSecretCreateCmd_PreRun(t *testing.T) {
 			t.Error("expected store to be initialised")
 		}
 	})
+
+	t.Run("json output silences errors", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretCreateCmd{secretType: "github", value: "ghp_token", output: "json", validTypes: testValidTypes}
+		cmd := buildPreRunCmd(t.TempDir())
+		if err := c.preRun(cmd, []string{"my-token"}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !cmd.SilenceErrors {
+			t.Error("expected cmd.SilenceErrors to be true when output is json")
+		}
+	})
 }
 
 func TestSecretCreateCmd_Run(t *testing.T) {
@@ -339,6 +352,31 @@ func TestSecretCreateCmd_Run(t *testing.T) {
 			t.Errorf("expected secret name in JSON output, got: %s", output)
 		}
 	})
+}
+
+func TestSecretCreateCmd_TypeFlagCompletion(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewSecretCreateCmd()
+	completionFunc, ok := cmd.GetFlagCompletionFunc("type")
+	if !ok {
+		t.Fatal("expected completion function registered for --type flag")
+	}
+
+	completions, directive := completionFunc(cmd, []string{}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	found := false
+	for _, c := range completions {
+		if c == "other" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'other' in completions, got %v", completions)
+	}
 }
 
 func TestSecretCreateCmd_PreRun_InvalidOutput(t *testing.T) {

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"strings"
 	"testing"
@@ -86,7 +87,7 @@ func TestSecretCreateCmd_Examples(t *testing.T) {
 		t.Fatalf("failed to parse examples: %v", err)
 	}
 
-	expectedCount := 3
+	expectedCount := 4
 	if len(commands) != expectedCount {
 		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
 	}
@@ -308,4 +309,44 @@ func TestSecretCreateCmd_Run(t *testing.T) {
 			t.Fatal("expected error when store fails")
 		}
 	})
+
+	t.Run("json output contains secret name", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeStore{}
+		c := &secretCreateCmd{
+			secretType: "github",
+			value:      "ghp_token",
+			output:     "json",
+			store:      fs,
+			validTypes: testValidTypes,
+		}
+
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-github-token"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		if !strings.Contains(output, `"name"`) {
+			t.Errorf("expected 'name' key in JSON output, got: %s", output)
+		}
+		if !strings.Contains(output, `"my-github-token"`) {
+			t.Errorf("expected secret name in JSON output, got: %s", output)
+		}
+	})
+}
+
+func TestSecretCreateCmd_PreRun_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &secretCreateCmd{output: "xml", validTypes: testValidTypes}
+	cmd := buildPreRunCmd(t.TempDir())
+	if err := c.preRun(cmd, []string{"name"}); err == nil {
+		t.Fatal("expected error for unsupported output format")
+	}
 }


### PR DESCRIPTION
Outputs {"name": "<name>"} on success and {"error": "..."} on failure, consistent with other commands. Adds -o/--output flag, updates preRun to silence errors in JSON mode, and adds a 4th example to the command.

Documents where the JSON output types are defined (openkaiden/kdn-api/cli/go) and how to locate api.go in the module cache for the current version.
    
Closes #313
    
