### PR TITLE
feat(cmd): add `kdn secret remove` command

### DIFF
--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -17,7 +17,7 @@ The secrets system uses a two-layer architecture: a **Store** that persists secr
 
 ## Key Components
 
-- **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error` and `List() ([]ListItem, error)`
+- **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error`, `Remove(name string) error` and `List() ([]ListItem, error)`
 - **Store implementation** (`pkg/secret/store.go`): writes the value to the keychain, metadata to `secrets.json`
 - **SecretService interface** (`pkg/secretservice/secretservice.go`): describes a named type — host pattern, path, header name, header template, env vars
 - **Registry** (`pkg/secretservice/registry.go`): maps names to `SecretService` implementations
@@ -77,6 +77,14 @@ To retrieve all stored secrets (metadata only — no secret values):
 items, err := store.List()
 // items is []secret.ListItem{Name, Type, Description, Hosts, Path, Header, HeaderTemplate, Envs}
 ```
+
+To remove a secret:
+
+```go
+err := store.Remove("my-token")
+```
+
+`Remove` deletes the value from the keychain and the metadata entry from `secrets.json`. If the keychain entry is missing (e.g. manually deleted), the metadata is still cleaned up. `ErrSecretNotFound` is returned when no secret with the given name exists.
 
 ## Adding a New Named Secret Type
 

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -25,6 +25,7 @@ import (
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/spf13/cobra"
 )
 
@@ -115,6 +116,37 @@ func completeRemoveWorkspaceID(cmd *cobra.Command, args []string, toComplete str
 	return getFilteredWorkspaceIDs(cmd, func(state api.WorkspaceState) bool {
 		return state != api.WorkspaceStateRunning
 	})
+}
+
+// completeSecretName provides completion for secret names by reading the secrets store.
+// The args and toComplete parameters are part of Cobra's ValidArgsFunction signature but are unused
+// because Cobra's shell completion framework automatically filters results based on user input.
+func completeSecretName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	if _, err := os.Stat(absStorageDir); os.IsNotExist(err) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	items, err := secret.NewStore(absStorageDir).List()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
 // newOutputFlagCompletion creates a completion function for the --output flag

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -709,6 +709,37 @@ func TestCompleteSecretName(t *testing.T) {
 			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
 		}
 	})
+
+	t.Run("returns error directive when storage flag is not registered", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		// Intentionally omit registering the "storage" flag so GetString returns an error.
+
+		_, directive := completeSecretName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("expected ShellCompDirectiveError, got %v", directive)
+		}
+	})
+
+	t.Run("returns error directive when secrets.json is corrupt", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(storageDir, "secrets.json"), []byte("not-json"), 0600); err != nil {
+			t.Fatalf("failed to write corrupt secrets.json: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		_, directive := completeSecretName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("expected ShellCompDirectiveError, got %v", directive)
+		}
+	})
 }
 
 func TestCompleteRuntimeFlag(t *testing.T) {

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -20,6 +20,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -615,6 +617,96 @@ func TestCompleteRemoveWorkspaceID(t *testing.T) {
 
 		if directive != cobra.ShellCompDirectiveNoFileComp {
 			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+	})
+}
+
+func TestCompleteSecretName(t *testing.T) {
+	t.Parallel()
+
+	// writeSecretsJSON writes a minimal secrets.json so List() returns known names without
+	// touching the keychain (only List() is called during completion — it reads metadata only).
+	writeSecretsJSON := func(t *testing.T, dir string, names []string) {
+		t.Helper()
+		type record struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		}
+		type file struct {
+			Secrets []record `json:"secrets"`
+		}
+		records := make([]record, 0, len(names))
+		for _, n := range names {
+			records = append(records, record{Name: n, Type: "github"})
+		}
+		data, err := json.Marshal(file{Secrets: records})
+		if err != nil {
+			t.Fatalf("failed to marshal secrets: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "secrets.json"), data, 0600); err != nil {
+			t.Fatalf("failed to write secrets.json: %v", err)
+		}
+	}
+
+	t.Run("returns names of stored secrets", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		writeSecretsJSON(t, storageDir, []string{"github-token", "api-key"})
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeSecretName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 2 {
+			t.Fatalf("expected 2 completions, got %d: %v", len(completions), completions)
+		}
+		found := map[string]bool{}
+		for _, c := range completions {
+			found[c] = true
+		}
+		for _, name := range []string{"github-token", "api-key"} {
+			if !found[name] {
+				t.Errorf("expected %q in completions, got %v", name, completions)
+			}
+		}
+	})
+
+	t.Run("returns no completions when storage directory does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", filepath.Join(t.TempDir(), "nonexistent"), "")
+
+		completions, directive := completeSecretName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns empty list when no secrets exist", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeSecretName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
 		}
 	})
 }

--- a/pkg/cmd/secret.go
+++ b/pkg/cmd/secret.go
@@ -42,6 +42,7 @@ func NewSecretCmd() *cobra.Command {
 
 	cmd.AddCommand(NewSecretCreateCmd())
 	cmd.AddCommand(NewSecretListCmd())
+	cmd.AddCommand(NewSecretRemoveCmd())
 
 	return cmd
 }

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -28,15 +28,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// fakeStore records Create calls for assertion in tests.
+// fakeStore records Create/Remove calls for assertion in tests.
 type fakeStore struct {
-	params secret.CreateParams
-	err    error
+	params     secret.CreateParams
+	createErr  error
+	removeErr  error
+	removeName string
 }
 
 func (f *fakeStore) Create(params secret.CreateParams) error {
 	f.params = params
-	return f.err
+	return f.createErr
+}
+
+func (f *fakeStore) Remove(name string) error {
+	f.removeName = name
+	return f.removeErr
 }
 
 func (f *fakeStore) List() ([]secret.ListItem, error) {
@@ -299,7 +306,7 @@ func TestSecretCreateCmd_Run(t *testing.T) {
 	t.Run("store error propagates", func(t *testing.T) {
 		t.Parallel()
 
-		fs := &fakeStore{err: os.ErrPermission}
+		fs := &fakeStore{createErr: os.ErrPermission}
 		c := &secretCreateCmd{store: fs, validTypes: testValidTypes}
 
 		cmd := &cobra.Command{}

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -43,6 +43,8 @@ func (f *fakeListStore) List() ([]secret.ListItem, error) {
 	return f.items, f.err
 }
 
+func (f *fakeListStore) Remove(name string) error { return nil }
+
 func TestSecretListCmd(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/secret_remove.go
+++ b/pkg/cmd/secret_remove.go
@@ -87,9 +87,10 @@ func NewSecretRemoveCmd() *cobra.Command {
 	c := &secretRemoveCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "remove <name>",
-		Short: "Remove a secret",
-		Long:  "Remove a secret from the system keychain and from the kdn storage directory.",
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a secret",
+		Long:    "Remove a secret from the system keychain and from the kdn storage directory.",
 		Example: `# Remove a secret by name
 kdn secret remove my-github-token
 

--- a/pkg/cmd/secret_remove.go
+++ b/pkg/cmd/secret_remove.go
@@ -1,0 +1,111 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/spf13/cobra"
+)
+
+type secretRemoveCmd struct {
+	store  secret.Store
+	output string
+}
+
+func (s *secretRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
+	if s.output != "" && s.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", s.output)
+	}
+
+	if s.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to read --storage flag: %w", err))
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to resolve storage directory path: %w", err))
+	}
+
+	s.store = secret.NewStore(absStorageDir)
+	return nil
+}
+
+func (s *secretRemoveCmd) run(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := s.store.Remove(name); err != nil {
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to remove secret: %w", err))
+	}
+
+	if s.output == "json" {
+		return s.outputJSON(cmd, name)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Secret %q removed successfully\n", name)
+	return nil
+}
+
+func (s *secretRemoveCmd) outputJSON(cmd *cobra.Command, name string) error {
+	response := api.SecretName{Name: name}
+
+	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, s.output, fmt.Errorf("failed to marshal to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
+func NewSecretRemoveCmd() *cobra.Command {
+	c := &secretRemoveCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Remove a secret",
+		Long:  "Remove a secret from the system keychain and from the kdn storage directory.",
+		Example: `# Remove a secret by name
+kdn secret remove my-github-token
+
+# Remove a secret with JSON output
+kdn secret remove my-github-token --output json
+
+# Remove a secret with short flag
+kdn secret remove my-github-token -o json`,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
+	cmd.ValidArgsFunction = completeSecretName
+
+	return cmd
+}

--- a/pkg/cmd/secret_remove_test.go
+++ b/pkg/cmd/secret_remove_test.go
@@ -1,0 +1,193 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/spf13/cobra"
+)
+
+func TestSecretRemoveCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewSecretRemoveCmd()
+	if cmd == nil {
+		t.Fatal("NewSecretRemoveCmd() returned nil")
+	}
+	if cmd.Use != "remove <name>" {
+		t.Errorf("expected Use %q, got %q", "remove <name>", cmd.Use)
+	}
+}
+
+func TestSecretRemoveCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewSecretRemoveCmd()
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("failed to parse examples: %v", err)
+	}
+
+	expectedCount := 3
+	if len(commands) != expectedCount {
+		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	if err := testutil.ValidateCommandExamples(rootCmd, cmd.Example); err != nil {
+		t.Errorf("example validation failed: %v", err)
+	}
+}
+
+func TestSecretRemoveCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects invalid output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretRemoveCmd{output: "xml"}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", t.TempDir(), "")
+
+		err := c.preRun(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error for invalid output format")
+		}
+		if !strings.Contains(err.Error(), "unsupported output format") {
+			t.Errorf("expected 'unsupported output format' error, got: %v", err)
+		}
+	})
+
+	t.Run("accepts json output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &secretRemoveCmd{output: "json"}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", t.TempDir(), "")
+
+		err := c.preRun(cmd, []string{})
+		if err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+		if c.store == nil {
+			t.Error("expected store to be set")
+		}
+	})
+}
+
+func TestSecretRemoveCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("calls store with correct name", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeStore{}
+		c := &secretRemoveCmd{store: fs}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-secret"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		if fs.removeName != "my-secret" {
+			t.Errorf("Name: want %q, got %q", "my-secret", fs.removeName)
+		}
+		if !strings.Contains(out.String(), "my-secret") {
+			t.Errorf("expected success message to contain secret name, got: %q", out.String())
+		}
+	})
+
+	t.Run("store error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeStore{removeErr: os.ErrPermission}
+		c := &secretRemoveCmd{store: fs}
+
+		cmd := &cobra.Command{}
+		err := c.run(cmd, []string{"x"})
+		if err == nil {
+			t.Fatal("expected error when store fails")
+		}
+	})
+
+	t.Run("outputs JSON on success", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeStore{}
+		c := &secretRemoveCmd{store: fs, output: "json"}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-secret"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(out.String()), &result); err != nil {
+			t.Fatalf("failed to parse JSON output: %v", err)
+		}
+		if result["name"] != "my-secret" {
+			t.Errorf("expected name %q in JSON, got: %v", "my-secret", result["name"])
+		}
+	})
+
+	t.Run("outputs JSON error on store failure", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeStore{removeErr: os.ErrPermission}
+		c := &secretRemoveCmd{store: fs, output: "json"}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		err := child.RunE(child, []string{"x"})
+		if err == nil {
+			t.Fatal("expected error when store fails")
+		}
+
+		var result map[string]interface{}
+		if jsonErr := json.Unmarshal([]byte(out.String()), &result); jsonErr != nil {
+			t.Fatalf("failed to parse JSON error output: %v", jsonErr)
+		}
+		if _, ok := result["error"]; !ok {
+			t.Errorf("expected 'error' key in JSON output, got: %v", result)
+		}
+	})
+}

--- a/pkg/cmd/secret_test.go
+++ b/pkg/cmd/secret_test.go
@@ -42,12 +42,15 @@ func TestSecretCmd(t *testing.T) {
 
 	foundCreate := false
 	foundList := false
+	foundRemove := false
 	for _, sub := range subCmds {
 		switch sub.Use {
 		case "create <name>":
 			foundCreate = true
 		case "list":
 			foundList = true
+		case "remove <name>":
+			foundRemove = true
 		}
 	}
 	if !foundCreate {
@@ -55,6 +58,9 @@ func TestSecretCmd(t *testing.T) {
 	}
 	if !foundList {
 		t.Error("expected secret command to have 'list' subcommand")
+	}
+	if !foundRemove {
+		t.Error("expected secret command to have 'remove' subcommand")
 	}
 }
 

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -57,4 +57,7 @@ type Store interface {
 	Create(params CreateParams) error
 	// List returns the metadata for all stored secrets.
 	List() ([]ListItem, error)
+	// Remove deletes the secret value from the system keychain and removes
+	// its metadata from the storage directory.
+	Remove(name string) error
 }

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -32,6 +32,9 @@ import (
 // ErrSecretAlreadyExists is returned when a secret with the same name already exists.
 var ErrSecretAlreadyExists = errors.New("secret already exists")
 
+// ErrSecretNotFound is returned when no secret with the given name exists.
+var ErrSecretNotFound = errors.New("secret not found")
+
 const (
 	keyringService  = "kdn"
 	secretsFileName = "secrets.json"
@@ -40,6 +43,7 @@ const (
 // keyring is an internal interface so tests can inject a fake implementation.
 type keyring interface {
 	Set(service, user, password string) error
+	Delete(service, user string) error
 }
 
 // realKeyring delegates to the go-keyring library.
@@ -49,6 +53,10 @@ var _ keyring = (*realKeyring)(nil)
 
 func (r *realKeyring) Set(service, user, password string) error {
 	return gokeyring.Set(service, user, password)
+}
+
+func (r *realKeyring) Delete(service, user string) error {
+	return gokeyring.Delete(service, user)
 }
 
 // store is the unexported implementation of Store.
@@ -130,6 +138,33 @@ func (s *store) List() ([]ListItem, error) {
 	return items, nil
 }
 
+// Remove deletes the secret from the system keychain and removes its metadata.
+// If the secret is not present in the keychain, it is still removed from storage.
+func (s *store) Remove(name string) error {
+	sf, err := s.loadSecretsFile()
+	if err != nil {
+		return err
+	}
+
+	idx := -1
+	for i, rec := range sf.Secrets {
+		if rec.Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("secret %q: %w", name, ErrSecretNotFound)
+	}
+
+	if err := s.kr.Delete(keyringService, name); err != nil && !errors.Is(err, gokeyring.ErrNotFound) {
+		return fmt.Errorf("failed to delete secret from keychain: %w", err)
+	}
+
+	sf.Secrets = append(sf.Secrets[:idx], sf.Secrets[idx+1:]...)
+	return s.saveSecretsFile(sf)
+}
+
 // loadSecretsFile reads and parses secrets.json, returning an empty struct when
 // the file does not yet exist.
 func (s *store) loadSecretsFile() (secretsFile, error) {
@@ -160,13 +195,18 @@ func (s *store) appendAndSave(sf secretsFile, params CreateParams) error {
 		Envs:           params.Envs,
 	})
 
+	if err := os.MkdirAll(s.storageDir, 0700); err != nil {
+		return fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	return s.saveSecretsFile(sf)
+}
+
+// saveSecretsFile marshals sf and writes it to disk.
+func (s *store) saveSecretsFile(sf secretsFile) error {
 	jsonData, err := json.MarshalIndent(sf, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal secrets: %w", err)
-	}
-
-	if err := os.MkdirAll(s.storageDir, 0700); err != nil {
-		return fmt.Errorf("failed to create storage directory: %w", err)
 	}
 
 	if err := os.WriteFile(filepath.Join(s.storageDir, secretsFileName), jsonData, 0600); err != nil {

--- a/pkg/secret/store_test.go
+++ b/pkg/secret/store_test.go
@@ -24,23 +24,37 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	gokeyring "github.com/zalando/go-keyring"
 )
 
-// fakeKeyring records Set calls without touching the real system keychain.
+// fakeKeyring records Set/Delete calls without touching the real system keychain.
 type fakeKeyring struct {
-	calls []fakeKeyringCall
-	err   error
+	setCalls    []fakeKeyringSetCall
+	deleteCalls []fakeKeyringDeleteCall
+	setErr      error
+	deleteErr   error
 }
 
-type fakeKeyringCall struct {
+type fakeKeyringSetCall struct {
 	service  string
 	user     string
 	password string
 }
 
+type fakeKeyringDeleteCall struct {
+	service string
+	user    string
+}
+
 func (f *fakeKeyring) Set(service, user, password string) error {
-	f.calls = append(f.calls, fakeKeyringCall{service, user, password})
-	return f.err
+	f.setCalls = append(f.setCalls, fakeKeyringSetCall{service, user, password})
+	return f.setErr
+}
+
+func (f *fakeKeyring) Delete(service, user string) error {
+	f.deleteCalls = append(f.deleteCalls, fakeKeyringDeleteCall{service, user})
+	return f.deleteErr
 }
 
 func TestStore_Create_StoresValueInKeychain(t *testing.T) {
@@ -58,10 +72,10 @@ func TestStore_Create_StoresValueInKeychain(t *testing.T) {
 		t.Fatalf("Create() failed: %v", err)
 	}
 
-	if len(kr.calls) != 1 {
-		t.Fatalf("expected 1 keychain call, got %d", len(kr.calls))
+	if len(kr.setCalls) != 1 {
+		t.Fatalf("expected 1 keychain Set call, got %d", len(kr.setCalls))
 	}
-	call := kr.calls[0]
+	call := kr.setCalls[0]
 	if call.service != keyringService {
 		t.Errorf("expected service %q, got %q", keyringService, call.service)
 	}
@@ -151,7 +165,7 @@ func TestStore_Create_ErrorsOnDuplicate(t *testing.T) {
 		t.Fatalf("first Create() failed: %v", err)
 	}
 
-	callsBefore := len(kr.calls)
+	callsBefore := len(kr.setCalls)
 	params.Value = "v2"
 	err := st.Create(params)
 	if err == nil {
@@ -161,8 +175,8 @@ func TestStore_Create_ErrorsOnDuplicate(t *testing.T) {
 		t.Errorf("expected ErrSecretAlreadyExists, got: %v", err)
 	}
 	// Keychain must not be touched when the duplicate is detected
-	if len(kr.calls) != callsBefore {
-		t.Errorf("keychain was written despite duplicate: got %d total calls, want %d", len(kr.calls), callsBefore)
+	if len(kr.setCalls) != callsBefore {
+		t.Errorf("keychain was written despite duplicate: got %d total calls, want %d", len(kr.setCalls), callsBefore)
 	}
 }
 
@@ -218,11 +232,112 @@ func TestStore_List(t *testing.T) {
 func TestStore_Create_KeychainError(t *testing.T) {
 	t.Parallel()
 
-	kr := &fakeKeyring{err: os.ErrPermission}
+	kr := &fakeKeyring{setErr: os.ErrPermission}
 	st := newStoreWithKeyring(t.TempDir(), kr)
 
 	err := st.Create(CreateParams{Name: "x", Type: "github", Value: "v"})
 	if err == nil {
 		t.Fatal("expected error when keychain fails")
+	}
+}
+
+func TestStore_Remove_DeletesFromKeychainAndFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	kr := &fakeKeyring{}
+	st := newStoreWithKeyring(dir, kr)
+
+	if err := st.Create(CreateParams{Name: "my-token", Type: "github", Value: "ghp_secret"}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if err := st.Remove("my-token"); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	if len(kr.deleteCalls) != 1 {
+		t.Fatalf("expected 1 keychain Delete call, got %d", len(kr.deleteCalls))
+	}
+	call := kr.deleteCalls[0]
+	if call.service != keyringService {
+		t.Errorf("expected service %q, got %q", keyringService, call.service)
+	}
+	if call.user != "my-token" {
+		t.Errorf("expected user %q, got %q", "my-token", call.user)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, secretsFileName))
+	if err != nil {
+		t.Fatalf("failed to read secrets file: %v", err)
+	}
+	var sf secretsFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		t.Fatalf("failed to parse secrets file: %v", err)
+	}
+	if len(sf.Secrets) != 0 {
+		t.Errorf("expected 0 secrets after Remove, got %d", len(sf.Secrets))
+	}
+}
+
+func TestStore_Remove_NotFound(t *testing.T) {
+	t.Parallel()
+
+	st := newStoreWithKeyring(t.TempDir(), &fakeKeyring{})
+
+	err := st.Remove("nonexistent")
+	if err == nil {
+		t.Fatal("expected error when secret does not exist")
+	}
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Errorf("expected ErrSecretNotFound, got: %v", err)
+	}
+}
+
+func TestStore_Remove_KeyringNotFound_StillRemovesMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	kr := &fakeKeyring{deleteErr: gokeyring.ErrNotFound}
+	st := newStoreWithKeyring(dir, kr)
+
+	if err := st.Create(CreateParams{Name: "my-token", Type: "github", Value: "v"}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	// Reset setErr after create so delete can proceed
+	kr.setErr = nil
+
+	if err := st.Remove("my-token"); err != nil {
+		t.Fatalf("Remove() should succeed even when keyring reports not found: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, secretsFileName))
+	if err != nil {
+		t.Fatalf("failed to read secrets file: %v", err)
+	}
+	var sf secretsFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		t.Fatalf("failed to parse secrets file: %v", err)
+	}
+	if len(sf.Secrets) != 0 {
+		t.Errorf("expected 0 secrets after Remove, got %d", len(sf.Secrets))
+	}
+}
+
+func TestStore_Remove_KeychainError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	kr := &fakeKeyring{}
+	st := newStoreWithKeyring(dir, kr)
+
+	if err := st.Create(CreateParams{Name: "my-token", Type: "github", Value: "v"}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	kr.deleteErr = os.ErrPermission
+
+	err := st.Remove("my-token")
+	if err == nil {
+		t.Fatal("expected error when keychain delete fails")
 	}
 }


### PR DESCRIPTION
Adds a new subcommand to delete a secret from the system keychain and its metadata from the secrets store. Supports --output json (returns the removed secret name) and tab-completion for secret names. Also adds Remove() to the Store interface and implementation, and fixes fakeListStore to satisfy the updated interface.

Fixes #304