### PR TITLE
feat(onecli): added networking to onecli container

### DIFF
--- a/.agents/skills/working-with-onecli/SKILL.md
+++ b/.agents/skills/working-with-onecli/SKILL.md
@@ -175,17 +175,63 @@ for _, name := range *mergedConfig.Secrets {
 
 ## Deny-mode Networking
 
-When a workspace is configured with `network.mode = deny`, outbound HTTP traffic from the agent container is intercepted by the OneCLI proxy. A single `manual_approval` rule covering all hosts (`*`) is created. Every intercepted request is held by the OneCLI gateway until the approval-handler sidecar approves or denies it.
+When a workspace is configured with `network.mode = deny`, two layers of enforcement prevent the agent from reaching the internet directly:
+
+1. **nftables firewall (kernel level)**: A `network-guard` sidecar container with `CAP_NET_ADMIN` sets nftables OUTPUT rules that DROP all outbound traffic from the agent's UID. Only loopback (intra-pod) and `host.containers.internal` (host-local services) are allowed. This prevents bypassing the proxy by unsetting `HTTP_PROXY`.
+2. **OneCLI proxy (application level)**: A `manual_approval` rule covering all hosts (`*`) is created. The approval-handler sidecar approves or denies each intercepted request based on the configured `hosts` list.
 
 ### Architecture
 
-```
-agent container
-  │  (HTTP_PROXY → OneCLI)
+```text
+agent container (UID blocked by nftables except loopback + host gateway)
+  │  (HTTP_PROXY → OneCLI on localhost)
   ▼
 OneCLI gateway (port 10255) ──► approval-handler sidecar
-                                  (polls gateway, approves/denies per hosts list)
+  │                               (polls gateway, approves/denies per hosts list)
+  ▼
+Internet (only OneCLI can reach it)
 ```
+
+### nftables firewall enforcement
+
+The `network-guard` container (`pkg/runtime/podman/pods/onecli-pod.yaml`) runs the same Fedora base image as the workspace. It has `CAP_NET_ADMIN` and installs `nftables` on first start, then sleeps. During `Start()`, the Podman runtime execs `nft` commands into this container.
+
+**Key files:**
+
+- `pkg/runtime/podman/network.go` — `setupFirewallRules()` / `clearFirewallRules()` / `buildNftScript()`
+- `pkg/runtime/podman/pods/onecli-pod.yaml` — network-guard container definition
+
+**nftables rules (deny mode):**
+
+```bash
+# IPv4 — default accept, block agent UID (except loopback + host gateway)
+nft add chain ip filter output '{ type filter hook output priority 0; policy accept; }'
+nft add rule ip filter output oif lo accept
+nft add rule ip filter output ip daddr <host-gw-ip> accept   # if resolvable
+nft add rule ip filter output meta skuid <agent-uid> drop
+
+# IPv6 — mirror (without host gateway since it's IPv4 only)
+nft add chain ip6 filter output '{ type filter hook output priority 0; policy accept; }'
+nft add rule ip6 filter output oif lo accept
+nft add rule ip6 filter output meta skuid <agent-uid> drop
+```
+
+Rules are **idempotent**: existing tables are deleted before being recreated on each `Start()`.
+
+**Always-allowed destinations:**
+
+- **localhost / loopback** (`oif lo accept`): Intra-pod communication — OneCLI proxy, postgres, local web servers. Required for the proxy to work.
+- **`host.containers.internal`** (resolved IP): The host machine gateway. Allows agents to reach host-local services like Ollama, RamaLama, or any LLM provider running on the host.
+
+**Why the agent cannot remove the rules:**
+
+- The workspace container does NOT have `CAP_NET_ADMIN` — only network-guard does
+- `nft` commands from the workspace container fail with EPERM
+- Even `sudo nft flush ruleset` fails because the capability is absent from the container
+
+**In allow mode**, `clearFirewallRules()` deletes the filter tables to restore default connectivity.
+
+### Application-level enforcement (OneCLI + approval-handler)
 
 ### Approval-handler sidecar
 

--- a/.agents/skills/working-with-onecli/SKILL.md
+++ b/.agents/skills/working-with-onecli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: working-with-onecli
-description: Guide to the OneCLI package including the Client, CredentialProvider, SecretMapper, and SecretProvisioner interfaces, and how they integrate with the Podman runtime
+description: Guide to the OneCLI package including the Client, CredentialProvider, SecretMapper, and SecretProvisioner interfaces, how they integrate with the Podman runtime, and the deny-mode networking / approval-handler sidecar design
 argument-hint: ""
 ---
 
@@ -69,11 +69,14 @@ cfg, err := client.GetContainerConfig(ctx)
 
 ### Networking Rules API
 
+Valid `Action` values are `"block"`, `"rate_limit"`, and `"manual_approval"`. `"allow"` is **not** a valid action — OneCLI rejects it.
+
 ```go
+// Create a catch-all manual_approval rule (used for deny-mode networking).
 rule, err := client.CreateRule(ctx, onecli.CreateRuleInput{
-    Name:        "allow-github",
-    HostPattern: "github\\.com",
-    Action:      "allow",
+    Name:        "manual-approval-all",
+    HostPattern: "*",
+    Action:      "manual_approval",
     Enabled:     true,
 })
 
@@ -142,11 +145,16 @@ The Podman runtime is the primary consumer of this package. The flow during work
 
 ### Workspace start (`pkg/runtime/podman/network.go` — `configureNetworking`)
 
+Only runs when the workspace config has `network.mode = deny` **and** at least one host in `network.hosts`. All other cases (allow mode, no config, deny with empty hosts) call `clearNetworkingRules` instead to remove leftover rules.
+
 1. `NewCredentialProvider(baseURL).APIKey(ctx)`
 2. `NewClient(baseURL, apiKey)`
 3. `client.ListRules(ctx)` + `client.DeleteRule(ctx, id)` — wipe stale rules (idempotency)
-4. `client.CreateRule(ctx, ...)` for each allowed host → `action: "allow"`
-5. `client.CreateRule(ctx, ...)` with `hostPattern: "*"` → `action: "block"` (catch-all)
+4. `client.CreateRule(ctx, CreateRuleInput{HostPattern: "*", Action: "manual_approval"})` — single catch-all rule; individual per-host allow rules are **not** used because `"allow"` is not a valid OneCLI action
+5. Write `config.json` to the approval-handler directory (see Deny-mode Networking below)
+6. The approval-handler sidecar container is then started by `Start()` — it reads `config.json` and connects to the OneCLI gateway to approve/deny each intercepted request
+
+The network policy is read fresh from `workspace.json` + `projects.json` on every `Start()`, so it takes effect without recreating the workspace.
 
 ### Secret flow from manager (`pkg/instances/manager.go`)
 
@@ -164,6 +172,90 @@ for _, name := range *mergedConfig.Secrets {
 }
 // runtime.CreateParams.OnecliSecrets = onecliSecrets
 ```
+
+## Deny-mode Networking
+
+When a workspace is configured with `network.mode = deny`, outbound HTTP traffic from the agent container is intercepted by the OneCLI proxy. A single `manual_approval` rule covering all hosts (`*`) is created. Every intercepted request is held by the OneCLI gateway until the approval-handler sidecar approves or denies it.
+
+### Architecture
+
+```
+agent container
+  │  (HTTP_PROXY → OneCLI)
+  ▼
+OneCLI gateway (port 10255) ──► approval-handler sidecar
+                                  (polls gateway, approves/denies per hosts list)
+```
+
+### Approval-handler sidecar
+
+The sidecar is a TypeScript script (`pkg/runtime/podman/pods/approval-handler.ts`) that runs inside the pod as a UBI Node.js 22 container. It uses the `@onecli-sh/sdk` package.
+
+**Startup sequence (in `Start()`):**
+
+1. `configureNetworking` writes `config.json` to the approval-handler directory on the host (mounted at `/app` inside the container)
+2. `podman start <pod>-approval-handler` — container copies `/app/*` to its working directory and runs the script
+
+**`config.json` format** (written by `configureNetworking`, never edited manually):
+
+```json
+{
+  "onecliUrl":  "http://localhost:10254",
+  "gatewayUrl": "http://localhost:10255",
+  "apiKey":     "oc_...",
+  "hosts":      ["api.github.com", "*.example.com"]
+}
+```
+
+- `onecliUrl` / `gatewayUrl` use the internal container ports, not the host-mapped ports
+- `apiKey` is fetched via `CredentialProvider.APIKey()` (calls `GET /api/user/api-key`)
+- `hosts` comes from `network.hosts` in the workspace config
+
+**If `config.json` is absent** the script exits immediately with `"no config.json found, exiting (allow mode)"` — this is expected when the workspace is in allow mode.
+
+### Host matching
+
+The approval-handler checks each request's hostname against the `hosts` list using glob patterns:
+
+| Pattern | Approves |
+|---------|---------|
+| `*` | everything |
+| `api.github.com` | exact match only |
+| `api.*.com` | `api.github.com`, `api.example.com` (one segment) |
+| `*.github.com` | `api.github.com`, `cdn.github.com` |
+
+`*` within a pattern matches exactly one hostname segment (no dots). The catch-all `*` entry approves all hosts unconditionally.
+
+Implementation (`approval-handler.ts`):
+
+```typescript
+function matchesPattern(pattern: string, hostname: string): boolean {
+  if (pattern === "*") return true;
+  if (!pattern.includes("*")) return pattern === hostname;
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  return new RegExp("^" + escaped.replace(/\*/g, "[^.]+") + "$").test(hostname);
+}
+```
+
+### Signal handling
+
+The sidecar registers both `SIGTERM` (Linux/macOS) and `SIGINT` (Ctrl+C, required on Windows) to gracefully stop the SDK polling loop.
+
+### Windows path translation (`pkg/runtime/podman/system`)
+
+On Windows, Podman runs inside a WSL2 VM. Host paths (`C:\Users\...`) must be translated to their VM-side POSIX equivalents (`/mnt/c/Users/...`) before being written into the pod YAML `hostPath` field, and translated back when reading the stored path to write `config.json`.
+
+```go
+import podmanSystem "github.com/openkaiden/kdn/pkg/runtime/podman/system"
+
+// In Create(): store the machine-side path in pod-template-data.json
+ApprovalHandlerDir: podmanSystem.HostPathToMachinePath(approvalHandlerDir),
+
+// In readPodTemplateData(): convert back to host path before writing config.json
+tmplData.ApprovalHandlerDir = podmanSystem.MachinePathToHostPath(tmplData.ApprovalHandlerDir)
+```
+
+Both functions are no-ops on Linux and macOS (`//go:build !windows`). The Windows build (`//go:build windows`) performs the `C:\` ↔ `/mnt/c/` conversion.
 
 ## Testing
 

--- a/.agents/skills/working-with-onecli/SKILL.md
+++ b/.agents/skills/working-with-onecli/SKILL.md
@@ -221,19 +221,20 @@ The approval-handler checks each request's hostname against the `hosts` list usi
 |---------|---------|
 | `*` | everything |
 | `api.github.com` | exact match only |
-| `api.*.com` | `api.github.com`, `api.example.com` (one segment) |
-| `*.github.com` | `api.github.com`, `cdn.github.com` |
+| `*.github.com` | `api.github.com`, `cdn.github.com` but **not** `github.com` |
 
-`*` within a pattern matches exactly one hostname segment (no dots). The catch-all `*` entry approves all hosts unconditionally.
+Only three forms are supported: catch-all `*`, leading-wildcard `*.domain`, or exact hostname. Mid-pattern wildcards like `api.*.com` are treated as literal strings and will never match.
 
 Implementation (`approval-handler.ts`):
 
 ```typescript
 function matchesPattern(pattern: string, hostname: string): boolean {
   if (pattern === "*") return true;
-  if (!pattern.includes("*")) return pattern === hostname;
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-  return new RegExp("^" + escaped.replace(/\*/g, "[^.]+") + "$").test(hostname);
+  if (pattern.startsWith("*.")) {
+    const suffix = pattern.slice(1); // ".github.com"
+    return hostname.endsWith(suffix) && hostname.length > suffix.length;
+  }
+  return pattern === hostname;
 }
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,23 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 
 **To add a new runtime, use:** `/add-runtime`
 
+### Podman Runtime — Deny-mode Networking
+
+When a workspace has `network.mode = deny` with at least one host in `network.hosts`, the Podman runtime configures outbound traffic filtering via OneCLI on every `Start()`:
+
+1. All existing OneCLI rules are deleted (idempotency across restarts)
+2. A single `manual_approval` rule for `*` is created — **`"allow"` is not a valid OneCLI action**
+3. `config.json` is written to `<storageDir>/runtimes/podman/approval-handler/<name>/` on the host, which is mounted at `/app` inside the pod
+4. The `approval-handler` sidecar container is started; it copies `/app/*` to its working directory, connects to the OneCLI gateway (port 10255), and approves/denies each intercepted request by matching the hostname against the `hosts` list (supports `*` catch-all and glob patterns like `api.*.com`)
+
+**Key files:**
+- `pkg/runtime/podman/network.go` — `configureNetworking` / `clearNetworkingRules` / `loadNetworkConfig`
+- `pkg/runtime/podman/pods/approval-handler.ts` — Node.js sidecar (TypeScript, runs via `tsx`)
+- `pkg/runtime/podman/pods/onecli-pod.yaml` — pod manifest with the approval-handler container
+- `pkg/runtime/podman/system/path.go` / `path_windows.go` — `HostPathToMachinePath` / `MachinePathToHostPath` for translating host paths to Podman Machine (WSL2) paths on Windows; no-ops on Linux/macOS
+
+**For the full design, use:** `/working-with-onecli`
+
 ### Secret Service System
 
 The secret service system provides a pluggable architecture for managing secret service definitions that describe how secrets are applied to workspace requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,17 +180,15 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 
 ### Podman Runtime — Deny-mode Networking
 
-When a workspace has `network.mode = deny` with at least one host in `network.hosts`, the Podman runtime configures outbound traffic filtering via OneCLI on every `Start()`:
+When a workspace has `network.mode = deny` with at least one host in `network.hosts`, the Podman runtime enforces outbound traffic filtering on every `Start()` using two layers:
 
-1. All existing OneCLI rules are deleted (idempotency across restarts)
-2. A single `manual_approval` rule for `*` is created — **`"allow"` is not a valid OneCLI action**
-3. `config.json` is written to `<storageDir>/runtimes/podman/approval-handler/<name>/` on the host, which is mounted at `/app` inside the pod
-4. The `approval-handler` sidecar container is started; it copies `/app/*` to its working directory, connects to the OneCLI gateway (port 10255), and approves/denies each intercepted request by matching the hostname against the `hosts` list (supports `*` catch-all and glob patterns like `api.*.com`)
+1. **nftables firewall (kernel level)**: A `network-guard` sidecar with `CAP_NET_ADMIN` runs nftables rules that DROP outbound traffic from the agent's UID. Loopback and `host.containers.internal` are always allowed. This prevents bypassing the proxy by unsetting `HTTP_PROXY`.
+2. **OneCLI proxy (application level)**: All existing OneCLI rules are deleted, a single `manual_approval` rule for `*` is created (**`"allow"` is not a valid OneCLI action**), and the `approval-handler` sidecar approves/denies intercepted requests by hostname pattern.
 
 **Key files:**
-- `pkg/runtime/podman/network.go` — `configureNetworking` / `clearNetworkingRules` / `loadNetworkConfig`
+- `pkg/runtime/podman/network.go` — `configureNetworking` / `clearNetworkingRules` / `setupFirewallRules` / `clearFirewallRules` / `buildNftScript`
 - `pkg/runtime/podman/pods/approval-handler.ts` — Node.js sidecar (TypeScript, runs via `tsx`)
-- `pkg/runtime/podman/pods/onecli-pod.yaml` — pod manifest with the approval-handler container
+- `pkg/runtime/podman/pods/onecli-pod.yaml` — pod manifest with the approval-handler, network-guard, and OneCLI containers
 - `pkg/runtime/podman/system/path.go` / `path_windows.go` — `HostPathToMachinePath` / `MachinePathToHostPath` for translating host paths to Podman Machine (WSL2) paths on Windows; no-ops on Linux/macOS
 
 **For the full design, use:** `/working-with-onecli`

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -282,6 +282,10 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(out, addedInstance.GetID())
 	}
 
+	if port, ok := addedInstance.GetRuntimeData().Info["onecli_web_port"]; ok {
+		fmt.Fprintf(out, "OneCLI dashboard: http://localhost:%s\n", port)
+	}
+
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,10 +234,6 @@ func (c *config) validate(cfg *workspace.WorkspaceConfiguration) error {
 		if cfg.Network.Mode != nil && !cfg.Network.Mode.Valid() {
 			return fmt.Errorf("%w: network mode %q is invalid (must be %q or %q)", ErrInvalidConfig, *cfg.Network.Mode, workspace.Allow, workspace.Deny)
 		}
-		isAllow := cfg.Network.Mode != nil && *cfg.Network.Mode == workspace.Allow
-		if isAllow && cfg.Network.Hosts != nil {
-			return fmt.Errorf("%w: network hosts must not be set when mode is %q", ErrInvalidConfig, workspace.Allow)
-		}
 		if cfg.Network.Hosts != nil {
 			for i, h := range *cfg.Network.Hosts {
 				if h == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1343,6 +1343,10 @@ func TestConfig_Load_Network_Valid(t *testing.T) {
 			json: `{"network": {"mode": "allow"}}`,
 		},
 		{
+			name: "allow mode with hosts is valid (hosts are ignored at runtime)",
+			json: `{"network": {"mode": "allow", "hosts": ["example.com"]}}`,
+		},
+		{
 			name: "no mode defaults to deny",
 			json: `{"network": {"hosts": ["example.com"]}}`,
 		},
@@ -1387,11 +1391,6 @@ func TestConfig_Load_Network_Invalid(t *testing.T) {
 			name:       "invalid mode",
 			json:       `{"network": {"mode": "block"}}`,
 			wantErrMsg: `network mode "block" is invalid`,
-		},
-		{
-			name:       "allow mode with hosts",
-			json:       `{"network": {"mode": "allow", "hosts": ["example.com"]}}`,
-			wantErrMsg: `network hosts must not be set when mode is "allow"`,
 		},
 		{
 			name:       "empty host entry",

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -431,10 +431,9 @@ func copyMCP(mcp *workspace.McpConfiguration) *workspace.McpConfiguration {
 }
 
 // mergeNetwork merges two NetworkConfiguration objects.
-// The base network policy is dominant:
-//   - if base has mode "allow", use base configuration
-//   - if base has mode "deny" and override has mode "allow", use base configuration
-//   - if both base and override have mode "deny", merge hosts from both
+// Override takes precedence, consistent with the rest of the merger:
+//   - override mode wins; fall back to base mode when override has none
+//   - hosts are the union of both (base entries first, override entries appended)
 func mergeNetwork(base, override *workspace.NetworkConfiguration) *workspace.NetworkConfiguration {
 	if base == nil && override == nil {
 		return nil
@@ -446,20 +445,16 @@ func mergeNetwork(base, override *workspace.NetworkConfiguration) *workspace.Net
 		return copyNetwork(base)
 	}
 
-	// Base with "allow" mode always wins, regardless of override
-	if base.Mode != nil && *base.Mode == workspace.Allow {
-		return copyNetwork(base)
-	}
-
-	// Base has "deny" (or default deny) and override has "allow": base wins
-	if override.Mode != nil && *override.Mode == workspace.Allow {
-		return copyNetwork(base)
-	}
-
-	// Both have "deny" mode: merge hosts
 	result := &workspace.NetworkConfiguration{}
-	mode := workspace.Deny
-	result.Mode = &mode
+
+	if override.Mode != nil {
+		modeCopy := *override.Mode
+		result.Mode = &modeCopy
+	} else if base.Mode != nil {
+		modeCopy := *base.Mode
+		result.Mode = &modeCopy
+	}
+
 	result.Hosts = mergeStringSlices(base.Hosts, override.Hosts)
 
 	return result

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -1229,12 +1229,12 @@ func TestMerger_Merge_Network_OverrideOnly(t *testing.T) {
 	}
 }
 
-func TestMerger_Merge_Network_BaseAllowWins(t *testing.T) {
+func TestMerger_Merge_Network_OverrideModeWins(t *testing.T) {
 	t.Parallel()
 
 	merger := NewMerger()
 
-	t.Run("base allow override deny", func(t *testing.T) {
+	t.Run("override deny beats base allow", func(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
@@ -1253,15 +1253,43 @@ func TestMerger_Merge_Network_BaseAllowWins(t *testing.T) {
 		if result.Network == nil {
 			t.Fatal("Expected non-nil Network")
 		}
-		if result.Network.Mode == nil || *result.Network.Mode != workspace.Allow {
-			t.Errorf("Expected base allow mode to win, got %v", result.Network.Mode)
+		if result.Network.Mode == nil || *result.Network.Mode != workspace.Deny {
+			t.Errorf("Expected override deny mode to win, got %v", result.Network.Mode)
 		}
-		if result.Network.Hosts != nil {
-			t.Error("Expected hosts to be nil when base allow wins")
+		if result.Network.Hosts == nil || len(*result.Network.Hosts) != 1 || (*result.Network.Hosts)[0] != "restricted.com" {
+			t.Errorf("Expected merged hosts, got %v", result.Network.Hosts)
 		}
 	})
 
-	t.Run("base allow override allow", func(t *testing.T) {
+	t.Run("override allow beats base deny", func(t *testing.T) {
+		t.Parallel()
+
+		base := &workspace.WorkspaceConfiguration{
+			Network: &workspace.NetworkConfiguration{
+				Mode:  networkModePtr(workspace.Deny),
+				Hosts: &[]string{"allowed.com"},
+			},
+		}
+		override := &workspace.WorkspaceConfiguration{
+			Network: &workspace.NetworkConfiguration{
+				Mode: networkModePtr(workspace.Allow),
+			},
+		}
+
+		result := merger.Merge(base, override)
+		if result.Network == nil {
+			t.Fatal("Expected non-nil Network")
+		}
+		if result.Network.Mode == nil || *result.Network.Mode != workspace.Allow {
+			t.Errorf("Expected override allow mode to win, got %v", result.Network.Mode)
+		}
+		// Hosts from base are still present in the union, but runtime ignores them in allow mode.
+		if result.Network.Hosts == nil || len(*result.Network.Hosts) != 1 || (*result.Network.Hosts)[0] != "allowed.com" {
+			t.Errorf("Expected base hosts preserved in union, got %v", result.Network.Hosts)
+		}
+	})
+
+	t.Run("both allow", func(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
@@ -1283,35 +1311,6 @@ func TestMerger_Merge_Network_BaseAllowWins(t *testing.T) {
 			t.Errorf("Expected allow mode, got %v", result.Network.Mode)
 		}
 	})
-}
-
-func TestMerger_Merge_Network_BaseDenyOverrideAllow(t *testing.T) {
-	t.Parallel()
-
-	merger := NewMerger()
-	base := &workspace.WorkspaceConfiguration{
-		Network: &workspace.NetworkConfiguration{
-			Mode:  networkModePtr(workspace.Deny),
-			Hosts: &[]string{"allowed.com"},
-		},
-	}
-	override := &workspace.WorkspaceConfiguration{
-		Network: &workspace.NetworkConfiguration{
-			Mode: networkModePtr(workspace.Allow),
-		},
-	}
-
-	result := merger.Merge(base, override)
-	if result.Network == nil {
-		t.Fatal("Expected non-nil Network")
-	}
-	// Base deny should win over override allow
-	if result.Network.Mode == nil || *result.Network.Mode != workspace.Deny {
-		t.Errorf("Expected base deny mode to win, got %v", result.Network.Mode)
-	}
-	if result.Network.Hosts == nil || len(*result.Network.Hosts) != 1 || (*result.Network.Hosts)[0] != "allowed.com" {
-		t.Errorf("Expected base hosts to be preserved, got %v", result.Network.Hosts)
-	}
 }
 
 func TestMerger_Merge_Network_BothDenyMerged(t *testing.T) {

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -340,6 +340,7 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		AgentSettings:      agentSettings,
 		OnecliSecrets:      onecliSecrets,
 		SecretEnvVars:      secretEnvVars,
+		ProjectID:          project,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)

--- a/pkg/onecli/client.go
+++ b/pkg/onecli/client.go
@@ -37,6 +37,9 @@ type Client interface {
 	ListSecrets(ctx context.Context) ([]Secret, error)
 	DeleteSecret(ctx context.Context, id string) error
 	GetContainerConfig(ctx context.Context) (*ContainerConfig, error)
+	CreateRule(ctx context.Context, input CreateRuleInput) (*Rule, error)
+	ListRules(ctx context.Context) ([]Rule, error)
+	DeleteRule(ctx context.Context, id string) error
 }
 
 // UpdateSecretInput is the request body for updating a secret.
@@ -80,6 +83,27 @@ type CreateSecretInput struct {
 	HostPattern     string           `json:"hostPattern"`
 	PathPattern     string           `json:"pathPattern,omitempty"`
 	InjectionConfig *InjectionConfig `json:"injectionConfig,omitempty"`
+}
+
+// CreateRuleInput is the request body for creating a networking rule.
+type CreateRuleInput struct {
+	Name            string `json:"name"`
+	HostPattern     string `json:"hostPattern"`
+	PathPattern     string `json:"pathPattern,omitempty"`
+	Action          string `json:"action"`
+	Enabled         bool   `json:"enabled"`
+	AgentID         string `json:"agentId,omitempty"`
+	RateLimit       int    `json:"rateLimit,omitempty"`
+	RateLimitWindow string `json:"rateLimitWindow,omitempty"`
+}
+
+// Rule represents a networking rule returned by the OneCLI API.
+type Rule struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	HostPattern string `json:"hostPattern"`
+	Action      string `json:"action"`
+	Enabled     bool   `json:"enabled"`
 }
 
 // APIError represents an error response from the OneCLI API.
@@ -153,6 +177,32 @@ func (c *client) GetContainerConfig(ctx context.Context) (*ContainerConfig, erro
 		return nil, fmt.Errorf("getting container config: %w", err)
 	}
 	return &cfg, nil
+}
+
+// CreateRule creates a new networking rule in OneCLI.
+func (c *client) CreateRule(ctx context.Context, input CreateRuleInput) (*Rule, error) {
+	var rule Rule
+	if err := c.do(ctx, http.MethodPost, "/api/rules", input, &rule); err != nil {
+		return nil, fmt.Errorf("creating rule: %w", err)
+	}
+	return &rule, nil
+}
+
+// ListRules returns all networking rules for the authenticated user.
+func (c *client) ListRules(ctx context.Context) ([]Rule, error) {
+	var rules []Rule
+	if err := c.do(ctx, http.MethodGet, "/api/rules", nil, &rules); err != nil {
+		return nil, fmt.Errorf("listing rules: %w", err)
+	}
+	return rules, nil
+}
+
+// DeleteRule deletes a networking rule by ID.
+func (c *client) DeleteRule(ctx context.Context, id string) error {
+	if err := c.do(ctx, http.MethodDelete, "/api/rules/"+id, nil, nil); err != nil {
+		return fmt.Errorf("deleting rule: %w", err)
+	}
+	return nil
 }
 
 func (c *client) do(ctx context.Context, method, path string, body any, result any) error {

--- a/pkg/onecli/client_test.go
+++ b/pkg/onecli/client_test.go
@@ -319,6 +319,9 @@ func TestCreateRule_AuthFailure(t *testing.T) {
 	}
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
-		t.Errorf("expected APIError, got %T: %v", err, err)
+		t.Fatalf("expected APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("got status %d, want %d", apiErr.StatusCode, http.StatusUnauthorized)
 	}
 }

--- a/pkg/onecli/client_test.go
+++ b/pkg/onecli/client_test.go
@@ -204,3 +204,121 @@ func TestGetContainerConfig(t *testing.T) {
 		t.Error("CACertificate should not be empty")
 	}
 }
+
+func TestCreateRule(t *testing.T) {
+	t.Parallel()
+
+	want := Rule{
+		ID:          "rule-1",
+		Name:        "allow-api.github.com",
+		HostPattern: "api.github.com",
+		Action:      "rate_limit",
+		Enabled:     true,
+	}
+
+	var gotInput CreateRuleInput
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/rules" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotInput); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	input := CreateRuleInput{
+		Name:            "allow-api.github.com",
+		HostPattern:     "api.github.com",
+		Action:          "rate_limit",
+		Enabled:         true,
+		RateLimit:       65535,
+		RateLimitWindow: "minute",
+	}
+
+	c := NewClient(server.URL, "test-key")
+	got, err := c.CreateRule(context.Background(), input)
+	if err != nil {
+		t.Fatalf("CreateRule() error: %v", err)
+	}
+	if got.ID != want.ID {
+		t.Errorf("got ID %q, want %q", got.ID, want.ID)
+	}
+	if gotInput.HostPattern != input.HostPattern {
+		t.Errorf("got HostPattern %q, want %q", gotInput.HostPattern, input.HostPattern)
+	}
+	if gotInput.RateLimit != input.RateLimit {
+		t.Errorf("got RateLimit %d, want %d", gotInput.RateLimit, input.RateLimit)
+	}
+}
+
+func TestListRules(t *testing.T) {
+	t.Parallel()
+
+	want := []Rule{
+		{ID: "rule-1", Name: "allow-github", HostPattern: "api.github.com", Action: "rate_limit", Enabled: true},
+		{ID: "rule-2", Name: "block-all", HostPattern: "*", Action: "block", Enabled: true},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/rules" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	got, err := c.ListRules(context.Background())
+	if err != nil {
+		t.Fatalf("ListRules() error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rules, want 2", len(got))
+	}
+	if got[0].ID != "rule-1" || got[1].ID != "rule-2" {
+		t.Errorf("unexpected rules: %+v", got)
+	}
+}
+
+func TestDeleteRule(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/rules/rule-1" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-key")
+	if err := c.DeleteRule(context.Background(), "rule-1"); err != nil {
+		t.Fatalf("DeleteRule() error: %v", err)
+	}
+}
+
+func TestCreateRule_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "bad-key")
+	_, err := c.CreateRule(context.Background(), CreateRuleInput{Name: "x", HostPattern: "x", Action: "block", Enabled: true})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected APIError, got %T: %v", err, err)
+	}
+}

--- a/pkg/onecli/provisioner_test.go
+++ b/pkg/onecli/provisioner_test.go
@@ -62,6 +62,18 @@ func (f *fakeClient) GetContainerConfig(_ context.Context) (*ContainerConfig, er
 	return &ContainerConfig{Env: map[string]string{}}, nil
 }
 
+func (f *fakeClient) CreateRule(_ context.Context, _ CreateRuleInput) (*Rule, error) {
+	return &Rule{}, nil
+}
+
+func (f *fakeClient) ListRules(_ context.Context) ([]Rule, error) {
+	return nil, nil
+}
+
+func (f *fakeClient) DeleteRule(_ context.Context, _ string) error {
+	return nil
+}
+
 func TestProvisioner_AllSecretsCreated(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -36,13 +36,17 @@ import (
 
 const defaultOnecliVersion = "1.17"
 
-// podTemplateData holds the values used to render the pod YAML template.
+// podTemplateData holds the values used to render the pod YAML template
+// and is also persisted as per-pod metadata (pod-template-data.json) so
+// that Start() can recover SourcePath, ProjectID and ApprovalHandlerDir
+// without re-reading the original CreateParams.
 type podTemplateData struct {
-	Name          string
-	OnecliWebPort int
-	OnecliVersion string
-	SourcePath    string
-	ProjectID     string
+	Name               string
+	OnecliWebPort      int
+	OnecliVersion      string
+	SourcePath         string
+	ProjectID          string
+	ApprovalHandlerDir string
 }
 
 // validateCreateParams validates the create parameters.
@@ -380,13 +384,21 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to allocate free ports: %w", err)
 	}
 
+	// Prepare the approval-handler directory with the embedded Node.js script
+	// so it is available as a hostPath volume when the pod is created.
+	approvalHandlerDir := filepath.Join(p.storageDir, "approval-handler", params.Name)
+	if err := writeApprovalHandlerFiles(approvalHandlerDir); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to write approval handler files: %w", err)
+	}
+
 	// Render the pod YAML template
 	tmplData := podTemplateData{
-		Name:          params.Name,
-		OnecliWebPort: freePorts[0],
-		OnecliVersion: defaultOnecliVersion,
-		SourcePath:    params.SourcePath,
-		ProjectID:     params.ProjectID,
+		Name:               params.Name,
+		OnecliWebPort:      freePorts[0],
+		OnecliVersion:      defaultOnecliVersion,
+		SourcePath:         params.SourcePath,
+		ProjectID:          params.ProjectID,
+		ApprovalHandlerDir: approvalHandlerDir,
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")
@@ -559,6 +571,27 @@ func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.S
 	}
 
 	return containerConfig, nil
+}
+
+// writeApprovalHandlerFiles writes the embedded Node.js approval handler
+// script and package.json into the given directory so it can be mounted
+// as a hostPath volume into the approval-handler sidecar container.
+func writeApprovalHandlerFiles(dir string) error {
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return fmt.Errorf("failed to create approval handler directory: %w", err)
+	}
+	// MkdirAll is subject to umask, so explicitly set permissions to allow
+	// the non-root container user (UID 1001) to write node_modules/.
+	if err := os.Chmod(dir, 0777); err != nil {
+		return fmt.Errorf("failed to chmod approval handler directory: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "approval-handler.ts"), pods.ApprovalHandlerTS, 0644); err != nil {
+		return fmt.Errorf("failed to write approval-handler.ts: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), pods.ApprovalHandlerPackageJSON, 0644); err != nil {
+		return fmt.Errorf("failed to write package.json: %w", err)
+	}
+	return nil
 }
 
 // writePodYAMLFile renders and writes the pod YAML template to the given path.

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/pods"
+	podmanSystem "github.com/openkaiden/kdn/pkg/runtime/podman/system"
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
@@ -398,7 +399,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		OnecliVersion:      defaultOnecliVersion,
 		SourcePath:         params.SourcePath,
 		ProjectID:          params.ProjectID,
-		ApprovalHandlerDir: approvalHandlerDir,
+		ApprovalHandlerDir: podmanSystem.HostPathToMachinePath(approvalHandlerDir),
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -41,6 +41,8 @@ type podTemplateData struct {
 	Name          string
 	OnecliWebPort int
 	OnecliVersion string
+	SourcePath    string
+	ProjectID     string
 }
 
 // validateCreateParams validates the create parameters.
@@ -383,6 +385,8 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		Name:          params.Name,
 		OnecliWebPort: freePorts[0],
 		OnecliVersion: defaultOnecliVersion,
+		SourcePath:    params.SourcePath,
+		ProjectID:     params.ProjectID,
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -415,31 +415,32 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		}
 	}()
 
-	// Start the pod so OneCLI can initialize and we can provision secrets + get proxy config
+	// Always start OneCLI to inject proxy env vars and the CA cert into the workspace container.
+	// Without HTTP_PROXY/HTTPS_PROXY pointing at the OneCLI gateway, deny-mode networking rules
+	// have no effect because workspace traffic bypasses the proxy entirely.
+	// Secrets are provisioned if any were provided.
+	containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets)
+	if setupErr != nil {
+		return runtime.RuntimeInfo{}, setupErr
+	}
 	var ccArgs *containerConfigArgs
-	if len(params.OnecliSecrets) > 0 {
-		containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets)
-		if setupErr != nil {
-			return runtime.RuntimeInfo{}, setupErr
+	if containerConfig != nil {
+		ccArgs = &containerConfigArgs{
+			envVars: containerConfig.Env,
 		}
-		if containerConfig != nil {
-			ccArgs = &containerConfigArgs{
-				envVars: containerConfig.Env,
+		// Write CA certificate to a durable location for mounting into the workspace container.
+		// Use a shared certs directory under storageDir (not instanceDir which is cleaned up).
+		if containerConfig.CACertificate != "" && containerConfig.CACertificateContainerPath != "" {
+			certsDir := filepath.Join(p.storageDir, "certs", params.Name)
+			if mkErr := os.MkdirAll(certsDir, 0755); mkErr != nil {
+				return runtime.RuntimeInfo{}, fmt.Errorf("failed to create certs directory: %w", mkErr)
 			}
-			// Write CA certificate to a durable location for mounting into the workspace container.
-			// Use a shared certs directory under storageDir (not instanceDir which is cleaned up).
-			if containerConfig.CACertificate != "" && containerConfig.CACertificateContainerPath != "" {
-				certsDir := filepath.Join(p.storageDir, "certs", params.Name)
-				if mkErr := os.MkdirAll(certsDir, 0755); mkErr != nil {
-					return runtime.RuntimeInfo{}, fmt.Errorf("failed to create certs directory: %w", mkErr)
-				}
-				caPath := filepath.Join(certsDir, "onecli-ca.pem")
-				if writeErr := os.WriteFile(caPath, []byte(containerConfig.CACertificate), 0644); writeErr != nil {
-					return runtime.RuntimeInfo{}, fmt.Errorf("failed to write CA certificate: %w", writeErr)
-				}
-				ccArgs.caFilePath = caPath
-				ccArgs.caContainerPath = containerConfig.CACertificateContainerPath
+			caPath := filepath.Join(certsDir, "onecli-ca.pem")
+			if writeErr := os.WriteFile(caPath, []byte(containerConfig.CACertificate), 0644); writeErr != nil {
+				return runtime.RuntimeInfo{}, fmt.Errorf("failed to write CA certificate: %w", writeErr)
 			}
+			ccArgs.caFilePath = caPath
+			ccArgs.caContainerPath = containerConfig.CACertificateContainerPath
 		}
 	}
 
@@ -515,7 +516,7 @@ func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.S
 		return nil, fmt.Errorf("failed to start OneCLI: %w", err)
 	}
 
-	baseURL := fmt.Sprintf("http://localhost:%d", tmplData.OnecliWebPort)
+	baseURL := p.onecliURL(tmplData.OnecliWebPort)
 
 	stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
 	if err := waitForReady(ctx, baseURL); err != nil {
@@ -532,12 +533,14 @@ func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.S
 
 	client := onecli.NewClient(baseURL, apiKey)
 
-	// Provision secrets
-	stepLogger.Start("Provisioning OneCLI secrets", "OneCLI secrets provisioned")
-	provisioner := onecli.NewSecretProvisioner(client)
-	if err := provisioner.ProvisionSecrets(ctx, secrets); err != nil {
-		stepLogger.Fail(err)
-		return nil, fmt.Errorf("failed to provision OneCLI secrets: %w", err)
+	// Provision secrets (skipped when none are configured)
+	if len(secrets) > 0 {
+		stepLogger.Start("Provisioning OneCLI secrets", "OneCLI secrets provisioned")
+		provisioner := onecli.NewSecretProvisioner(client)
+		if err := provisioner.ProvisionSecrets(ctx, secrets); err != nil {
+			stepLogger.Fail(err)
+			return nil, fmt.Errorf("failed to provision OneCLI secrets: %w", err)
+		}
 	}
 
 	// Get container config (proxy env vars, CA cert, agent token)

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
+	"github.com/openkaiden/kdn/pkg/runtime/podman/constants"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/pods"
 	podmanSystem "github.com/openkaiden/kdn/pkg/runtime/podman/system"
 	"github.com/openkaiden/kdn/pkg/steplogger"
@@ -45,6 +46,9 @@ type podTemplateData struct {
 	Name               string
 	OnecliWebPort      int
 	OnecliVersion      string
+	AgentUID           int
+	BaseImageRegistry  string
+	BaseImageVersion   string
 	SourcePath         string
 	ProjectID          string
 	ApprovalHandlerDir string
@@ -236,11 +240,21 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 	// Add OneCLI proxy env vars after workspace config (OneCLI takes precedence).
 	// Log collisions so users know their workspace values are being overridden.
 	if ccArgs != nil {
+		onecliEnvNames := make(map[string]bool)
 		for k, v := range ccArgs.envVars {
 			if workspaceEnvNames[k] {
 				fmt.Fprintf(os.Stderr, "warning: OneCLI overrides workspace env var %q\n", k)
 			}
 			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+			onecliEnvNames[k] = true
+		}
+		// Ensure local addresses bypass the OneCLI proxy so tools can reach
+		// localhost and host.containers.internal (e.g. Ollama) directly.
+		// Only inject if neither the workspace config nor OneCLI already set NO_PROXY.
+		if !workspaceEnvNames["NO_PROXY"] && !workspaceEnvNames["no_proxy"] &&
+			!onecliEnvNames["NO_PROXY"] && !onecliEnvNames["no_proxy"] {
+			const noProxy = "localhost,127.0.0.1,host.containers.internal"
+			args = append(args, "-e", "NO_PROXY="+noProxy, "-e", "no_proxy="+noProxy)
 		}
 		if ccArgs.caFilePath != "" && ccArgs.caContainerPath != "" {
 			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", ccArgs.caFilePath, ccArgs.caContainerPath))
@@ -397,6 +411,9 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		Name:               params.Name,
 		OnecliWebPort:      freePorts[0],
 		OnecliVersion:      defaultOnecliVersion,
+		AgentUID:           p.system.Getuid(),
+		BaseImageRegistry:  constants.BaseImageRegistry,
+		BaseImageVersion:   imageConfig.Version,
 		SourcePath:         params.SourcePath,
 		ProjectID:          params.ProjectID,
 		ApprovalHandlerDir: podmanSystem.HostPathToMachinePath(approvalHandlerDir),

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -16,9 +16,12 @@ package podman
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -831,6 +834,7 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 
 	storageDir := t.TempDir()
 	sourcePath := t.TempDir()
+	onecliServer := newOnecliTestServer(t)
 
 	fakeExec := exec.NewFake()
 	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
@@ -841,10 +845,11 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 	}
 
 	p := &podmanRuntime{
-		system:     &fakeSystem{},
-		executor:   fakeExec,
-		storageDir: storageDir,
-		config:     &fakeConfig{},
+		system:          &fakeSystem{},
+		executor:        fakeExec,
+		storageDir:      storageDir,
+		config:          &fakeConfig{},
+		onecliBaseURLFn: func(_ int) string { return onecliServer.URL },
 	}
 
 	fakeLogger := &fakeStepLogger{}
@@ -871,28 +876,19 @@ func TestCreate_StepLogger_Success(t *testing.T) {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Verify Start was called 5 times with correct messages
+	// Verify the full step sequence including OneCLI setup (always runs to inject proxy env vars)
 	expectedSteps := []stepCall{
-		{
-			inProgress: "Creating temporary build directory",
-			completed:  "Temporary build directory created",
-		},
-		{
-			inProgress: "Generating Containerfile",
-			completed:  "Containerfile generated",
-		},
-		{
-			inProgress: "Building container image: kdn-test-workspace",
-			completed:  "Container image built",
-		},
-		{
-			inProgress: "Creating onecli services",
-			completed:  "Onecli services created",
-		},
-		{
-			inProgress: "Creating workspace container: test-workspace",
-			completed:  "Workspace container created",
-		},
+		{inProgress: "Creating temporary build directory", completed: "Temporary build directory created"},
+		{inProgress: "Generating Containerfile", completed: "Containerfile generated"},
+		{inProgress: "Building container image: kdn-test-workspace", completed: "Container image built"},
+		{inProgress: "Creating onecli services", completed: "Onecli services created"},
+		{inProgress: "Starting postgres", completed: "Postgres started"},
+		{inProgress: "Waiting for postgres readiness", completed: "Postgres ready"},
+		{inProgress: "Starting OneCLI", completed: "OneCLI started"},
+		{inProgress: "Waiting for OneCLI readiness", completed: "OneCLI ready"},
+		{inProgress: "Retrieving OneCLI container config", completed: "Container config retrieved"},
+		{inProgress: "Stopping OneCLI services", completed: "OneCLI services stopped"},
+		{inProgress: "Creating workspace container: test-workspace", completed: "Workspace container created"},
 	}
 
 	if len(fakeLogger.startCalls) != len(expectedSteps) {
@@ -1103,6 +1099,7 @@ func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
 
 	storageDir := t.TempDir()
 	sourcePath := t.TempDir()
+	onecliServer := newOnecliTestServer(t)
 
 	fakeExec := exec.NewFake()
 	// Make Run succeed for build, but Output fail for create
@@ -1117,10 +1114,11 @@ func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
 	}
 
 	p := &podmanRuntime{
-		system:     &fakeSystem{},
-		executor:   fakeExec,
-		storageDir: storageDir,
-		config:     &fakeConfig{},
+		system:          &fakeSystem{},
+		executor:        fakeExec,
+		storageDir:      storageDir,
+		config:          &fakeConfig{},
+		onecliBaseURLFn: func(_ int) string { return onecliServer.URL },
 	}
 
 	fakeLogger := &fakeStepLogger{}
@@ -1142,17 +1140,23 @@ func TestCreate_StepLogger_FailOnCreateContainer(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	// Verify Start was called 5 times (all steps through workspace container creation)
-	if len(fakeLogger.startCalls) != 5 {
-		t.Fatalf("Expected 5 Start() calls, got %d", len(fakeLogger.startCalls))
-	}
-
+	// OneCLI setup always runs; workspace container creation is the last step (which fails)
 	expectedSteps := []string{
 		"Creating temporary build directory",
 		"Generating Containerfile",
 		"Building container image: kdn-test-workspace",
 		"Creating onecli services",
+		"Starting postgres",
+		"Waiting for postgres readiness",
+		"Starting OneCLI",
+		"Waiting for OneCLI readiness",
+		"Retrieving OneCLI container config",
+		"Stopping OneCLI services",
 		"Creating workspace container: test-workspace",
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("Expected %d Start() calls, got %d", len(expectedSteps), len(fakeLogger.startCalls))
 	}
 
 	for i, expected := range expectedSteps {
@@ -1343,6 +1347,7 @@ func TestCreate_CleansUpInstanceDirectory(t *testing.T) {
 
 		storageDir := t.TempDir()
 		sourcePath := t.TempDir()
+		onecliServer := newOnecliTestServer(t)
 
 		// Create a fake executor that simulates successful operations
 		fakeExec := &fakeExecutor{
@@ -1352,10 +1357,11 @@ func TestCreate_CleansUpInstanceDirectory(t *testing.T) {
 		}
 
 		p := &podmanRuntime{
-			system:     &fakeSystem{},
-			executor:   fakeExec,
-			storageDir: storageDir,
-			config:     &fakeConfig{},
+			system:          &fakeSystem{},
+			executor:        fakeExec,
+			storageDir:      storageDir,
+			config:          &fakeConfig{},
+			onecliBaseURLFn: func(_ int) string { return onecliServer.URL },
 		}
 
 		params := runtime.CreateParams{
@@ -1421,6 +1427,32 @@ func TestCreate_CleansUpInstanceDirectory(t *testing.T) {
 }
 
 // fakeExecutor is a test double for the exec.Executor interface
+// newOnecliTestServer starts an httptest server that handles the OneCLI endpoints
+// invoked during Create() (health, api-key, container-config). Use together with
+// podmanRuntime.onecliBaseURLFn to avoid dialling a real localhost port in tests.
+func newOnecliTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/container-config":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"env":                        map[string]string{},
+				"caCertificate":              "",
+				"caCertificateContainerPath": "",
+			})
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
 type fakeExecutor struct {
 	runErr    error
 	outputErr error

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -619,10 +619,112 @@ func TestBuildContainerArgs(t *testing.T) {
 			t.Error("Expected HTTPS_PROXY env var")
 		}
 
+		// Verify NO_PROXY is injected so local addresses bypass the proxy
+		if !strings.Contains(argsStr, "-e NO_PROXY=localhost,127.0.0.1,host.containers.internal") {
+			t.Errorf("Expected NO_PROXY env var in args: %s", argsStr)
+		}
+		if !strings.Contains(argsStr, "-e no_proxy=localhost,127.0.0.1,host.containers.internal") {
+			t.Errorf("Expected no_proxy env var in args: %s", argsStr)
+		}
+
 		// Verify CA cert volume mount
 		expectedMount := fmt.Sprintf("-v %s:/etc/ssl/certs/onecli-ca.pem:ro,Z", caFile)
 		if !strings.Contains(argsStr, expectedMount) {
 			t.Errorf("Expected CA cert mount %q in args: %s", expectedMount, argsStr)
+		}
+	})
+
+	t.Run("no_proxy not injected when onecli already sets it", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+		}
+
+		ccArgs := &containerConfigArgs{
+			envVars: map[string]string{
+				"HTTP_PROXY": "http://proxy:8080",
+				"NO_PROXY":   "custom.internal",
+				"no_proxy":   "custom.internal",
+			},
+		}
+
+		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+		argsStr := strings.Join(args, " ")
+
+		// OneCLI's NO_PROXY must be preserved as-is; we must not inject a second one.
+		if !strings.Contains(argsStr, "-e NO_PROXY=custom.internal") {
+			t.Errorf("Expected OneCLI NO_PROXY in args: %s", argsStr)
+		}
+		if strings.Contains(argsStr, "-e NO_PROXY=localhost") || strings.Contains(argsStr, "-e no_proxy=localhost") {
+			t.Errorf("Should not inject default NO_PROXY when OneCLI already provides it: %s", argsStr)
+		}
+	})
+
+	t.Run("no_proxy not injected when workspace config sets it", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+		noProxyVal := "my-internal-host"
+
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Environment: &[]workspace.EnvironmentVariable{
+					{Name: "NO_PROXY", Value: &noProxyVal},
+				},
+			},
+		}
+
+		ccArgs := &containerConfigArgs{
+			envVars: map[string]string{"HTTP_PROXY": "http://proxy:8080"},
+		}
+
+		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+		argsStr := strings.Join(args, " ")
+
+		if !strings.Contains(argsStr, "-e NO_PROXY=my-internal-host") {
+			t.Errorf("Expected workspace NO_PROXY in args: %s", argsStr)
+		}
+		if strings.Contains(argsStr, "-e NO_PROXY=localhost") || strings.Contains(argsStr, "-e no_proxy=localhost") {
+			t.Errorf("Should not inject default NO_PROXY when workspace config already sets it: %s", argsStr)
+		}
+	})
+
+	t.Run("no_proxy not injected when ccArgs is nil", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		sourcePath := t.TempDir()
+
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+		}
+
+		args, err := p.buildContainerArgs(params, "kdn-test", nil)
+		if err != nil {
+			t.Fatalf("buildContainerArgs() failed: %v", err)
+		}
+		argsStr := strings.Join(args, " ")
+
+		if strings.Contains(argsStr, "-e NO_PROXY=") || strings.Contains(argsStr, "-e no_proxy=") {
+			t.Errorf("Should not inject NO_PROXY when no OneCLI config: %s", argsStr)
 		}
 	})
 

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1250,6 +1250,7 @@ func TestCreate_StepLogger_Success_WithFeatures(t *testing.T) {
 
 	storageDir := t.TempDir()
 	sourcePath := t.TempDir()
+	onecliServer := newOnecliTestServer(t)
 
 	// Set up a minimal local feature.
 	configDir := t.TempDir()
@@ -1281,10 +1282,11 @@ func TestCreate_StepLogger_Success_WithFeatures(t *testing.T) {
 	}
 
 	p := &podmanRuntime{
-		system:     &fakeSystem{},
-		executor:   fakeExec,
-		storageDir: storageDir,
-		config:     &fakeConfig{},
+		system:          &fakeSystem{},
+		executor:        fakeExec,
+		storageDir:      storageDir,
+		config:          &fakeConfig{},
+		onecliBaseURLFn: func(_ int) string { return onecliServer.URL },
 	}
 
 	fakeLogger := &fakeStepLogger{}
@@ -1315,13 +1317,18 @@ func TestCreate_StepLogger_Success_WithFeatures(t *testing.T) {
 		t.Errorf("Expected no Fail() calls, got %d", len(fakeLogger.failCalls))
 	}
 
-	// Six steps: create dir, download features, containerfile, build, onecli services, workspace container.
 	expectedSteps := []stepCall{
 		{inProgress: "Creating temporary build directory", completed: "Temporary build directory created"},
 		{inProgress: "Downloading devcontainer features", completed: "Devcontainer features downloaded"},
 		{inProgress: "Generating Containerfile", completed: "Containerfile generated"},
 		{inProgress: "Building container image: kdn-test-workspace", completed: "Container image built"},
 		{inProgress: "Creating onecli services", completed: "Onecli services created"},
+		{inProgress: "Starting postgres", completed: "Postgres started"},
+		{inProgress: "Waiting for postgres readiness", completed: "Postgres ready"},
+		{inProgress: "Starting OneCLI", completed: "OneCLI started"},
+		{inProgress: "Waiting for OneCLI readiness", completed: "OneCLI ready"},
+		{inProgress: "Retrieving OneCLI container config", completed: "Container config retrieved"},
+		{inProgress: "Stopping OneCLI services", completed: "OneCLI services stopped"},
 		{inProgress: "Creating workspace container: test-workspace", completed: "Workspace container created"},
 	}
 

--- a/pkg/runtime/podman/exec/fake.go
+++ b/pkg/runtime/podman/exec/fake.go
@@ -91,6 +91,18 @@ func (f *FakeExecutor) AssertRunCalledWith(t interface {
 	t.Errorf("Expected Run to be called with %v, but it was called with: %v", expectedArgs, f.RunCalls)
 }
 
+// AssertRunNotCalledWith checks that Run was never called with the expected arguments.
+func (f *FakeExecutor) AssertRunNotCalledWith(t interface {
+	Errorf(format string, args ...interface{})
+}, expectedArgs ...string) {
+	for _, call := range f.RunCalls {
+		if argsEqual(call, expectedArgs) {
+			t.Errorf("Expected Run NOT to be called with %v, but it was", expectedArgs)
+			return
+		}
+	}
+}
+
 // AssertOutputCalledWith checks if Output was called with the expected arguments.
 func (f *FakeExecutor) AssertOutputCalledWith(t interface {
 	Errorf(format string, args ...interface{})

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -16,7 +16,9 @@ package podman
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
@@ -35,15 +37,16 @@ func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.Wor
 	var merged *workspace.WorkspaceConfiguration
 
 	wsCfgLoader, err := config.NewConfig(filepath.Join(sourcePath, ".kaiden"))
-	if err == nil {
-		if wc, loadErr := wsCfgLoader.Load(); loadErr == nil {
-			merged = wc
-		}
+	if err != nil {
+		return nil, fmt.Errorf("initializing workspace config loader: %w", err)
+	}
+	if wc, loadErr := wsCfgLoader.Load(); loadErr == nil {
+		merged = wc
 	}
 
 	projectLoader, err := config.NewProjectConfigLoader(storageDir)
 	if err != nil {
-		return merged, nil
+		return nil, fmt.Errorf("initializing project config loader: %w", err)
 	}
 	if pc, loadErr := projectLoader.Load(projectID); loadErr == nil {
 		merged = merger.Merge(merged, pc)
@@ -52,10 +55,44 @@ func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.Wor
 	return merged, nil
 }
 
-// configureNetworking applies deny-mode network rules to the OneCLI gateway.
-// It first deletes any existing rules (ensuring idempotency across restarts),
-// then creates a rate_limit rule for each allowed host and a catch-all block rule.
-func (p *podmanRuntime) configureNetworking(ctx context.Context, onecliBaseURL string, hosts []string) error {
+// approvalHandlerConfig is serialized to config.json in the approval-handler
+// directory so the Node.js sidecar can connect to OneCLI and make decisions.
+type approvalHandlerConfig struct {
+	OnecliURL  string   `json:"onecliUrl"`
+	GatewayURL string   `json:"gatewayUrl"`
+	APIKey     string   `json:"apiKey"`
+	Hosts      []string `json:"hosts"`
+}
+
+// clearNetworkingRules removes all existing networking rules from OneCLI.
+// Called when switching to allow mode so that no leftover manual_approval or
+// block rules from a previous deny-mode start remain active.
+func (p *podmanRuntime) clearNetworkingRules(ctx context.Context, onecliBaseURL string) error {
+	creds := onecli.NewCredentialProvider(onecliBaseURL)
+	apiKey, err := creds.APIKey(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get OneCLI API key: %w", err)
+	}
+
+	client := onecli.NewClient(onecliBaseURL, apiKey)
+
+	rules, err := client.ListRules(ctx)
+	if err != nil {
+		return fmt.Errorf("listing existing rules: %w", err)
+	}
+	for _, r := range rules {
+		if delErr := client.DeleteRule(ctx, r.ID); delErr != nil {
+			return fmt.Errorf("deleting rule %s: %w", r.ID, delErr)
+		}
+	}
+	return nil
+}
+
+// configureNetworking applies deny-mode networking via the OneCLI manual
+// approval mechanism. It deletes any existing rules, creates a single
+// manual_approval rule for all hosts, and writes config.json so the
+// approval-handler sidecar knows which hosts to approve.
+func (p *podmanRuntime) configureNetworking(ctx context.Context, onecliBaseURL string, hosts []string, approvalHandlerDir string) error {
 	creds := onecli.NewCredentialProvider(onecliBaseURL)
 	apiKey, err := creds.APIKey(ctx)
 	if err != nil {
@@ -74,26 +111,32 @@ func (p *podmanRuntime) configureNetworking(ctx context.Context, onecliBaseURL s
 		}
 	}
 
-	for _, host := range hosts {
-		if _, createErr := client.CreateRule(ctx, onecli.CreateRuleInput{
-			Name:            "allow-" + host,
-			HostPattern:     host,
-			Action:          "rate_limit",
-			Enabled:         true,
-			RateLimit:       65535,
-			RateLimitWindow: "minute",
-		}); createErr != nil {
-			return fmt.Errorf("creating rule for %s: %w", host, createErr)
-		}
-	}
-
 	if _, err := client.CreateRule(ctx, onecli.CreateRuleInput{
-		Name:        "block-all",
+		Name:        "manual-approval-all",
 		HostPattern: "*",
-		Action:      "block",
+		Action:      "manual_approval",
 		Enabled:     true,
 	}); err != nil {
-		return fmt.Errorf("creating block-all rule: %w", err)
+		return fmt.Errorf("creating manual_approval rule: %w", err)
+	}
+
+	// The sidecar runs inside the pod and shares the network namespace with
+	// OneCLI, so it must use the internal container ports, not the host-mapped
+	// ports that the Go CLI uses from outside the pod.
+	// API (10254) is used for rule management; gateway (10255) is used for
+	// manual approval long-polling.
+	cfg := approvalHandlerConfig{
+		OnecliURL:  "http://localhost:10254",
+		GatewayURL: "http://localhost:10255",
+		APIKey:     apiKey,
+		Hosts:      hosts,
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling approval handler config: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(approvalHandlerDir, "config.json"), data, 0644); err != nil {
+		return fmt.Errorf("writing approval handler config: %w", err)
 	}
 
 	return nil

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/onecli"
+	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
+)
+
+// loadNetworkConfig reads the merged workspace configuration for a project by
+// combining the workspace-level config (.kaiden/workspace.json) with the
+// project-level config from projects.json. It mirrors the merge logic used
+// at workspace creation time so that edits to projects.json are picked up on
+// the next Start() without recreating the workspace.
+func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.WorkspaceConfiguration, error) {
+	merger := config.NewMerger()
+
+	var merged *workspace.WorkspaceConfiguration
+
+	wsCfgLoader, err := config.NewConfig(filepath.Join(sourcePath, ".kaiden"))
+	if err == nil {
+		if wc, loadErr := wsCfgLoader.Load(); loadErr == nil {
+			merged = wc
+		}
+	}
+
+	projectLoader, err := config.NewProjectConfigLoader(storageDir)
+	if err != nil {
+		return merged, nil
+	}
+	if pc, loadErr := projectLoader.Load(projectID); loadErr == nil {
+		merged = merger.Merge(merged, pc)
+	}
+
+	return merged, nil
+}
+
+// getAPIKeyFromPostgres queries the postgres container for the OneCLI API key
+// by running a psql command inside the pod's postgres container.
+func getAPIKeyFromPostgres(ctx context.Context, podName string, executor exec.Executor) (string, error) {
+	output, err := executor.Output(ctx, io.Discard,
+		"exec", podName+"-postgres",
+		"psql", "-U", "onecli", "-d", "onecli", "-t", "-A",
+		"-c", "select key from api_keys limit 1",
+	)
+	if err != nil {
+		return "", fmt.Errorf("querying postgres for API key: %w", err)
+	}
+	key := strings.TrimSpace(string(output))
+	if key == "" {
+		return "", fmt.Errorf("no API key found in database")
+	}
+	return key, nil
+}
+
+// configureNetworking applies deny-mode network rules to the OneCLI gateway.
+// It first deletes any existing rules (ensuring idempotency across restarts),
+// then creates a rate_limit rule for each allowed host and a catch-all block rule.
+func (p *podmanRuntime) configureNetworking(ctx context.Context, podName, onecliBaseURL string, hosts []string) error {
+	apiKey, err := getAPIKeyFromPostgres(ctx, podName, p.executor)
+	if err != nil {
+		return err
+	}
+
+	client := onecli.NewClient(onecliBaseURL, apiKey)
+
+	rules, err := client.ListRules(ctx)
+	if err != nil {
+		return fmt.Errorf("listing existing rules: %w", err)
+	}
+	for _, r := range rules {
+		if delErr := client.DeleteRule(ctx, r.ID); delErr != nil {
+			return fmt.Errorf("deleting rule %s: %w", r.ID, delErr)
+		}
+	}
+
+	for _, host := range hosts {
+		if _, createErr := client.CreateRule(ctx, onecli.CreateRuleInput{
+			Name:            "allow-" + host,
+			HostPattern:     host,
+			Action:          "rate_limit",
+			Enabled:         true,
+			RateLimit:       65535,
+			RateLimitWindow: "minute",
+		}); createErr != nil {
+			return fmt.Errorf("creating rule for %s: %w", host, createErr)
+		}
+	}
+
+	if _, err := client.CreateRule(ctx, onecli.CreateRuleInput{
+		Name:        "block-all",
+		HostPattern: "=*",
+		Action:      "block",
+		Enabled:     true,
+	}); err != nil {
+		return fmt.Errorf("creating block-all rule: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -17,14 +17,11 @@ package podman
 import (
 	"context"
 	"fmt"
-	"io"
 	"path/filepath"
-	"strings"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/config"
 	"github.com/openkaiden/kdn/pkg/onecli"
-	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
 )
 
 // loadNetworkConfig reads the merged workspace configuration for a project by
@@ -55,31 +52,14 @@ func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.Wor
 	return merged, nil
 }
 
-// getAPIKeyFromPostgres queries the postgres container for the OneCLI API key
-// by running a psql command inside the pod's postgres container.
-func getAPIKeyFromPostgres(ctx context.Context, podName string, executor exec.Executor) (string, error) {
-	output, err := executor.Output(ctx, io.Discard,
-		"exec", podName+"-postgres",
-		"psql", "-U", "onecli", "-d", "onecli", "-t", "-A",
-		"-c", "select key from api_keys limit 1",
-	)
-	if err != nil {
-		return "", fmt.Errorf("querying postgres for API key: %w", err)
-	}
-	key := strings.TrimSpace(string(output))
-	if key == "" {
-		return "", fmt.Errorf("no API key found in database")
-	}
-	return key, nil
-}
-
 // configureNetworking applies deny-mode network rules to the OneCLI gateway.
 // It first deletes any existing rules (ensuring idempotency across restarts),
 // then creates a rate_limit rule for each allowed host and a catch-all block rule.
-func (p *podmanRuntime) configureNetworking(ctx context.Context, podName, onecliBaseURL string, hosts []string) error {
-	apiKey, err := getAPIKeyFromPostgres(ctx, podName, p.executor)
+func (p *podmanRuntime) configureNetworking(ctx context.Context, onecliBaseURL string, hosts []string) error {
+	creds := onecli.NewCredentialProvider(onecliBaseURL)
+	apiKey, err := creds.APIKey(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get OneCLI API key: %w", err)
 	}
 
 	client := onecli.NewClient(onecliBaseURL, apiKey)
@@ -109,7 +89,7 @@ func (p *podmanRuntime) configureNetworking(ctx context.Context, podName, onecli
 
 	if _, err := client.CreateRule(ctx, onecli.CreateRuleInput{
 		Name:        "block-all",
-		HostPattern: "=*",
+		HostPattern: "*",
 		Action:      "block",
 		Enabled:     true,
 	}); err != nil {

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/config"
@@ -140,4 +142,95 @@ func (p *podmanRuntime) configureNetworking(ctx context.Context, onecliBaseURL s
 	}
 
 	return nil
+}
+
+// setupFirewallRules execs into the network-guard container and configures
+// nftables rules that DROP outbound traffic from the agent's UID, except:
+//   - Loopback (localhost / intra-pod communication including the OneCLI proxy)
+//   - Traffic to host.containers.internal (for host-local LLMs like Ollama/RamaLama)
+//
+// All other UIDs (OneCLI, postgres, approval-handler) retain full outbound access.
+// Rules are idempotent: existing tables are deleted before being recreated.
+// Both IPv4 and IPv6 families are configured.
+func (p *podmanRuntime) setupFirewallRules(ctx context.Context, podName string, agentUID int) error {
+	container := podName + "-network-guard"
+
+	// Resolve host.containers.internal inside the container.
+	// If it cannot be resolved the host-gateway rule is simply skipped.
+	hostGW := p.resolveHostGateway(ctx, container)
+
+	script := buildNftScript(agentUID, hostGW)
+
+	if err := p.executor.Run(ctx, io.Discard, io.Discard,
+		"exec", container, "sh", "-c", script,
+	); err != nil {
+		return fmt.Errorf("failed to set up nftables firewall rules: %w", err)
+	}
+	return nil
+}
+
+// clearFirewallRules removes the nftables filter tables installed by
+// setupFirewallRules, restoring the default ACCEPT policy. This is called on
+// Start() when the workspace is in allow mode to clear leftover rules from a
+// previous deny-mode start.
+func (p *podmanRuntime) clearFirewallRules(ctx context.Context, podName string) error {
+	container := podName + "-network-guard"
+
+	script := "command -v nft >/dev/null 2>&1 || true; nft delete table ip filter 2>/dev/null || true; nft delete table ip6 filter 2>/dev/null || true"
+
+	if err := p.executor.Run(ctx, io.Discard, io.Discard,
+		"exec", container, "sh", "-c", script,
+	); err != nil {
+		return fmt.Errorf("failed to clear nftables firewall rules: %w", err)
+	}
+	return nil
+}
+
+// resolveHostGateway attempts to resolve host.containers.internal inside the
+// given container. Returns the IP string on success or empty string on failure.
+func (p *podmanRuntime) resolveHostGateway(ctx context.Context, container string) string {
+	out, err := p.executor.Output(ctx, io.Discard,
+		"exec", container, "sh", "-c", "getent hosts host.containers.internal | awk '{print $1}'",
+	)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// buildNftScript generates the shell script that sets up nftables OUTPUT rules.
+// The script is executed as a single sh -c invocation inside the network-guard
+// container.
+//
+// Uses a blacklist approach: default policy is ACCEPT, and only the agent UID
+// is blocked from outbound traffic (except loopback and host.containers.internal).
+// All other UIDs (OneCLI, postgres, etc.) retain full outbound access.
+func buildNftScript(agentUID int, hostGW string) string {
+	var parts []string
+
+	// Ensure nftables is installed before applying rules.
+	parts = append(parts, "command -v nft >/dev/null 2>&1 || dnf install -y nftables >/dev/null 2>&1")
+
+	// IPv4 rules — default accept, block agent UID (except loopback + host gateway)
+	parts = append(parts,
+		"nft delete table ip filter 2>/dev/null || true",
+		"nft add table ip filter",
+		"nft add chain ip filter output '{ type filter hook output priority 0; policy accept; }'",
+		"nft add rule ip filter output oif lo accept",
+	)
+	if hostGW != "" {
+		parts = append(parts, fmt.Sprintf("nft add rule ip filter output ip daddr %s accept", hostGW))
+	}
+	parts = append(parts, fmt.Sprintf("nft add rule ip filter output meta skuid %d drop", agentUID))
+
+	// IPv6 rules — mirror
+	parts = append(parts,
+		"nft delete table ip6 filter 2>/dev/null || true",
+		"nft add table ip6 filter",
+		"nft add chain ip6 filter output '{ type filter hook output priority 0; policy accept; }'",
+		"nft add rule ip6 filter output oif lo accept",
+		fmt.Sprintf("nft add rule ip6 filter output meta skuid %d drop", agentUID),
+	)
+
+	return strings.Join(parts, "; ")
 }

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -17,13 +17,16 @@ package podman
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/onecli"
+	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
 )
 
 func assertAuth(t *testing.T, r *http.Request) {
@@ -319,6 +322,201 @@ func TestClearNetworkingRules(t *testing.T) {
 
 		rt := &podmanRuntime{}
 		if err := rt.clearNetworkingRules(context.Background(), server.URL); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestBuildNftScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates IPv4 and IPv6 rules blocking agent UID", func(t *testing.T) {
+		t.Parallel()
+
+		script := buildNftScript(1000, "")
+
+		if !strings.Contains(script, "command -v nft") {
+			t.Error("expected nftables install guard")
+		}
+		if !strings.Contains(script, "nft add table ip filter") {
+			t.Error("expected IPv4 table creation")
+		}
+		if !strings.Contains(script, "nft add table ip6 filter") {
+			t.Error("expected IPv6 table creation")
+		}
+		if !strings.Contains(script, "policy accept") {
+			t.Error("expected ACCEPT default policy")
+		}
+		if !strings.Contains(script, "meta skuid 1000 drop") {
+			t.Error("expected agent UID drop rule")
+		}
+		if !strings.Contains(script, "oif lo accept") {
+			t.Error("expected loopback rule")
+		}
+		if strings.Contains(script, "ip daddr") {
+			t.Error("expected no host-gateway rule when hostGW is empty")
+		}
+	})
+
+	t.Run("includes host-gateway rule when IP provided", func(t *testing.T) {
+		t.Parallel()
+
+		script := buildNftScript(1000, "10.0.2.2")
+
+		if !strings.Contains(script, "nft add rule ip filter output ip daddr 10.0.2.2 accept") {
+			t.Error("expected host-gateway rule for 10.0.2.2")
+		}
+	})
+
+	t.Run("host-gateway rule comes before agent drop rule", func(t *testing.T) {
+		t.Parallel()
+
+		script := buildNftScript(1000, "10.0.2.2")
+
+		hostGWIdx := strings.Index(script, "ip daddr 10.0.2.2 accept")
+		dropIdx := strings.Index(script, "meta skuid 1000 drop")
+		if hostGWIdx >= dropIdx {
+			t.Error("host-gateway accept should come before agent drop rule")
+		}
+	})
+
+	t.Run("idempotent delete before create", func(t *testing.T) {
+		t.Parallel()
+
+		script := buildNftScript(1000, "")
+
+		ipv4DeleteIdx := strings.Index(script, "nft delete table ip filter")
+		ipv4CreateIdx := strings.Index(script, "nft add table ip filter")
+		if ipv4DeleteIdx >= ipv4CreateIdx {
+			t.Error("IPv4 delete should come before create")
+		}
+
+		ipv6DeleteIdx := strings.Index(script, "nft delete table ip6 filter")
+		ipv6CreateIdx := strings.Index(script, "nft add table ip6 filter")
+		if ipv6DeleteIdx >= ipv6CreateIdx {
+			t.Error("IPv6 delete should come before create")
+		}
+	})
+}
+
+func TestSetupFirewallRules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("execs nft commands into network-guard container", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+			if len(args) >= 5 && args[0] == "exec" && args[2] == "sh" && args[3] == "-c" {
+				return []byte("10.0.2.2\n"), nil
+			}
+			return []byte{}, nil
+		}
+
+		rt := &podmanRuntime{executor: fakeExec}
+
+		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
+		if err != nil {
+			t.Fatalf("setupFirewallRules() error: %v", err)
+		}
+
+		found := false
+		for _, call := range fakeExec.RunCalls {
+			if len(call) >= 4 && call[0] == "exec" && call[1] == "my-pod-network-guard" && call[2] == "sh" && call[3] == "-c" {
+				script := call[4]
+				if strings.Contains(script, "meta skuid 1000 drop") && strings.Contains(script, "ip daddr 10.0.2.2") {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Error("expected exec call with nft script including agent UID drop and host-gateway rules")
+		}
+	})
+
+	t.Run("skips host-gateway rule when resolution fails", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+			return nil, fmt.Errorf("getent failed")
+		}
+
+		rt := &podmanRuntime{executor: fakeExec}
+
+		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
+		if err != nil {
+			t.Fatalf("setupFirewallRules() error: %v", err)
+		}
+
+		for _, call := range fakeExec.RunCalls {
+			if len(call) >= 5 && call[0] == "exec" && call[2] == "sh" {
+				if strings.Contains(call[4], "ip daddr") {
+					t.Error("expected no host-gateway rule when resolution fails")
+				}
+			}
+		}
+	})
+
+	t.Run("returns error when exec fails", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+			return fmt.Errorf("exec failed")
+		}
+
+		rt := &podmanRuntime{executor: fakeExec}
+
+		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestClearFirewallRules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("execs delete commands into network-guard container", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		rt := &podmanRuntime{executor: fakeExec}
+
+		err := rt.clearFirewallRules(context.Background(), "my-pod")
+		if err != nil {
+			t.Fatalf("clearFirewallRules() error: %v", err)
+		}
+
+		found := false
+		for _, call := range fakeExec.RunCalls {
+			if len(call) >= 4 && call[0] == "exec" && call[1] == "my-pod-network-guard" && call[2] == "sh" && call[3] == "-c" {
+				script := call[4]
+				if strings.Contains(script, "nft delete table ip filter") && strings.Contains(script, "nft delete table ip6 filter") {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Error("expected exec call with delete table commands")
+		}
+	})
+
+	t.Run("returns error when exec fails", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+			return fmt.Errorf("exec failed")
+		}
+
+		rt := &podmanRuntime{executor: fakeExec}
+
+		err := rt.clearFirewallRules(context.Background(), "my-pod")
+		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
 	})

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/onecli"
+	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
+	"github.com/openkaiden/kdn/pkg/system"
+)
+
+func TestGetAPIKeyFromPostgres(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns key from psql output", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("oc_testkey123\n"), nil
+		}
+
+		key, err := getAPIKeyFromPostgres(context.Background(), "mypod", fakeExec)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if key != "oc_testkey123" {
+			t.Errorf("got key %q, want %q", key, "oc_testkey123")
+		}
+
+		fakeExec.AssertOutputCalledWith(t,
+			"exec", "mypod-postgres",
+			"psql", "-U", "onecli", "-d", "onecli", "-t", "-A",
+			"-c", "select key from api_keys limit 1",
+		)
+	})
+
+	t.Run("returns error when output is empty", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("  \n"), nil
+		}
+
+		_, err := getAPIKeyFromPostgres(context.Background(), "mypod", fakeExec)
+		if err == nil {
+			t.Fatal("expected error for empty key, got nil")
+		}
+	})
+
+	t.Run("returns error when psql fails", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return nil, errors.New("exec failed")
+		}
+
+		_, err := getAPIKeyFromPostgres(context.Background(), "mypod", fakeExec)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestConfigureNetworking(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates allow and block rules", func(t *testing.T) {
+		t.Parallel()
+
+		var createdRules []onecli.CreateRuleInput
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+				var input onecli.CreateRuleInput
+				if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+					t.Errorf("decoding rule: %v", err)
+				}
+				createdRules = append(createdRules, input)
+				_ = json.NewEncoder(w).Encode(onecli.Rule{ID: "new-rule"})
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+		defer server.Close()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("oc_testkey\n"), nil
+		}
+
+		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
+
+		hosts := []string{"api.github.com", "registry.npmjs.org"}
+		err := rt.configureNetworking(context.Background(), "mypod", server.URL, hosts)
+		if err != nil {
+			t.Fatalf("configureNetworking() error: %v", err)
+		}
+
+		// Expect 2 allow rules + 1 block-all rule
+		if len(createdRules) != 3 {
+			t.Fatalf("got %d rules, want 3", len(createdRules))
+		}
+
+		for i, host := range hosts {
+			if createdRules[i].HostPattern != host {
+				t.Errorf("rule[%d].HostPattern = %q, want %q", i, createdRules[i].HostPattern, host)
+			}
+			if createdRules[i].Action != "rate_limit" {
+				t.Errorf("rule[%d].Action = %q, want %q", i, createdRules[i].Action, "rate_limit")
+			}
+			if createdRules[i].RateLimit != 65535 {
+				t.Errorf("rule[%d].RateLimit = %d, want 65535", i, createdRules[i].RateLimit)
+			}
+			if createdRules[i].RateLimitWindow != "minute" {
+				t.Errorf("rule[%d].RateLimitWindow = %q, want %q", i, createdRules[i].RateLimitWindow, "minute")
+			}
+		}
+
+		last := createdRules[2]
+		if last.HostPattern != "=*" {
+			t.Errorf("block-all HostPattern = %q, want %q", last.HostPattern, "=*")
+		}
+		if last.Action != "block" {
+			t.Errorf("block-all Action = %q, want %q", last.Action, "block")
+		}
+	})
+
+	t.Run("deletes existing rules before creating new ones", func(t *testing.T) {
+		t.Parallel()
+
+		deletedIDs := []string{}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				existing := []onecli.Rule{
+					{ID: "old-1", Name: "old-rule-1", HostPattern: "old.example.com", Action: "rate_limit"},
+					{ID: "old-2", Name: "block-all", HostPattern: "*", Action: "block"},
+				}
+				_ = json.NewEncoder(w).Encode(existing)
+			case r.Method == http.MethodDelete:
+				id := r.URL.Path[len("/api/rules/"):]
+				deletedIDs = append(deletedIDs, id)
+				w.WriteHeader(http.StatusNoContent)
+			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+				_ = json.NewEncoder(w).Encode(onecli.Rule{ID: "new-rule"})
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+		defer server.Close()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("oc_testkey\n"), nil
+		}
+
+		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
+		err := rt.configureNetworking(context.Background(), "mypod", server.URL, []string{"api.github.com"})
+		if err != nil {
+			t.Fatalf("configureNetworking() error: %v", err)
+		}
+
+		if len(deletedIDs) != 2 {
+			t.Errorf("deleted %d rules, want 2", len(deletedIDs))
+		}
+	})
+
+	t.Run("handles empty hosts with only block-all rule", func(t *testing.T) {
+		t.Parallel()
+
+		var createdRules []onecli.CreateRuleInput
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+				var input onecli.CreateRuleInput
+				_ = json.NewDecoder(r.Body).Decode(&input)
+				createdRules = append(createdRules, input)
+				_ = json.NewEncoder(w).Encode(onecli.Rule{ID: "new-rule"})
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+		defer server.Close()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("oc_testkey\n"), nil
+		}
+
+		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
+		err := rt.configureNetworking(context.Background(), "mypod", server.URL, []string{})
+		if err != nil {
+			t.Fatalf("configureNetworking() error: %v", err)
+		}
+
+		if len(createdRules) != 1 {
+			t.Fatalf("got %d rules, want 1 (block-all)", len(createdRules))
+		}
+		if createdRules[0].HostPattern != "=*" || createdRules[0].Action != "block" {
+			t.Errorf("expected block-all rule, got %+v", createdRules[0])
+		}
+	})
+
+	t.Run("returns error when postgres key retrieval fails", func(t *testing.T) {
+		t.Parallel()
+
+		fakeExec := exec.NewFake()
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return nil, errors.New("container not found")
+		}
+
+		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
+		err := rt.configureNetworking(context.Background(), "mypod", "http://localhost:9999", []string{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -19,15 +19,24 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/onecli"
 )
 
+func assertAuth(t *testing.T, r *http.Request) {
+	t.Helper()
+	if got, want := r.Header.Get("Authorization"), "Bearer oc_testkey"; got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
 func TestConfigureNetworking(t *testing.T) {
 	t.Parallel()
 
-	t.Run("creates allow and block rules", func(t *testing.T) {
+	t.Run("creates manual_approval rule and writes config", func(t *testing.T) {
 		t.Parallel()
 
 		var createdRules []onecli.CreateRuleInput
@@ -37,8 +46,10 @@ func TestConfigureNetworking(t *testing.T) {
 			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
 				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
 			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
 				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
 				var input onecli.CreateRuleInput
 				if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 					t.Errorf("decoding rule: %v", err)
@@ -53,39 +64,49 @@ func TestConfigureNetworking(t *testing.T) {
 		defer server.Close()
 
 		rt := &podmanRuntime{}
+		approvalDir := t.TempDir()
 
 		hosts := []string{"api.github.com", "registry.npmjs.org"}
-		err := rt.configureNetworking(context.Background(), server.URL, hosts)
+		err := rt.configureNetworking(context.Background(), server.URL, hosts, approvalDir)
 		if err != nil {
 			t.Fatalf("configureNetworking() error: %v", err)
 		}
 
-		// Expect 2 allow rules + 1 block-all rule
-		if len(createdRules) != 3 {
-			t.Fatalf("got %d rules, want 3", len(createdRules))
+		if len(createdRules) != 1 {
+			t.Fatalf("got %d rules, want 1", len(createdRules))
 		}
 
-		for i, host := range hosts {
-			if createdRules[i].HostPattern != host {
-				t.Errorf("rule[%d].HostPattern = %q, want %q", i, createdRules[i].HostPattern, host)
-			}
-			if createdRules[i].Action != "rate_limit" {
-				t.Errorf("rule[%d].Action = %q, want %q", i, createdRules[i].Action, "rate_limit")
-			}
-			if createdRules[i].RateLimit != 65535 {
-				t.Errorf("rule[%d].RateLimit = %d, want 65535", i, createdRules[i].RateLimit)
-			}
-			if createdRules[i].RateLimitWindow != "minute" {
-				t.Errorf("rule[%d].RateLimitWindow = %q, want %q", i, createdRules[i].RateLimitWindow, "minute")
-			}
+		rule := createdRules[0]
+		if rule.HostPattern != "*" {
+			t.Errorf("rule.HostPattern = %q, want %q", rule.HostPattern, "*")
+		}
+		if rule.Action != "manual_approval" {
+			t.Errorf("rule.Action = %q, want %q", rule.Action, "manual_approval")
+		}
+		if rule.Name != "manual-approval-all" {
+			t.Errorf("rule.Name = %q, want %q", rule.Name, "manual-approval-all")
 		}
 
-		last := createdRules[2]
-		if last.HostPattern != "*" {
-			t.Errorf("block-all HostPattern = %q, want %q", last.HostPattern, "*")
+		// Verify config.json was written with correct content
+		data, err := os.ReadFile(filepath.Join(approvalDir, "config.json"))
+		if err != nil {
+			t.Fatalf("reading config.json: %v", err)
 		}
-		if last.Action != "block" {
-			t.Errorf("block-all Action = %q, want %q", last.Action, "block")
+		var cfg approvalHandlerConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("unmarshaling config.json: %v", err)
+		}
+		if cfg.OnecliURL != "http://localhost:10254" {
+			t.Errorf("config.onecliUrl = %q, want %q", cfg.OnecliURL, "http://localhost:10254")
+		}
+		if cfg.GatewayURL != "http://localhost:10255" {
+			t.Errorf("config.gatewayUrl = %q, want %q", cfg.GatewayURL, "http://localhost:10255")
+		}
+		if cfg.APIKey != "oc_testkey" {
+			t.Errorf("config.apiKey = %q, want %q", cfg.APIKey, "oc_testkey")
+		}
+		if len(cfg.Hosts) != 2 || cfg.Hosts[0] != "api.github.com" || cfg.Hosts[1] != "registry.npmjs.org" {
+			t.Errorf("config.hosts = %v, want [api.github.com registry.npmjs.org]", cfg.Hosts)
 		}
 	})
 
@@ -93,22 +114,28 @@ func TestConfigureNetworking(t *testing.T) {
 		t.Parallel()
 
 		deletedIDs := []string{}
+		operations := []string{}
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
 				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
 			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
 				existing := []onecli.Rule{
 					{ID: "old-1", Name: "old-rule-1", HostPattern: "old.example.com", Action: "rate_limit"},
 					{ID: "old-2", Name: "block-all", HostPattern: "*", Action: "block"},
 				}
 				_ = json.NewEncoder(w).Encode(existing)
 			case r.Method == http.MethodDelete:
+				assertAuth(t, r)
 				id := r.URL.Path[len("/api/rules/"):]
 				deletedIDs = append(deletedIDs, id)
+				operations = append(operations, "delete:"+id)
 				w.WriteHeader(http.StatusNoContent)
 			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
+				operations = append(operations, "create")
 				_ = json.NewEncoder(w).Encode(onecli.Rule{ID: "new-rule"})
 			default:
 				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -118,17 +145,36 @@ func TestConfigureNetworking(t *testing.T) {
 		defer server.Close()
 
 		rt := &podmanRuntime{}
-		err := rt.configureNetworking(context.Background(), server.URL, []string{"api.github.com"})
+		approvalDir := t.TempDir()
+		err := rt.configureNetworking(context.Background(), server.URL, []string{"api.github.com"}, approvalDir)
 		if err != nil {
 			t.Fatalf("configureNetworking() error: %v", err)
 		}
 
-		if len(deletedIDs) != 2 {
-			t.Errorf("deleted %d rules, want 2", len(deletedIDs))
+		// Assert exact deleted IDs
+		wantDeleted := []string{"old-1", "old-2"}
+		if len(deletedIDs) != len(wantDeleted) {
+			t.Fatalf("deletedIDs = %v, want %v", deletedIDs, wantDeleted)
+		}
+		for i, want := range wantDeleted {
+			if deletedIDs[i] != want {
+				t.Fatalf("deletedIDs = %v, want %v", deletedIDs, wantDeleted)
+			}
+		}
+
+		// Assert all deletes happened before creates
+		wantOps := []string{"delete:old-1", "delete:old-2", "create"}
+		if len(operations) != len(wantOps) {
+			t.Fatalf("operations = %v, want %v", operations, wantOps)
+		}
+		for i, want := range wantOps {
+			if operations[i] != want {
+				t.Fatalf("operations = %v, want deletes before creates", operations)
+			}
 		}
 	})
 
-	t.Run("handles empty hosts with only block-all rule", func(t *testing.T) {
+	t.Run("handles empty hosts with manual_approval rule", func(t *testing.T) {
 		t.Parallel()
 
 		var createdRules []onecli.CreateRuleInput
@@ -138,8 +184,10 @@ func TestConfigureNetworking(t *testing.T) {
 			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
 				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
 			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
 				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
 				var input onecli.CreateRuleInput
 				_ = json.NewDecoder(r.Body).Decode(&input)
 				createdRules = append(createdRules, input)
@@ -151,16 +199,30 @@ func TestConfigureNetworking(t *testing.T) {
 		defer server.Close()
 
 		rt := &podmanRuntime{}
-		err := rt.configureNetworking(context.Background(), server.URL, []string{})
+		approvalDir := t.TempDir()
+		err := rt.configureNetworking(context.Background(), server.URL, []string{}, approvalDir)
 		if err != nil {
 			t.Fatalf("configureNetworking() error: %v", err)
 		}
 
 		if len(createdRules) != 1 {
-			t.Fatalf("got %d rules, want 1 (block-all)", len(createdRules))
+			t.Fatalf("got %d rules, want 1 (manual_approval)", len(createdRules))
 		}
-		if createdRules[0].HostPattern != "*" || createdRules[0].Action != "block" {
-			t.Errorf("expected block-all rule, got %+v", createdRules[0])
+		if createdRules[0].Action != "manual_approval" || createdRules[0].HostPattern != "*" {
+			t.Errorf("expected manual_approval rule, got %+v", createdRules[0])
+		}
+
+		// Verify config.json has empty hosts
+		data, err := os.ReadFile(filepath.Join(approvalDir, "config.json"))
+		if err != nil {
+			t.Fatalf("reading config.json: %v", err)
+		}
+		var cfg approvalHandlerConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("unmarshaling config.json: %v", err)
+		}
+		if len(cfg.Hosts) != 0 {
+			t.Errorf("config.hosts = %v, want empty", cfg.Hosts)
 		}
 	})
 
@@ -173,8 +235,90 @@ func TestConfigureNetworking(t *testing.T) {
 		defer server.Close()
 
 		rt := &podmanRuntime{}
-		err := rt.configureNetworking(context.Background(), server.URL, []string{})
+		approvalDir := t.TempDir()
+		err := rt.configureNetworking(context.Background(), server.URL, []string{}, approvalDir)
 		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestClearNetworkingRules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deletes all existing rules", func(t *testing.T) {
+		t.Parallel()
+
+		deletedIDs := []string{}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				assertAuth(t, r)
+				existing := []onecli.Rule{
+					{ID: "rule-1", Name: "manual-approval-all", HostPattern: "*", Action: "manual_approval"},
+					{ID: "rule-2", Name: "old-rule", HostPattern: "example.com", Action: "block"},
+				}
+				_ = json.NewEncoder(w).Encode(existing)
+			case r.Method == http.MethodDelete:
+				assertAuth(t, r)
+				deletedIDs = append(deletedIDs, r.URL.Path[len("/api/rules/"):])
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+		defer server.Close()
+
+		rt := &podmanRuntime{}
+		err := rt.clearNetworkingRules(context.Background(), server.URL)
+		if err != nil {
+			t.Fatalf("clearNetworkingRules() error: %v", err)
+		}
+
+		if len(deletedIDs) != 2 {
+			t.Fatalf("expected 2 deletions, got %d: %v", len(deletedIDs), deletedIDs)
+		}
+		if deletedIDs[0] != "rule-1" || deletedIDs[1] != "rule-2" {
+			t.Errorf("deleted IDs = %v, want [rule-1 rule-2]", deletedIDs)
+		}
+	})
+
+	t.Run("succeeds when no rules exist", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+		defer server.Close()
+
+		rt := &podmanRuntime{}
+		if err := rt.clearNetworkingRules(context.Background(), server.URL); err != nil {
+			t.Fatalf("clearNetworkingRules() error: %v", err)
+		}
+	})
+
+	t.Run("returns error when API key retrieval fails", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		rt := &podmanRuntime{}
+		if err := rt.clearNetworkingRules(context.Background(), server.URL); err == nil {
 			t.Fatal("expected error, got nil")
 		}
 	})

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -17,70 +17,12 @@ package podman
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/onecli"
-	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
-	"github.com/openkaiden/kdn/pkg/system"
 )
-
-func TestGetAPIKeyFromPostgres(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns key from psql output", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return []byte("oc_testkey123\n"), nil
-		}
-
-		key, err := getAPIKeyFromPostgres(context.Background(), "mypod", fakeExec)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if key != "oc_testkey123" {
-			t.Errorf("got key %q, want %q", key, "oc_testkey123")
-		}
-
-		fakeExec.AssertOutputCalledWith(t,
-			"exec", "mypod-postgres",
-			"psql", "-U", "onecli", "-d", "onecli", "-t", "-A",
-			"-c", "select key from api_keys limit 1",
-		)
-	})
-
-	t.Run("returns error when output is empty", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return []byte("  \n"), nil
-		}
-
-		_, err := getAPIKeyFromPostgres(context.Background(), "mypod", fakeExec)
-		if err == nil {
-			t.Fatal("expected error for empty key, got nil")
-		}
-	})
-
-	t.Run("returns error when psql fails", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return nil, errors.New("exec failed")
-		}
-
-		_, err := getAPIKeyFromPostgres(context.Background(), "mypod", fakeExec)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-	})
-}
 
 func TestConfigureNetworking(t *testing.T) {
 	t.Parallel()
@@ -92,6 +34,8 @@ func TestConfigureNetworking(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
 			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
 				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
@@ -108,15 +52,10 @@ func TestConfigureNetworking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return []byte("oc_testkey\n"), nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
+		rt := &podmanRuntime{}
 
 		hosts := []string{"api.github.com", "registry.npmjs.org"}
-		err := rt.configureNetworking(context.Background(), "mypod", server.URL, hosts)
+		err := rt.configureNetworking(context.Background(), server.URL, hosts)
 		if err != nil {
 			t.Fatalf("configureNetworking() error: %v", err)
 		}
@@ -142,8 +81,8 @@ func TestConfigureNetworking(t *testing.T) {
 		}
 
 		last := createdRules[2]
-		if last.HostPattern != "=*" {
-			t.Errorf("block-all HostPattern = %q, want %q", last.HostPattern, "=*")
+		if last.HostPattern != "*" {
+			t.Errorf("block-all HostPattern = %q, want %q", last.HostPattern, "*")
 		}
 		if last.Action != "block" {
 			t.Errorf("block-all Action = %q, want %q", last.Action, "block")
@@ -157,6 +96,8 @@ func TestConfigureNetworking(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
 			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
 				existing := []onecli.Rule{
 					{ID: "old-1", Name: "old-rule-1", HostPattern: "old.example.com", Action: "rate_limit"},
@@ -176,13 +117,8 @@ func TestConfigureNetworking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return []byte("oc_testkey\n"), nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
-		err := rt.configureNetworking(context.Background(), "mypod", server.URL, []string{"api.github.com"})
+		rt := &podmanRuntime{}
+		err := rt.configureNetworking(context.Background(), server.URL, []string{"api.github.com"})
 		if err != nil {
 			t.Fatalf("configureNetworking() error: %v", err)
 		}
@@ -199,6 +135,8 @@ func TestConfigureNetworking(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+				_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
 			case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
 				_ = json.NewEncoder(w).Encode([]onecli.Rule{})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
@@ -212,13 +150,8 @@ func TestConfigureNetworking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return []byte("oc_testkey\n"), nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
-		err := rt.configureNetworking(context.Background(), "mypod", server.URL, []string{})
+		rt := &podmanRuntime{}
+		err := rt.configureNetworking(context.Background(), server.URL, []string{})
 		if err != nil {
 			t.Fatalf("configureNetworking() error: %v", err)
 		}
@@ -226,21 +159,21 @@ func TestConfigureNetworking(t *testing.T) {
 		if len(createdRules) != 1 {
 			t.Fatalf("got %d rules, want 1 (block-all)", len(createdRules))
 		}
-		if createdRules[0].HostPattern != "=*" || createdRules[0].Action != "block" {
+		if createdRules[0].HostPattern != "*" || createdRules[0].Action != "block" {
 			t.Errorf("expected block-all rule, got %+v", createdRules[0])
 		}
 	})
 
-	t.Run("returns error when postgres key retrieval fails", func(t *testing.T) {
+	t.Run("returns error when API key retrieval fails", func(t *testing.T) {
 		t.Parallel()
 
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
-			return nil, errors.New("container not found")
-		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
 
-		rt := &podmanRuntime{executor: fakeExec, system: system.New()}
-		err := rt.configureNetworking(context.Background(), "mypod", "http://localhost:9999", []string{})
+		rt := &podmanRuntime{}
+		err := rt.configureNetworking(context.Background(), server.URL, []string{})
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
+	podmanSystem "github.com/openkaiden/kdn/pkg/runtime/podman/system"
 	"github.com/openkaiden/kdn/pkg/system"
 )
 
@@ -192,6 +193,7 @@ func (p *podmanRuntime) readPodTemplateData(containerID string) (podTemplateData
 	if err := json.Unmarshal(data, &tmplData); err != nil {
 		return podTemplateData{}, fmt.Errorf("failed to unmarshal pod template data: %w", err)
 	}
+	tmplData.ApprovalHandlerDir = podmanSystem.MachinePathToHostPath(tmplData.ApprovalHandlerDir)
 	return tmplData, nil
 }
 

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -30,10 +30,19 @@ import (
 
 // podmanRuntime implements the runtime.Runtime interface for Podman.
 type podmanRuntime struct {
-	system     system.System
-	executor   exec.Executor
-	storageDir string        // Directory for storing runtime-specific data
-	config     config.Config // Configuration manager for runtime settings
+	system          system.System
+	executor        exec.Executor
+	storageDir      string        // Directory for storing runtime-specific data
+	config          config.Config // Configuration manager for runtime settings
+	onecliBaseURLFn func(port int) string // overridable in tests; nil uses default http://localhost:<port>
+}
+
+// onecliURL returns the base URL for the OneCLI service on the given port.
+func (p *podmanRuntime) onecliURL(port int) string {
+	if p.onecliBaseURLFn != nil {
+		return p.onecliBaseURLFn(port)
+	}
+	return fmt.Sprintf("http://localhost:%d", port)
 }
 
 // Ensure podmanRuntime implements runtime.Runtime at compile time.

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -32,8 +32,9 @@ import (
 type podmanRuntime struct {
 	system          system.System
 	executor        exec.Executor
-	storageDir      string        // Directory for storing runtime-specific data
-	config          config.Config // Configuration manager for runtime settings
+	storageDir      string                // Runtime-specific storage: <globalStorageDir>/runtimes/podman
+	globalStorageDir string               // Top-level kdn storage dir: where config/projects.json lives
+	config          config.Config         // Configuration manager for runtime settings
 	onecliBaseURLFn func(port int) string // overridable in tests; nil uses default http://localhost:<port>
 }
 
@@ -80,6 +81,8 @@ func (p *podmanRuntime) Initialize(storageDir string) error {
 		return fmt.Errorf("storage directory cannot be empty")
 	}
 	p.storageDir = storageDir
+	// storageDir is <globalStorageDir>/runtimes/podman; the global dir is two levels up.
+	p.globalStorageDir = filepath.Dir(filepath.Dir(storageDir))
 
 	// Create config directory
 	configDir := filepath.Join(storageDir, "config")

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -30,12 +30,12 @@ import (
 
 // podmanRuntime implements the runtime.Runtime interface for Podman.
 type podmanRuntime struct {
-	system          system.System
-	executor        exec.Executor
-	storageDir      string                // Runtime-specific storage: <globalStorageDir>/runtimes/podman
-	globalStorageDir string               // Top-level kdn storage dir: where config/projects.json lives
-	config          config.Config         // Configuration manager for runtime settings
-	onecliBaseURLFn func(port int) string // overridable in tests; nil uses default http://localhost:<port>
+	system           system.System
+	executor         exec.Executor
+	storageDir       string                // Runtime-specific storage: <globalStorageDir>/runtimes/podman
+	globalStorageDir string                // Top-level kdn storage dir: where config/projects.json lives
+	config           config.Config         // Configuration manager for runtime settings
+	onecliBaseURLFn  func(port int) string // overridable in tests; nil uses default http://localhost:<port>
 }
 
 // onecliURL returns the base URL for the OneCLI service on the given port.

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -189,9 +189,12 @@ func TestWritePodFiles(t *testing.T) {
 		containerID := "abc123"
 
 		data := podTemplateData{
-			Name:          "my-project",
-			OnecliWebPort: 30001,
-			OnecliVersion: "1.17",
+			Name:              "my-project",
+			OnecliWebPort:     30001,
+			OnecliVersion:     "1.17",
+			AgentUID:          1000,
+			BaseImageRegistry: "registry.fedoraproject.org/fedora",
+			BaseImageVersion:  "latest",
 		}
 
 		err := p.writePodFiles(containerID, data)
@@ -229,9 +232,12 @@ func TestWritePodFiles(t *testing.T) {
 		containerID := "def456"
 
 		data := podTemplateData{
-			Name:          "test-ws",
-			OnecliWebPort: 40001,
-			OnecliVersion: "1.17",
+			Name:              "test-ws",
+			OnecliWebPort:     40001,
+			OnecliVersion:     "1.17",
+			AgentUID:          1000,
+			BaseImageRegistry: "registry.fedoraproject.org/fedora",
+			BaseImageVersion:  "latest",
 		}
 
 		err := p.writePodFiles(containerID, data)
@@ -268,9 +274,12 @@ func TestCleanupPodFiles(t *testing.T) {
 	containerID := "abc123"
 
 	data := podTemplateData{
-		Name:          "my-ws",
-		OnecliWebPort: 50001,
-		OnecliVersion: "1.17",
+		Name:              "my-ws",
+		OnecliWebPort:     50001,
+		OnecliVersion:     "1.17",
+		AgentUID:          1000,
+		BaseImageRegistry: "registry.fedoraproject.org/fedora",
+		BaseImageVersion:  "latest",
 	}
 
 	if err := p.writePodFiles(containerID, data); err != nil {
@@ -298,6 +307,9 @@ func TestRenderPodYAML(t *testing.T) {
 			Name:               "my-project",
 			OnecliWebPort:      32101,
 			OnecliVersion:      "1.17",
+			AgentUID:           1000,
+			BaseImageRegistry:  "registry.fedoraproject.org/fedora",
+			BaseImageVersion:   "latest",
 			ApprovalHandlerDir: "/tmp/approval-handler/my-project",
 		}
 
@@ -326,6 +338,15 @@ func TestRenderPodYAML(t *testing.T) {
 		if !strings.Contains(yamlStr, "volumeMounts") {
 			t.Error("Expected rendered YAML to contain volumeMounts for approval-handler")
 		}
+		if !strings.Contains(yamlStr, "network-guard") {
+			t.Error("Expected rendered YAML to contain network-guard container")
+		}
+		if !strings.Contains(yamlStr, "NET_ADMIN") {
+			t.Error("Expected rendered YAML to contain NET_ADMIN capability for network-guard")
+		}
+		if !strings.Contains(yamlStr, "registry.fedoraproject.org/fedora:latest") {
+			t.Error("Expected rendered YAML to contain base image for network-guard")
+		}
 
 		// Postgres (5432) and proxy (10255) ports should NOT have hostPort mappings
 		if strings.Contains(yamlStr, "hostPort: 5432") {
@@ -343,6 +364,9 @@ func TestRenderPodYAML(t *testing.T) {
 			Name:               "test",
 			OnecliWebPort:      10001,
 			OnecliVersion:      "2.0",
+			AgentUID:           1000,
+			BaseImageRegistry:  "registry.fedoraproject.org/fedora",
+			BaseImageVersion:   "42",
 			ApprovalHandlerDir: "/tmp/approval-handler/test",
 		}
 

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -295,9 +295,10 @@ func TestRenderPodYAML(t *testing.T) {
 		t.Parallel()
 
 		data := podTemplateData{
-			Name:          "my-project",
-			OnecliWebPort: 32101,
-			OnecliVersion: "1.17",
+			Name:               "my-project",
+			OnecliWebPort:      32101,
+			OnecliVersion:      "1.17",
+			ApprovalHandlerDir: "/tmp/approval-handler/my-project",
 		}
 
 		result, err := renderPodYAML(data)
@@ -316,11 +317,14 @@ func TestRenderPodYAML(t *testing.T) {
 		if !strings.Contains(yamlStr, "ghcr.io/onecli/onecli:1.17") {
 			t.Error("Expected rendered YAML to contain versioned onecli image")
 		}
-		if strings.Contains(yamlStr, "volumeMounts") {
-			t.Error("Expected rendered YAML to NOT contain volumeMounts")
+		if !strings.Contains(yamlStr, "approval-handler") {
+			t.Error("Expected rendered YAML to contain approval-handler container")
 		}
-		if strings.Contains(yamlStr, "volumes:") {
-			t.Error("Expected rendered YAML to NOT contain volumes section")
+		if !strings.Contains(yamlStr, "/tmp/approval-handler/my-project") {
+			t.Error("Expected rendered YAML to contain approval handler hostPath")
+		}
+		if !strings.Contains(yamlStr, "volumeMounts") {
+			t.Error("Expected rendered YAML to contain volumeMounts for approval-handler")
 		}
 
 		// Postgres (5432) and proxy (10255) ports should NOT have hostPort mappings
@@ -336,9 +340,10 @@ func TestRenderPodYAML(t *testing.T) {
 		t.Parallel()
 
 		data := podTemplateData{
-			Name:          "test",
-			OnecliWebPort: 10001,
-			OnecliVersion: "2.0",
+			Name:               "test",
+			OnecliWebPort:      10001,
+			OnecliVersion:      "2.0",
+			ApprovalHandlerDir: "/tmp/approval-handler/test",
 		}
 
 		result, err := renderPodYAML(data)

--- a/pkg/runtime/podman/pods/approval-handler-package.json
+++ b/pkg/runtime/podman/pods/approval-handler-package.json
@@ -1,0 +1,8 @@
+{
+  "name": "approval-handler",
+  "private": true,
+  "dependencies": {
+    "@onecli-sh/sdk": "latest",
+    "tsx": "latest"
+  }
+}

--- a/pkg/runtime/podman/pods/approval-handler.ts
+++ b/pkg/runtime/podman/pods/approval-handler.ts
@@ -45,10 +45,12 @@ const onecli = new OneCLI({
 
 function matchesPattern(pattern: string, hostname: string): boolean {
   if (pattern === "*") return true;
-  if (!pattern.includes("*")) return pattern === hostname;
-  // Convert glob to regex: * matches one hostname segment (no dots)
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-  return new RegExp("^" + escaped.replace(/\*/g, "[^.]+") + "$").test(hostname);
+  // *.github.com matches api.github.com but not github.com itself
+  if (pattern.startsWith("*.")) {
+    const suffix = pattern.slice(1); // ".github.com"
+    return hostname.endsWith(suffix) && hostname.length > suffix.length;
+  }
+  return pattern === hostname;
 }
 
 const handle = onecli.configureManualApproval(async (request) => {

--- a/pkg/runtime/podman/pods/approval-handler.ts
+++ b/pkg/runtime/podman/pods/approval-handler.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { OneCLI } from "@onecli-sh/sdk";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface Config {
+  onecliUrl: string;
+  gatewayUrl: string;
+  apiKey: string;
+  hosts: string[];
+}
+
+const CONFIG_PATH = join(__dirname, "config.json");
+
+if (!existsSync(CONFIG_PATH)) {
+  console.log("approval-handler: no config.json found, exiting (allow mode)");
+  process.exit(0);
+}
+
+const config: Config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+const allowedHosts = new Set(config.hosts ?? []);
+
+console.log(
+  `approval-handler: loaded ${allowedHosts.size} allowed host(s), connecting to ${config.onecliUrl}`,
+);
+
+const onecli = new OneCLI({
+  url: config.onecliUrl,
+  gatewayUrl: config.gatewayUrl,
+  apiKey: config.apiKey,
+});
+
+const handle = onecli.configureManualApproval(async (request) => {
+  // Strip port from host (e.g. "api.github.com:443" → "api.github.com")
+  const hostname = request.host.split(":")[0];
+  const decision = allowedHosts.has(hostname) ? "approve" : "deny";
+  console.log(`approval-handler: ${decision} ${request.host} (hostname: ${hostname})`);
+  return decision;
+});
+
+console.log("approval-handler: listening for approval requests");
+
+// Keep the process alive — the SDK polls for approval requests but may not
+// hold the event loop open on its own.
+const keepalive = setInterval(() => {}, 1 << 30);
+
+process.on("SIGTERM", () => {
+  console.log("approval-handler: received SIGTERM, stopping");
+  clearInterval(keepalive);
+  handle.stop();
+});

--- a/pkg/runtime/podman/pods/approval-handler.ts
+++ b/pkg/runtime/podman/pods/approval-handler.ts
@@ -46,7 +46,7 @@ const onecli = new OneCLI({
 const handle = onecli.configureManualApproval(async (request) => {
   // Strip port from host (e.g. "api.github.com:443" → "api.github.com")
   const hostname = request.host.split(":")[0];
-  const decision = allowedHosts.has(hostname) ? "approve" : "deny";
+  const decision = allowedHosts.has("*") || allowedHosts.has(hostname) ? "approve" : "deny";
   console.log(`approval-handler: ${decision} ${request.host} (hostname: ${hostname})`);
   return decision;
 });

--- a/pkg/runtime/podman/pods/approval-handler.ts
+++ b/pkg/runtime/podman/pods/approval-handler.ts
@@ -57,8 +57,12 @@ console.log("approval-handler: listening for approval requests");
 // hold the event loop open on its own.
 const keepalive = setInterval(() => {}, 1 << 30);
 
-process.on("SIGTERM", () => {
-  console.log("approval-handler: received SIGTERM, stopping");
+function shutdown(signal: string): void {
+  console.log(`approval-handler: received ${signal}, stopping`);
   clearInterval(keepalive);
   handle.stop();
-});
+}
+
+// SIGTERM on Linux/macOS; SIGINT covers Ctrl+C on all platforms including Windows.
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/pkg/runtime/podman/pods/approval-handler.ts
+++ b/pkg/runtime/podman/pods/approval-handler.ts
@@ -43,10 +43,18 @@ const onecli = new OneCLI({
   apiKey: config.apiKey,
 });
 
+function matchesPattern(pattern: string, hostname: string): boolean {
+  if (pattern === "*") return true;
+  if (!pattern.includes("*")) return pattern === hostname;
+  // Convert glob to regex: * matches one hostname segment (no dots)
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  return new RegExp("^" + escaped.replace(/\*/g, "[^.]+") + "$").test(hostname);
+}
+
 const handle = onecli.configureManualApproval(async (request) => {
   // Strip port from host (e.g. "api.github.com:443" → "api.github.com")
   const hostname = request.host.split(":")[0];
-  const decision = allowedHosts.has("*") || allowedHosts.has(hostname) ? "approve" : "deny";
+  const decision = [...allowedHosts].some((p) => matchesPattern(p, hostname)) ? "approve" : "deny";
   console.log(`approval-handler: ${decision} ${request.host} (hostname: ${hostname})`);
   return decision;
 });

--- a/pkg/runtime/podman/pods/embed.go
+++ b/pkg/runtime/podman/pods/embed.go
@@ -18,3 +18,9 @@ import _ "embed"
 
 //go:embed onecli-pod.yaml
 var OnecliPodYAML []byte
+
+//go:embed approval-handler.ts
+var ApprovalHandlerTS []byte
+
+//go:embed approval-handler-package.json
+var ApprovalHandlerPackageJSON []byte

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -54,7 +54,7 @@ spec:
 
     - name: approval-handler
       image: registry.access.redhat.com/ubi9/nodejs-22-minimal
-      command: ["sh", "-c", "cp /app/* . && npm install --omit=optional && npx tsx approval-handler.ts"]
+      command: ["sh", "-c", "cp /app/approval-handler.ts /app/package.json . && npm install --omit=optional && npx tsx approval-handler.ts"]
       volumeMounts:
         - name: approval-handler
           mountPath: /app

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -54,7 +54,7 @@ spec:
 
     - name: approval-handler
       image: registry.access.redhat.com/ubi9/nodejs-22-minimal
-      command: ["sh", "-c", "cp /app/approval-handler.ts /app/package.json . && npm install --omit=optional && npx tsx approval-handler.ts"]
+      command: ["sh", "-c", "cp /app/approval-handler.ts /app/package.json . && cp /app/config.json . 2>/dev/null; npm install --omit=optional && npx tsx approval-handler.ts"]
       volumeMounts:
         - name: approval-handler
           mountPath: /app

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -58,3 +58,10 @@ spec:
       volumeMounts:
         - name: approval-handler
           mountPath: /app
+
+    - name: network-guard
+      image: {{.BaseImageRegistry}}:{{.BaseImageVersion}}
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN"]
+      command: ["sleep", "infinity"]

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -9,6 +9,10 @@ spec:
   # avoid migration race conditions. OnFailure/Always would restart onecli before
   # postgres is ready, causing repeated migration failures.
   restartPolicy: Never
+  volumes:
+    - name: approval-handler
+      hostPath:
+        path: {{.ApprovalHandlerDir}}
   containers:
     - name: postgres
       image: docker.io/library/postgres:18-alpine
@@ -47,3 +51,10 @@ spec:
         - containerPort: 10254
           hostPort: {{.OnecliWebPort}}
           hostIP: "127.0.0.1"
+
+    - name: approval-handler
+      image: registry.access.redhat.com/ubi9/nodejs-22-minimal
+      command: ["sh", "-c", "cd /app && npm install --omit=optional && npx tsx approval-handler.ts"]
+      volumeMounts:
+        - name: approval-handler
+          mountPath: /app

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -54,7 +54,7 @@ spec:
 
     - name: approval-handler
       image: registry.access.redhat.com/ubi9/nodejs-22-minimal
-      command: ["sh", "-c", "cp /app/approval-handler.ts /app/package.json . && cp /app/config.json . 2>/dev/null; npm install --omit=optional && npx tsx approval-handler.ts"]
+      command: ["sh", "-c", "cp /app/* . 2>/dev/null; npm install --omit=optional && npx tsx approval-handler.ts"]
       volumeMounts:
         - name: approval-handler
           mountPath: /app

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -54,7 +54,7 @@ spec:
 
     - name: approval-handler
       image: registry.access.redhat.com/ubi9/nodejs-22-minimal
-      command: ["sh", "-c", "cd /app && npm install --omit=optional && npx tsx approval-handler.ts"]
+      command: ["sh", "-c", "cp /app/* . && npm install --omit=optional && npx tsx approval-handler.ts"]
       volumeMounts:
         - name: approval-handler
           mountPath: /app

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -33,8 +33,11 @@ const (
 )
 
 // Start starts all containers in the workspace pod.
-// Postgres is started first and verified ready before starting the remaining
-// containers so that onecli can connect to the database immediately.
+// Postgres and onecli are started individually first. When the workspace is
+// configured with mode: deny and at least one allowed host, networking rules and
+// the approval-handler config are set up before the remaining containers are
+// started. In all other cases (allow, no config, deny without hosts) any stale
+// rules from a previous deny-mode start are cleared before the pod is started.
 func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
 	stepLogger := steplogger.FromContext(ctx)
 	defer stepLogger.Complete()
@@ -67,8 +70,77 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		return runtime.RuntimeInfo{}, fmt.Errorf("postgres did not become ready: %w", err)
 	}
 
-	// Start the rest of the pod (onecli + workspace); already-running
-	// containers (postgres) are left untouched by pod start.
+	// Start onecli individually so we can configure networking rules and write
+	// the approval-handler config BEFORE the approval-handler container starts.
+	onecliContainer := podName + "-onecli"
+	stepLogger.Start("Starting OneCLI", "OneCLI started")
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", onecliContainer); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start onecli container: %w", err)
+	}
+
+	// Read persisted pod template data for networking config and approval handler path.
+	tmplData, err := p.readPodTemplateData(id)
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to read pod template data: %w", err)
+	}
+
+	// Configure OneCLI networking rules. Deny is the default — rules are applied
+	// unless the network mode is explicitly set to allow in the workspace config.
+	// The policy is read fresh from projects.json on each start so edits take effect
+	// without recreating the workspace.
+	wsCfg, loadErr := loadNetworkConfig(tmplData.SourcePath, p.globalStorageDir, tmplData.ProjectID)
+	if loadErr != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load network config: %w", loadErr)
+	}
+
+	// Networking rules are only configured when mode is explicitly deny AND at
+	// least one allowed host is specified. All other cases (allow, no config,
+	// deny without hosts) clear any stale rules so that mode switches take
+	// effect without recreating the workspace.
+	shouldConfigureNetworking := wsCfg != nil &&
+		wsCfg.Network != nil &&
+		wsCfg.Network.Mode != nil &&
+		*wsCfg.Network.Mode == workspace.Deny &&
+		wsCfg.Network.Hosts != nil &&
+		len(*wsCfg.Network.Hosts) > 0
+
+	// Always connect to OneCLI so networking state is kept consistent across
+	// mode switches without recreating the workspace.
+	onecliBaseURL := p.onecliURL(tmplData.OnecliWebPort)
+
+	stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
+	if err := waitForReady(ctx, onecliBaseURL); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("OneCLI not ready: %w", err)
+	}
+
+	if shouldConfigureNetworking {
+		hosts := *wsCfg.Network.Hosts
+
+		stepLogger.Start("Configuring network rules", "Network rules configured")
+		if err := p.configureNetworking(ctx, onecliBaseURL, hosts, tmplData.ApprovalHandlerDir); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
+		}
+
+		// Start the approval-handler now that config.json is in place.
+		approvalContainer := podName + "-approval-handler"
+		stepLogger.Start("Starting approval handler", "Approval handler started")
+		if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", approvalContainer); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to start approval handler: %w", err)
+		}
+	} else {
+		// Clear any leftover rules from a previous deny-mode start.
+		stepLogger.Start("Clearing network rules", "Network rules cleared")
+		if err := p.clearNetworkingRules(ctx, onecliBaseURL); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to clear networking rules: %w", err)
+		}
+	}
+
+	// Start the remaining containers (workspace and, in allow mode, approval-handler).
 	stepLogger.Start(fmt.Sprintf("Starting pod: %s", podName), "Pod started")
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "start", podName); err != nil {
 		stepLogger.Fail(err)
@@ -81,46 +153,6 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		if err := p.installCACert(ctx, id, caPath); err != nil {
 			stepLogger.Fail(err)
 			return runtime.RuntimeInfo{}, fmt.Errorf("failed to install CA certificate: %w", err)
-		}
-	}
-
-	// Configure OneCLI networking rules. Deny is the default — rules are applied
-	// unless the network mode is explicitly set to allow in the workspace config.
-	// The policy is read fresh from projects.json on each start so edits take effect
-	// without recreating the workspace.
-	tmplData, err := p.readPodTemplateData(id)
-	if err != nil {
-		return runtime.RuntimeInfo{}, fmt.Errorf("failed to read pod template data: %w", err)
-	}
-	wsCfg, loadErr := loadNetworkConfig(tmplData.SourcePath, p.storageDir, tmplData.ProjectID)
-	if loadErr != nil {
-		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load network config: %w", loadErr)
-	}
-
-	// Deny mode is the default. Only skip networking rules when mode is explicitly set to allow.
-	isAllow := wsCfg != nil &&
-		wsCfg.Network != nil &&
-		wsCfg.Network.Mode != nil &&
-		*wsCfg.Network.Mode == workspace.Allow
-
-	if !isAllow {
-		onecliBaseURL := p.onecliURL(tmplData.OnecliWebPort)
-
-		stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
-		if err := waitForReady(ctx, onecliBaseURL); err != nil {
-			stepLogger.Fail(err)
-			return runtime.RuntimeInfo{}, fmt.Errorf("OneCLI not ready: %w", err)
-		}
-
-		hosts := []string{}
-		if wsCfg != nil && wsCfg.Network != nil && wsCfg.Network.Hosts != nil {
-			hosts = *wsCfg.Network.Hosts
-		}
-
-		stepLogger.Start("Configuring network rules", "Network rules configured")
-		if err := p.configureNetworking(ctx, onecliBaseURL, hosts); err != nil {
-			stepLogger.Fail(err)
-			return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
 		}
 	}
 

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -105,6 +105,14 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		wsCfg.Network.Hosts != nil &&
 		len(*wsCfg.Network.Hosts) > 0
 
+	// Start the network-guard container so we can exec nftables commands into it.
+	networkGuardContainer := podName + "-network-guard"
+	stepLogger.Start("Starting network guard", "Network guard started")
+	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "start", networkGuardContainer); err != nil {
+		stepLogger.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start network-guard container: %w", err)
+	}
+
 	// Always connect to OneCLI so networking state is kept consistent across
 	// mode switches without recreating the workspace.
 	onecliBaseURL := p.onecliURL(tmplData.OnecliWebPort)
@@ -124,6 +132,13 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 			return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
 		}
 
+		// Apply nftables firewall rules to block direct outbound from the agent UID.
+		stepLogger.Start("Configuring firewall rules", "Firewall rules configured")
+		if err := p.setupFirewallRules(ctx, podName, tmplData.AgentUID); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to set up firewall rules: %w", err)
+		}
+
 		// Start the approval-handler now that config.json is in place.
 		approvalContainer := podName + "-approval-handler"
 		stepLogger.Start("Starting approval handler", "Approval handler started")
@@ -132,11 +147,18 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 			return runtime.RuntimeInfo{}, fmt.Errorf("failed to start approval handler: %w", err)
 		}
 	} else {
-		// Clear any leftover rules from a previous deny-mode start.
+		// Clear any leftover OneCLI proxy rules from a previous deny-mode start.
 		stepLogger.Start("Clearing network rules", "Network rules cleared")
 		if err := p.clearNetworkingRules(ctx, onecliBaseURL); err != nil {
 			stepLogger.Fail(err)
 			return runtime.RuntimeInfo{}, fmt.Errorf("failed to clear networking rules: %w", err)
+		}
+
+		// Clear any leftover nftables firewall rules from a previous deny-mode start.
+		stepLogger.Start("Clearing firewall rules", "Firewall rules cleared")
+		if err := p.clearFirewallRules(ctx, podName); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to clear firewall rules: %w", err)
 		}
 	}
 

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"time"
 
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/steplogger"
@@ -80,6 +81,41 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		if err := p.installCACert(ctx, id, caPath); err != nil {
 			stepLogger.Fail(err)
 			return runtime.RuntimeInfo{}, fmt.Errorf("failed to install CA certificate: %w", err)
+		}
+	}
+
+	// Configure OneCLI networking rules when deny mode is active.
+	// The network policy is read fresh from projects.json on each start so that
+	// edits take effect without recreating the workspace.
+	tmplData, err := p.readPodTemplateData(id)
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to read pod template data: %w", err)
+	}
+	if tmplData.SourcePath != "" {
+		wsCfg, _ := loadNetworkConfig(tmplData.SourcePath, p.storageDir, tmplData.ProjectID)
+		if wsCfg != nil &&
+			wsCfg.Network != nil &&
+			wsCfg.Network.Mode != nil &&
+			*wsCfg.Network.Mode == workspace.Deny {
+
+			onecliBaseURL := fmt.Sprintf("http://localhost:%d", tmplData.OnecliWebPort)
+
+			stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
+			if err := waitForReady(ctx, onecliBaseURL); err != nil {
+				stepLogger.Fail(err)
+				return runtime.RuntimeInfo{}, fmt.Errorf("OneCLI not ready: %w", err)
+			}
+
+			hosts := []string{}
+			if wsCfg.Network.Hosts != nil {
+				hosts = *wsCfg.Network.Hosts
+			}
+
+			stepLogger.Start("Configuring network rules", "Network rules configured")
+			if err := p.configureNetworking(ctx, podName, onecliBaseURL, hosts); err != nil {
+				stepLogger.Fail(err)
+				return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
+			}
 		}
 	}
 

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -84,38 +84,43 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		}
 	}
 
-	// Configure OneCLI networking rules when deny mode is active.
-	// The network policy is read fresh from projects.json on each start so that
-	// edits take effect without recreating the workspace.
+	// Configure OneCLI networking rules. Deny is the default — rules are applied
+	// unless the network mode is explicitly set to allow in the workspace config.
+	// The policy is read fresh from projects.json on each start so edits take effect
+	// without recreating the workspace.
 	tmplData, err := p.readPodTemplateData(id)
 	if err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to read pod template data: %w", err)
 	}
-	if tmplData.SourcePath != "" {
-		wsCfg, _ := loadNetworkConfig(tmplData.SourcePath, p.storageDir, tmplData.ProjectID)
-		if wsCfg != nil &&
-			wsCfg.Network != nil &&
-			wsCfg.Network.Mode != nil &&
-			*wsCfg.Network.Mode == workspace.Deny {
+	wsCfg, loadErr := loadNetworkConfig(tmplData.SourcePath, p.storageDir, tmplData.ProjectID)
+	if loadErr != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load network config: %w", loadErr)
+	}
 
-			onecliBaseURL := fmt.Sprintf("http://localhost:%d", tmplData.OnecliWebPort)
+	// Deny mode is the default. Only skip networking rules when mode is explicitly set to allow.
+	isAllow := wsCfg != nil &&
+		wsCfg.Network != nil &&
+		wsCfg.Network.Mode != nil &&
+		*wsCfg.Network.Mode == workspace.Allow
 
-			stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
-			if err := waitForReady(ctx, onecliBaseURL); err != nil {
-				stepLogger.Fail(err)
-				return runtime.RuntimeInfo{}, fmt.Errorf("OneCLI not ready: %w", err)
-			}
+	if !isAllow {
+		onecliBaseURL := p.onecliURL(tmplData.OnecliWebPort)
 
-			hosts := []string{}
-			if wsCfg.Network.Hosts != nil {
-				hosts = *wsCfg.Network.Hosts
-			}
+		stepLogger.Start("Waiting for OneCLI readiness", "OneCLI ready")
+		if err := waitForReady(ctx, onecliBaseURL); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("OneCLI not ready: %w", err)
+		}
 
-			stepLogger.Start("Configuring network rules", "Network rules configured")
-			if err := p.configureNetworking(ctx, podName, onecliBaseURL, hosts); err != nil {
-				stepLogger.Fail(err)
-				return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
-			}
+		hosts := []string{}
+		if wsCfg != nil && wsCfg.Network != nil && wsCfg.Network.Hosts != nil {
+			hosts = *wsCfg.Network.Hosts
+		}
+
+		stepLogger.Start("Configuring network rules", "Network rules configured")
+		if err := p.configureNetworking(ctx, onecliBaseURL, hosts); err != nil {
+			stepLogger.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
 		}
 	}
 

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -16,14 +16,41 @@ package podman
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
+
+// newOnecliStartTestServer starts an httptest server that handles the OneCLI endpoints
+// invoked during Start() (health, api-key, rules). Use together with
+// podmanRuntime.onecliBaseURLFn to avoid dialling a real localhost port in tests.
+func newOnecliStartTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "new-rule"})
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
 
 func TestStart_ValidatesID(t *testing.T) {
 	t.Parallel()
@@ -59,7 +86,9 @@ func TestStart_Success(t *testing.T) {
 		return []byte(output), nil
 	}
 
+	onecliServer := newOnecliStartTestServer(t)
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return onecliServer.URL }
 	podName := setupPodFiles(t, p, containerID, workspaceName)
 
 	info, err := p.Start(context.Background(), containerID)
@@ -159,7 +188,9 @@ func TestStart_InspectFailure(t *testing.T) {
 		return nil, fmt.Errorf("inspect failed")
 	}
 
+	onecliServer := newOnecliStartTestServer(t)
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return onecliServer.URL }
 	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	_, err := p.Start(context.Background(), containerID)
@@ -210,7 +241,9 @@ func TestStart_StepLogger_Success(t *testing.T) {
 		return []byte(output), nil
 	}
 
+	onecliServer := newOnecliStartTestServer(t)
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return onecliServer.URL }
 	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
@@ -241,6 +274,14 @@ func TestStart_StepLogger_Success(t *testing.T) {
 		{
 			inProgress: fmt.Sprintf("Starting pod: %s", podName),
 			completed:  "Pod started",
+		},
+		{
+			inProgress: "Waiting for OneCLI readiness",
+			completed:  "OneCLI ready",
+		},
+		{
+			inProgress: "Configuring network rules",
+			completed:  "Network rules configured",
 		},
 		{
 			inProgress: "Verifying container status",
@@ -314,7 +355,9 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		return nil, fmt.Errorf("failed to inspect container")
 	}
 
+	onecliServer := newOnecliStartTestServer(t)
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return onecliServer.URL }
 	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	fakeLogger := &fakeStepLogger{}
@@ -329,14 +372,16 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	if len(fakeLogger.startCalls) != 4 {
-		t.Fatalf("Expected 4 Start() calls, got %d", len(fakeLogger.startCalls))
+	if len(fakeLogger.startCalls) != 6 {
+		t.Fatalf("Expected 6 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
 		"Starting postgres",
 		"Waiting for postgres to be ready",
 		fmt.Sprintf("Starting pod: %s", podName),
+		"Waiting for OneCLI readiness",
+		"Configuring network rules",
 		"Verifying container status",
 	}
 

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -104,6 +104,9 @@ func TestStart_Success(t *testing.T) {
 	// Verify pg_isready was called to wait for postgres
 	fakeExec.AssertOutputCalledWith(t, "exec", podName+"-postgres", "pg_isready", "-U", "onecli")
 
+	// Verify network-guard was started
+	fakeExec.AssertRunCalledWith(t, "start", podName+"-network-guard")
+
 	// Verify pod start was called for remaining containers
 	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
 
@@ -281,12 +284,20 @@ func TestStart_StepLogger_Success(t *testing.T) {
 			completed:  "OneCLI started",
 		},
 		{
+			inProgress: "Starting network guard",
+			completed:  "Network guard started",
+		},
+		{
 			inProgress: "Waiting for OneCLI readiness",
 			completed:  "OneCLI ready",
 		},
 		{
 			inProgress: "Clearing network rules",
 			completed:  "Network rules cleared",
+		},
+		{
+			inProgress: "Clearing firewall rules",
+			completed:  "Firewall rules cleared",
 		},
 		{
 			inProgress: fmt.Sprintf("Starting pod: %s", podName),
@@ -381,16 +392,18 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	if len(fakeLogger.startCalls) != 7 {
-		t.Fatalf("Expected 7 Start() calls, got %d", len(fakeLogger.startCalls))
+	if len(fakeLogger.startCalls) != 9 {
+		t.Fatalf("Expected 9 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
 		"Starting postgres",
 		"Waiting for postgres to be ready",
 		"Starting OneCLI",
+		"Starting network guard",
 		"Waiting for OneCLI readiness",
 		"Clearing network rules",
+		"Clearing firewall rules",
 		fmt.Sprintf("Starting pod: %s", podName),
 		"Verifying container status",
 	}
@@ -434,6 +447,9 @@ func setupPodFilesWithSource(t *testing.T, p *podmanRuntime, containerID, worksp
 		Name:               workspaceName,
 		OnecliWebPort:      20254,
 		OnecliVersion:      defaultOnecliVersion,
+		AgentUID:           1000,
+		BaseImageRegistry:  "registry.fedoraproject.org/fedora",
+		BaseImageVersion:   "latest",
 		SourcePath:         sourceDir,
 		ApprovalHandlerDir: approvalDir,
 	}
@@ -497,6 +513,9 @@ func TestStart_AllowMode_ClearsRules(t *testing.T) {
 		t.Errorf("deleted IDs = %v, want [stale-rule-1 stale-rule-2]", deletedIDs)
 	}
 
+	// Network-guard must be started in allow mode (to clear firewall rules).
+	fakeExec.AssertRunCalledWith(t, "start", "test-ws-network-guard")
+
 	// Approval handler must NOT be started individually in allow mode.
 	fakeExec.AssertRunNotCalledWith(t, "start", "test-ws-approval-handler")
 
@@ -549,8 +568,152 @@ func TestStart_AllowMode_StepLogger(t *testing.T) {
 		{"Starting postgres", "Postgres started"},
 		{"Waiting for postgres to be ready", "Postgres is ready"},
 		{"Starting OneCLI", "OneCLI started"},
+		{"Starting network guard", "Network guard started"},
 		{"Waiting for OneCLI readiness", "OneCLI ready"},
 		{"Clearing network rules", "Network rules cleared"},
+		{"Clearing firewall rules", "Firewall rules cleared"},
+		{fmt.Sprintf("Starting pod: %s", podName), "Pod started"},
+		{"Verifying container status", "Container status verified"},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("expected %d steps, got %d: %v", len(expectedSteps), len(fakeLogger.startCalls), fakeLogger.startCalls)
+	}
+	for i, want := range expectedSteps {
+		got := fakeLogger.startCalls[i]
+		if got.inProgress != want.inProgress || got.completed != want.completed {
+			t.Errorf("step %d: got {%q, %q}, want {%q, %q}", i, got.inProgress, got.completed, want.inProgress, want.completed)
+		}
+	}
+}
+
+func TestStart_DenyMode_ConfiguresNetworking(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "exec" {
+			return []byte("accepting connections\n"), nil
+		}
+		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	var ruleActions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+			var body struct {
+				Action string `json:"action"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			ruleActions = append(ruleActions, body.Action)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "new-rule"})
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return server.URL }
+	podName := setupPodFilesWithSource(t, p, containerID, "test-ws", `{"network":{"mode":"deny","hosts":["*.github.com","registry.npmjs.org"]}}`)
+
+	_, err := p.Start(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// A single manual_approval catch-all rule should be created; the approval-handler
+	// decides per-request using the hosts list, so OneCLI doesn't need per-host rules.
+	if len(ruleActions) != 1 || ruleActions[0] != "manual_approval" {
+		t.Errorf("expected one manual_approval rule, got: %v", ruleActions)
+	}
+
+	// config.json must contain the glob pattern so the approval-handler's matchesPattern
+	// can approve api.github.com when *.github.com is in the hosts list.
+	approvalDir := filepath.Join(p.storageDir, "approval-handler", "test-ws")
+	data, readErr := os.ReadFile(filepath.Join(approvalDir, "config.json"))
+	if readErr != nil {
+		t.Fatalf("reading config.json: %v", readErr)
+	}
+	var cfg approvalHandlerConfig
+	if jsonErr := json.Unmarshal(data, &cfg); jsonErr != nil {
+		t.Fatalf("unmarshaling config.json: %v", jsonErr)
+	}
+	if len(cfg.Hosts) != 2 || cfg.Hosts[0] != "*.github.com" || cfg.Hosts[1] != "registry.npmjs.org" {
+		t.Errorf("config.hosts = %v, want [*.github.com registry.npmjs.org]", cfg.Hosts)
+	}
+
+	// Approval-handler must be started individually after config.json is written,
+	// not via pod start (which would run it before config is available).
+	fakeExec.AssertRunCalledWith(t, "start", podName+"-approval-handler")
+
+	// Pod start brings up the workspace agent container last.
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
+}
+
+func TestStart_DenyMode_StepLogger(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "exec" {
+			return []byte("accepting connections\n"), nil
+		}
+		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "new-rule"})
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return server.URL }
+	podName := setupPodFilesWithSource(t, p, containerID, "test-ws", `{"network":{"mode":"deny","hosts":["*.github.com"]}}`)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	_, err := p.Start(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	expectedSteps := []stepCall{
+		{"Starting postgres", "Postgres started"},
+		{"Waiting for postgres to be ready", "Postgres is ready"},
+		{"Starting OneCLI", "OneCLI started"},
+		{"Starting network guard", "Network guard started"},
+		{"Waiting for OneCLI readiness", "OneCLI ready"},
+		{"Configuring network rules", "Network rules configured"},
+		{"Configuring firewall rules", "Firewall rules configured"},
+		{"Starting approval handler", "Approval handler started"},
 		{fmt.Sprintf("Starting pod: %s", podName), "Pod started"},
 		{"Verifying container status", "Container status verified"},
 	}

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -163,7 +165,9 @@ func TestStart_PodStartFailure(t *testing.T) {
 		return []byte("accepting connections\n"), nil
 	}
 
+	onecliServer := newOnecliStartTestServer(t)
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return onecliServer.URL }
 	podName := setupPodFiles(t, p, containerID, "test-ws")
 
 	_, err := p.Start(context.Background(), containerID)
@@ -172,6 +176,7 @@ func TestStart_PodStartFailure(t *testing.T) {
 	}
 
 	fakeExec.AssertRunCalledWith(t, "start", podName+"-postgres")
+	fakeExec.AssertRunCalledWith(t, "start", podName+"-onecli")
 	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
 }
 
@@ -272,16 +277,20 @@ func TestStart_StepLogger_Success(t *testing.T) {
 			completed:  "Postgres is ready",
 		},
 		{
-			inProgress: fmt.Sprintf("Starting pod: %s", podName),
-			completed:  "Pod started",
+			inProgress: "Starting OneCLI",
+			completed:  "OneCLI started",
 		},
 		{
 			inProgress: "Waiting for OneCLI readiness",
 			completed:  "OneCLI ready",
 		},
 		{
-			inProgress: "Configuring network rules",
-			completed:  "Network rules configured",
+			inProgress: "Clearing network rules",
+			completed:  "Network rules cleared",
+		},
+		{
+			inProgress: fmt.Sprintf("Starting pod: %s", podName),
+			completed:  "Pod started",
 		},
 		{
 			inProgress: "Verifying container status",
@@ -372,16 +381,17 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 		t.Errorf("Expected Complete() to be called 1 time, got %d", fakeLogger.completeCalls)
 	}
 
-	if len(fakeLogger.startCalls) != 6 {
-		t.Fatalf("Expected 6 Start() calls, got %d", len(fakeLogger.startCalls))
+	if len(fakeLogger.startCalls) != 7 {
+		t.Fatalf("Expected 7 Start() calls, got %d", len(fakeLogger.startCalls))
 	}
 
 	expectedSteps := []string{
 		"Starting postgres",
 		"Waiting for postgres to be ready",
-		fmt.Sprintf("Starting pod: %s", podName),
+		"Starting OneCLI",
 		"Waiting for OneCLI readiness",
-		"Configuring network rules",
+		"Clearing network rules",
+		fmt.Sprintf("Starting pod: %s", podName),
 		"Verifying container status",
 	}
 
@@ -393,5 +403,165 @@ func TestStart_StepLogger_FailOnGetContainerInfo(t *testing.T) {
 
 	if len(fakeLogger.failCalls) != 1 {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
+	}
+}
+
+// setupPodFilesWithSource is like setupPodFiles but writes a workspace.json at
+// sourceDir/.kaiden/workspace.json so loadNetworkConfig picks it up.
+func setupPodFilesWithSource(t *testing.T, p *podmanRuntime, containerID, workspaceName, workspaceJSON string) string {
+	t.Helper()
+	if p.storageDir == "" {
+		p.storageDir = t.TempDir()
+	}
+	if p.globalStorageDir == "" {
+		p.globalStorageDir = t.TempDir()
+	}
+
+	sourceDir := t.TempDir()
+	kaidenDir := filepath.Join(sourceDir, ".kaiden")
+	if err := os.MkdirAll(kaidenDir, 0755); err != nil {
+		t.Fatalf("failed to create .kaiden dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kaidenDir, "workspace.json"), []byte(workspaceJSON), 0644); err != nil {
+		t.Fatalf("failed to write workspace.json: %v", err)
+	}
+
+	approvalDir := filepath.Join(p.storageDir, "approval-handler", workspaceName)
+	if err := os.MkdirAll(approvalDir, 0755); err != nil {
+		t.Fatalf("failed to create approval handler dir: %v", err)
+	}
+	data := podTemplateData{
+		Name:               workspaceName,
+		OnecliWebPort:      20254,
+		OnecliVersion:      defaultOnecliVersion,
+		SourcePath:         sourceDir,
+		ApprovalHandlerDir: approvalDir,
+	}
+	if err := p.writePodFiles(containerID, data); err != nil {
+		t.Fatalf("failed to write pod files for test: %v", err)
+	}
+	return workspaceName
+}
+
+func TestStart_AllowMode_ClearsRules(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "exec" {
+			return []byte("accepting connections\n"), nil
+		}
+		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	deletedIDs := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+			existing := []map[string]string{
+				{"id": "stale-rule-1"},
+				{"id": "stale-rule-2"},
+			}
+			_ = json.NewEncoder(w).Encode(existing)
+		case r.Method == http.MethodDelete:
+			deletedIDs = append(deletedIDs, r.URL.Path[len("/api/rules/"):])
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return server.URL }
+	setupPodFilesWithSource(t, p, containerID, "test-ws", `{"network":{"mode":"allow"}}`)
+
+	_, err := p.Start(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Stale rules from a previous deny-mode start must be deleted.
+	if len(deletedIDs) != 2 {
+		t.Fatalf("expected 2 deletions, got %d: %v", len(deletedIDs), deletedIDs)
+	}
+	if deletedIDs[0] != "stale-rule-1" || deletedIDs[1] != "stale-rule-2" {
+		t.Errorf("deleted IDs = %v, want [stale-rule-1 stale-rule-2]", deletedIDs)
+	}
+
+	// Approval handler must NOT be started individually in allow mode.
+	fakeExec.AssertRunNotCalledWith(t, "start", "test-ws-approval-handler")
+
+	// Pod start must still be called.
+	fakeExec.AssertRunCalledWith(t, "pod", "start", "test-ws")
+}
+
+func TestStart_AllowMode_StepLogger(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "exec" {
+			return []byte("accepting connections\n"), nil
+		}
+		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode([]any{})
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return server.URL }
+	podName := setupPodFilesWithSource(t, p, containerID, "test-ws", `{"network":{"mode":"allow"}}`)
+
+	fakeLogger := &fakeStepLogger{}
+	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
+
+	_, err := p.Start(ctx, containerID)
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	expectedSteps := []stepCall{
+		{"Starting postgres", "Postgres started"},
+		{"Waiting for postgres to be ready", "Postgres is ready"},
+		{"Starting OneCLI", "OneCLI started"},
+		{"Waiting for OneCLI readiness", "OneCLI ready"},
+		{"Clearing network rules", "Network rules cleared"},
+		{fmt.Sprintf("Starting pod: %s", podName), "Pod started"},
+		{"Verifying container status", "Container status verified"},
+	}
+
+	if len(fakeLogger.startCalls) != len(expectedSteps) {
+		t.Fatalf("expected %d steps, got %d: %v", len(expectedSteps), len(fakeLogger.startCalls), fakeLogger.startCalls)
+	}
+	for i, want := range expectedSteps {
+		got := fakeLogger.startCalls[i]
+		if got.inProgress != want.inProgress || got.completed != want.completed {
+			t.Errorf("step %d: got {%q, %q}, want {%q, %q}", i, got.inProgress, got.completed, want.inProgress, want.completed)
+		}
 	}
 }

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -102,6 +102,9 @@ func setupPodFiles(t *testing.T, p *podmanRuntime, containerID, workspaceName st
 		Name:               workspaceName,
 		OnecliWebPort:      20254,
 		OnecliVersion:      defaultOnecliVersion,
+		AgentUID:           1000,
+		BaseImageRegistry:  "registry.fedoraproject.org/fedora",
+		BaseImageVersion:   "latest",
 		ApprovalHandlerDir: approvalDir,
 	}
 	if err := p.writePodFiles(containerID, data); err != nil {

--- a/pkg/runtime/podman/steplogger_test.go
+++ b/pkg/runtime/podman/steplogger_test.go
@@ -15,6 +15,8 @@
 package podman
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
@@ -89,10 +91,18 @@ func setupPodFiles(t *testing.T, p *podmanRuntime, containerID, workspaceName st
 	if p.storageDir == "" {
 		p.storageDir = t.TempDir()
 	}
+	if p.globalStorageDir == "" {
+		p.globalStorageDir = t.TempDir()
+	}
+	approvalDir := filepath.Join(p.storageDir, "approval-handler", workspaceName)
+	if err := os.MkdirAll(approvalDir, 0755); err != nil {
+		t.Fatalf("failed to create approval handler dir: %v", err)
+	}
 	data := podTemplateData{
-		Name:          workspaceName,
-		OnecliWebPort: 20254,
-		OnecliVersion: defaultOnecliVersion,
+		Name:               workspaceName,
+		OnecliWebPort:      20254,
+		OnecliVersion:      defaultOnecliVersion,
+		ApprovalHandlerDir: approvalDir,
 	}
 	if err := p.writePodFiles(containerID, data); err != nil {
 		t.Fatalf("failed to write pod files for test: %v", err)

--- a/pkg/runtime/podman/system/path.go
+++ b/pkg/runtime/podman/system/path.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package system
+
+// HostPathToMachinePath returns the path unchanged on non-Windows platforms.
+func HostPathToMachinePath(p string) string {
+	return p
+}
+
+// MachinePathToHostPath returns the path unchanged on non-Windows platforms.
+func MachinePathToHostPath(p string) string {
+	return p
+}

--- a/pkg/runtime/podman/system/path_test.go
+++ b/pkg/runtime/podman/system/path_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package system_test
+
+import (
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/runtime/podman/system"
+)
+
+func TestHostPathToMachinePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input string
+	}{
+		{"/home/user/.kdn/approval-handler/myworkspace"},
+		{"/tmp/foo/bar"},
+		{"relative/path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			if got := system.HostPathToMachinePath(tc.input); got != tc.input {
+				t.Errorf("HostPathToMachinePath(%q) = %q, want %q", tc.input, got, tc.input)
+			}
+		})
+	}
+}
+
+func TestMachinePathToHostPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input string
+	}{
+		{"/home/user/.kdn/approval-handler/myworkspace"},
+		{"/tmp/foo/bar"},
+		{"relative/path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			if got := system.MachinePathToHostPath(tc.input); got != tc.input {
+				t.Errorf("MachinePathToHostPath(%q) = %q, want %q", tc.input, got, tc.input)
+			}
+		})
+	}
+}

--- a/pkg/runtime/podman/system/path_windows.go
+++ b/pkg/runtime/podman/system/path_windows.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package system
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// HostPathToMachinePath converts a Windows host path to its Podman machine
+// (WSL2) equivalent, e.g. C:\Users\foo → /mnt/c/Users/foo.
+func HostPathToMachinePath(p string) string {
+	p = filepath.ToSlash(p)
+	if len(p) >= 3 && p[1] == ':' && p[2] == '/' {
+		drive := strings.ToLower(string(p[0]))
+		return "/mnt/" + drive + p[2:]
+	}
+	return p
+}
+
+// MachinePathToHostPath converts a Podman machine (WSL2) path back to a
+// Windows host path, e.g. /mnt/c/Users/foo → C:\Users\foo.
+func MachinePathToHostPath(p string) string {
+	// /mnt/<drive>/... → <DRIVE>:\...
+	if strings.HasPrefix(p, "/mnt/") && len(p) >= 7 && p[6] == '/' {
+		drive := strings.ToUpper(string(p[5]))
+		return drive + ":" + filepath.FromSlash(p[6:])
+	}
+	return filepath.FromSlash(p)
+}

--- a/pkg/runtime/podman/system/path_windows_test.go
+++ b/pkg/runtime/podman/system/path_windows_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package system_test
+
+import (
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/runtime/podman/system"
+)
+
+func TestHostPathToMachinePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`C:\Users\foo\.kdn\approval-handler\myworkspace`, "/mnt/c/Users/foo/.kdn/approval-handler/myworkspace"},
+		{`D:\some\path`, "/mnt/d/some/path"},
+		{`c:\lowercase\drive`, "/mnt/c/lowercase/drive"},
+		{"/already/posix", "/already/posix"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			if got := system.HostPathToMachinePath(tc.input); got != tc.want {
+				t.Errorf("HostPathToMachinePath(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMachinePathToHostPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"/mnt/c/Users/foo/.kdn/approval-handler/myworkspace", `C:\Users\foo\.kdn\approval-handler\myworkspace`},
+		{"/mnt/d/some/path", `D:\some\path`},
+		{"/not/mnt/path", `\not\mnt\path`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			if got := system.MachinePathToHostPath(tc.input); got != tc.want {
+				t.Errorf("MachinePathToHostPath(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -90,6 +90,10 @@ type CreateParams struct {
 	// Used to resolve relative paths for local devcontainer features (e.g. "./my-feature").
 	// Can be empty if no workspace configuration exists.
 	WorkspaceConfigDir string
+
+	// ProjectID is the project identifier used to load per-project workspace
+	// configuration (e.g. network policy) during subsequent Start() calls.
+	ProjectID string
 }
 
 // RuntimeInfo contains information about a runtime instance.


### PR DESCRIPTION
Adds networking to the onecli container

  Test deny+hosts mode                                                                                                                    
```                                                                                                                                          
  ~/.kdn/config/projects.json:                                                                                                            
  {                                                                                                                                       
    "": {                                      
      "network": {                             
        "mode": "deny",                                                                                                                   
        "hosts": ["api.github.com", "registry.npmjs.org"]                                                                                 
      }                                                                                                                                   
    }                                                                                                                                     
  }                                                                                                                                       
   ```                                            
  Start the workspace and you should see Configuring network rules → Starting approval handler:                                           
 ` kdn start kdn     `                                                                                                                      
                                                                                                                                          
  Exec in and test:                                                                                                                       
  `podman exec -it kdn-workspace bash                  `                                                                                    
                                                                                                                                          
  Allowed — should return 200                                                                                                           
  `curl -s https://api.github.com/zen `                                                                                                     
                                                                                                                                          
   Blocked — should return 403 manual_approval_denied                                                                                    
  `curl -v https://example.com `                                                                                                            
                                                                                                                                          
  ---                                                                                                                                     
  Switch to allow mode (no recreation needed)  
  
```                                                                                                                                      
  ~/.kdn/config/projects.json:
  {                                                                                                                                       
    "": {                                                                                                                                 
      "network": {                             
        "mode": "allow"                                                                                                                   
      }                            
    }                                          
  }  
   ```

  Restart — you should see Clearing network rules instead:                                                                                
  `kdn start kdn `                                                                                                                          
                                                                                                                                          
  Now example.com should return 200.                                                                                                      
                                                                                                                                          
  ---                                                                                                                                     
  No network config (clear any stale rules)                                                                                               
                                                                                                                                          
  Remove ~/.kdn/config/projects.json entirely (or use {}), restart — same Clearing network rules step, full network access.

Closes https://github.com/openkaiden/kdn/issues/265