### PR TITLE
feat: update kdn-api to v0.5.0, secrets as name references

### DIFF
--- a/.agents/skills/working-with-config-system/SKILL.md
+++ b/.agents/skills/working-with-config-system/SKILL.md
@@ -14,7 +14,7 @@ The config system manages **workspace configuration** for injecting environment 
 - Skills directories to provide to agents inside the workspace
 - MCP servers to configure in the agent (command-based and URL-based)
 - Network access policies (allow all or deny with host exceptions)
-- Secrets to inject into the workspace (typed credentials with optional host/header bindings)
+- Secrets to inject into the workspace (secret names resolved from the CLI-managed store)
 
 **What this does NOT control:**
 - Runtime-specific settings (e.g., Podman container image, packages to install)

--- a/.agents/skills/working-with-config-system/SKILL.md
+++ b/.agents/skills/working-with-config-system/SKILL.md
@@ -170,8 +170,8 @@ The `workspace.json` file controls what gets injected into the workspace:
     "hosts": ["api.github.com"]
   },
   "secrets": [
-    {"type": "github", "value": "ghp_xxxxxxxxxxxx"},
-    {"type": "other", "name": "api-key", "value": "my-token", "header": "Authorization", "headerTemplate": "Bearer {{value}}", "hosts": ["api.example.com"], "path": "/v1"}
+    "my-github-token",
+    "my-api-key"
   ]
 }
 ```
@@ -217,14 +217,9 @@ kdn init /path/to/workspace --workspace-configuration /path/to/config-dir
 - `network` - Network access policy for the workspace (optional)
   - `mode` - Access mode: `"allow"` (permit all) or `"deny"` (block all except listed hosts). Defaults to `"deny"`
   - `hosts` - List of hostnames to allow in deny mode (optional, must not be set when mode is `"allow"`)
-- `secrets` - List of secrets to inject into the workspace (optional)
-  - `type` - Secret type identifier (required); use a registered service name (e.g., `"github"`) or `"other"` for custom secrets
-  - `value` - The secret value or token (required)
-  - `name` - Optional name to distinguish multiple secrets of the same type
-  - `header` - HTTP header name for injecting the secret (optional, only applicable when type is `"other"`)
-  - `headerTemplate` - Template for formatting the secret in a header, e.g., `"Bearer {{value}}"` (optional, only applicable when type is `"other"`)
-  - `hosts` - List of hosts where this secret applies (optional, only applicable when type is `"other"`)
-  - `path` - API path associated with the secret (optional, only applicable when type is `"other"`)
+- `secrets` - List of secret names to inject into the workspace (optional)
+  - Each entry is a string: the name of a secret previously created with `kdn secret create`
+  - Secret metadata (hosts, header, type, etc.) is resolved from the store at workspace creation time
   - Secrets are distinct from the `secret` field in environment variables, which references runtime secrets by name
 
 ### Agent Configuration (`agents.json`)
@@ -380,7 +375,7 @@ The Manager's `Add()` method:
   - If base has `allow` mode, the base configuration is used regardless of the override
   - If base has `deny` and override has `allow`, the base configuration is used (overrides cannot loosen the policy)
   - If both have `deny` mode, the hosts from both are merged (deduplicated, base entries first)
-- **Secrets**: Deduplicated by `(type, name)` tuple (override replaces base entries with the same key, order preserved: base first then new override entries)
+- **Secrets**: Deduplicated by name (string); base entries come first, override adds new names that are not already present
 
 **Example Merge Flow:**
 
@@ -453,10 +448,8 @@ The `Load()` method automatically validates the configuration and returns `ErrIn
 
 ### Secrets
 
-- `type` cannot be empty
-- `value` cannot be empty
-- Secrets must be unique by `(type, name)` tuple — duplicates are rejected
-- `name` is optional, but when omitted it is treated as a distinct value for uniqueness (a secret with type `"other"` and no name is different from one with type `"other"` and name `"key"`)
+- Each entry (a secret name string) cannot be empty
+- Secret names must be unique within the list — duplicate names are rejected
 
 ## Error Handling
 

--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -177,6 +177,15 @@ type fakeListStore struct {
     err   error
 }
 
-func (f *fakeListStore) Create(params secret.CreateParams) error { return nil }
-func (f *fakeListStore) List() ([]secret.ListItem, error)        { return f.items, f.err }
+func (f *fakeListStore) Create(_ secret.CreateParams) error     { return nil }
+func (f *fakeListStore) List() ([]secret.ListItem, error)       { return f.items, f.err }
+func (f *fakeListStore) Remove(_ string) error                  { return f.err }
+func (f *fakeListStore) Get(name string) (secret.ListItem, string, error) {
+    for _, item := range f.items {
+        if item.Name == name {
+            return item, "", f.err
+        }
+    }
+    return secret.ListItem{}, "", f.err
+}
 ```

--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -17,7 +17,7 @@ The secrets system uses a two-layer architecture: a **Store** that persists secr
 
 ## Key Components
 
-- **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error`, `Remove(name string) error` and `List() ([]ListItem, error)`
+- **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error`, `List() ([]ListItem, error)`, `Get(name string) (ListItem, string, error)`, `Remove(name string) error`
 - **Store implementation** (`pkg/secret/store.go`): writes the value to the keychain, metadata to `secrets.json`
 - **SecretService interface** (`pkg/secretservice/secretservice.go`): describes a named type — host pattern, path, header name, header template, env vars
 - **Registry** (`pkg/secretservice/registry.go`): maps names to `SecretService` implementations
@@ -77,6 +77,15 @@ To retrieve all stored secrets (metadata only — no secret values):
 items, err := store.List()
 // items is []secret.ListItem{Name, Type, Description, Hosts, Path, Header, HeaderTemplate, Envs}
 ```
+
+To retrieve a single secret's metadata and value (used when resolving secrets at workspace creation time):
+
+```go
+item, value, err := store.Get("my-token")
+// item is secret.ListItem (metadata); value is the keychain secret
+```
+
+`Get` returns `ErrSecretNotFound` if no secret with the given name exists.
 
 To remove a secret:
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.1
 require (
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.4.0
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.4.0
+	github.com/openkaiden/kdn-api/cli/go v0.5.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.5.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/openkaiden/kdn-api/cli/go v0.4.0 h1:Z7sF+bsz85sby2iH97lvvPzqf02K2I3k1ovSrCzwreQ=
-github.com/openkaiden/kdn-api/cli/go v0.4.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.4.0 h1:zASComTK9z6T30jn+KD2KWUaNt8gF7DDzkW5n+LOG7U=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.4.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.5.0 h1:ZmsFzec/YmpRuCpz/rRWmVZfw5LUS2yziGzIbhBeNGQ=
+github.com/openkaiden/kdn-api/cli/go v0.5.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.5.0 h1:uhLFgPhIw7E0cWjiQxCEOkzgW27HvdQCLDKY6xUmakk=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.5.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -51,6 +51,10 @@ func (f *fakeStore) List() ([]secret.ListItem, error) {
 	return nil, nil
 }
 
+func (f *fakeStore) Get(name string) (secret.ListItem, string, error) {
+	return secret.ListItem{}, "", nil
+}
+
 // buildPreRunCmd creates a cobra.Command that mirrors the flag set seen by
 // preRun when called through the real command tree.
 func buildPreRunCmd(storageDir string) *cobra.Command {

--- a/pkg/cmd/secret_create_test.go
+++ b/pkg/cmd/secret_create_test.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -52,7 +53,7 @@ func (f *fakeStore) List() ([]secret.ListItem, error) {
 }
 
 func (f *fakeStore) Get(name string) (secret.ListItem, string, error) {
-	return secret.ListItem{}, "", nil
+	return secret.ListItem{}, "", fmt.Errorf("secret %q: %w", name, secret.ErrSecretNotFound)
 }
 
 // buildPreRunCmd creates a cobra.Command that mirrors the flag set seen by

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -44,7 +45,12 @@ func (f *fakeListStore) List() ([]secret.ListItem, error) {
 }
 
 func (f *fakeListStore) Get(name string) (secret.ListItem, string, error) {
-	return secret.ListItem{}, "", nil
+	for _, item := range f.items {
+		if item.Name == name {
+			return item, "", nil
+		}
+	}
+	return secret.ListItem{}, "", fmt.Errorf("secret %q: %w", name, secret.ErrSecretNotFound)
 }
 
 func (f *fakeListStore) Remove(name string) error { return nil }

--- a/pkg/cmd/secret_list_test.go
+++ b/pkg/cmd/secret_list_test.go
@@ -43,6 +43,10 @@ func (f *fakeListStore) List() ([]secret.ListItem, error) {
 	return f.items, f.err
 }
 
+func (f *fakeListStore) Get(name string) (secret.ListItem, string, error) {
+	return secret.ListItem{}, "", nil
+}
+
 func (f *fakeListStore) Remove(name string) error { return nil }
 
 func TestSecretListCmd(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -217,27 +217,15 @@ func (c *config) validate(cfg *workspace.WorkspaceConfiguration) error {
 
 	// Validate secrets
 	if cfg.Secrets != nil {
-		type sKey struct{ typ, name string }
-		seenSecrets := make(map[sKey]int)
-		for i, s := range *cfg.Secrets {
-			if s.Type == "" {
-				return fmt.Errorf("%w: secret at index %d has empty type", ErrInvalidConfig, i)
+		seenSecrets := make(map[string]int)
+		for i, name := range *cfg.Secrets {
+			if name == "" {
+				return fmt.Errorf("%w: secret at index %d has empty name", ErrInvalidConfig, i)
 			}
-			if s.Value == "" {
-				return fmt.Errorf("%w: secret at index %d has empty value", ErrInvalidConfig, i)
+			if prevIdx, exists := seenSecrets[name]; exists {
+				return fmt.Errorf("%w: secret %q (index %d) is a duplicate of index %d", ErrInvalidConfig, name, i, prevIdx)
 			}
-			name := ""
-			if s.Name != nil {
-				name = *s.Name
-			}
-			key := sKey{typ: s.Type, name: name}
-			if prevIdx, exists := seenSecrets[key]; exists {
-				if s.Name != nil {
-					return fmt.Errorf("%w: secret with type %q and name %q (index %d) is a duplicate of index %d", ErrInvalidConfig, s.Type, *s.Name, i, prevIdx)
-				}
-				return fmt.Errorf("%w: secret with type %q (index %d) is a duplicate of index %d", ErrInvalidConfig, s.Type, i, prevIdx)
-			}
-			seenSecrets[key] = i
+			seenSecrets[name] = i
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1219,9 +1219,9 @@ func TestConfig_Load_Secrets_Valid(t *testing.T) {
 	configDir := t.TempDir()
 	workspaceJSON := `{
   "secrets": [
-    {"type": "github", "value": "gh-token"},
-    {"type": "slack", "value": "slack-token"},
-    {"type": "other", "name": "api-key", "value": "my-key", "header": "Authorization", "headerTemplate": "Bearer {{value}}", "hosts": ["api.example.com"], "path": "/v1"}
+    "gh-token",
+    "slack-token",
+    "api-key"
   ]
 }`
 	err := os.WriteFile(filepath.Join(configDir, WorkspaceConfigFile), []byte(workspaceJSON), 0644)
@@ -1253,24 +1253,14 @@ func TestConfig_Load_Secrets_Invalid(t *testing.T) {
 		wantErrMsg string
 	}{
 		{
-			name:       "secret with empty type",
-			json:       `{"secrets": [{"type": "", "value": "token"}]}`,
-			wantErrMsg: "secret at index 0 has empty type",
+			name:       "secret with empty name",
+			json:       `{"secrets": [""]}`,
+			wantErrMsg: "secret at index 0 has empty name",
 		},
 		{
-			name:       "secret with empty value",
-			json:       `{"secrets": [{"type": "github", "value": ""}]}`,
-			wantErrMsg: "secret at index 0 has empty value",
-		},
-		{
-			name:       "duplicate secrets by type only",
-			json:       `{"secrets": [{"type": "github", "value": "token1"}, {"type": "github", "value": "token2"}]}`,
-			wantErrMsg: "secret with type \"github\" (index 1) is a duplicate of index 0",
-		},
-		{
-			name:       "duplicate secrets by type and name",
-			json:       `{"secrets": [{"type": "other", "name": "key", "value": "val1"}, {"type": "other", "name": "key", "value": "val2"}]}`,
-			wantErrMsg: "secret with type \"other\" and name \"key\" (index 1) is a duplicate of index 0",
+			name:       "duplicate secret names",
+			json:       `{"secrets": ["my-token", "my-token"]}`,
+			wantErrMsg: "secret \"my-token\" (index 1) is a duplicate of index 0",
 		},
 	}
 
@@ -1303,14 +1293,14 @@ func TestConfig_Load_Secrets_Invalid(t *testing.T) {
 	}
 }
 
-func TestConfig_Load_Secrets_SameTypeDifferentNames(t *testing.T) {
+func TestConfig_Load_Secrets_MultipleNames(t *testing.T) {
 	t.Parallel()
 
 	configDir := t.TempDir()
 	workspaceJSON := `{
   "secrets": [
-    {"type": "other", "name": "key-a", "value": "val-a"},
-    {"type": "other", "name": "key-b", "value": "val-b"}
+    "key-a",
+    "key-b"
   ]
 }`
 	err := os.WriteFile(filepath.Join(configDir, WorkspaceConfigFile), []byte(workspaceJSON), 0644)
@@ -1329,7 +1319,7 @@ func TestConfig_Load_Secrets_SameTypeDifferentNames(t *testing.T) {
 	}
 
 	if workspaceCfg.Secrets == nil || len(*workspaceCfg.Secrets) != 2 {
-		t.Errorf("Expected 2 secrets with same type but different names, got %v", workspaceCfg.Secrets)
+		t.Errorf("Expected 2 secrets, got %v", workspaceCfg.Secrets)
 	}
 }
 

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -196,79 +196,29 @@ func mergeSkills(base, override *[]string) *[]string {
 	return &result
 }
 
-// deepCopySecret returns a deep copy of s so that its pointer fields do not
-// alias the original.
-func deepCopySecret(s workspace.Secret) workspace.Secret {
-	if s.Header != nil {
-		headerCopy := *s.Header
-		s.Header = &headerCopy
-	}
-	if s.HeaderTemplate != nil {
-		htCopy := *s.HeaderTemplate
-		s.HeaderTemplate = &htCopy
-	}
-	if s.Hosts != nil {
-		hostsCopy := make([]string, len(*s.Hosts))
-		copy(hostsCopy, *s.Hosts)
-		s.Hosts = &hostsCopy
-	}
-	if s.Name != nil {
-		nameCopy := *s.Name
-		s.Name = &nameCopy
-	}
-	if s.Path != nil {
-		pathCopy := *s.Path
-		s.Path = &pathCopy
-	}
-	return s
-}
-
-// secretKey builds the deduplication key for a secret from its (type, name) tuple.
-func secretKey(s workspace.Secret) struct{ typ, name string } {
-	name := ""
-	if s.Name != nil {
-		name = *s.Name
-	}
-	return struct{ typ, name string }{typ: s.Type, name: name}
-}
-
-// mergeSecrets merges secret slices, deduplicating by (type, name) tuple.
-// Secrets from base come first; override entries replace base entries with the
-// same key.
-func mergeSecrets(base, override *[]workspace.Secret) *[]workspace.Secret {
+// mergeSecrets merges secret name slices, deduplicating by name.
+// Names from base come first; names from override are appended if not already present.
+func mergeSecrets(base, override *[]string) *[]string {
 	if base == nil && override == nil {
 		return nil
 	}
+	seen := make(map[string]bool)
+	var result []string
 
-	type sKey = struct{ typ, name string }
-	sMap := make(map[sKey]workspace.Secret)
-	var order []sKey
-
-	if base != nil {
-		for _, s := range *base {
-			key := secretKey(s)
-			sMap[key] = s
-			order = append(order, key)
+	for _, slice := range []*[]string{base, override} {
+		if slice == nil {
+			continue
 		}
-	}
-
-	if override != nil {
-		for _, s := range *override {
-			key := secretKey(s)
-			if _, exists := sMap[key]; !exists {
-				order = append(order, key)
+		for _, name := range *slice {
+			if !seen[name] {
+				seen[name] = true
+				result = append(result, name)
 			}
-			sMap[key] = s
 		}
 	}
 
-	if len(sMap) == 0 {
+	if len(result) == 0 {
 		return nil
-	}
-
-	result := make([]workspace.Secret, 0, len(order))
-	for _, key := range order {
-		result = append(result, deepCopySecret(sMap[key]))
 	}
 	return &result
 }
@@ -593,10 +543,8 @@ func copyConfig(cfg *workspace.WorkspaceConfiguration) *workspace.WorkspaceConfi
 
 	// Copy secrets
 	if cfg.Secrets != nil {
-		secretsCopy := make([]workspace.Secret, len(*cfg.Secrets))
-		for i, s := range *cfg.Secrets {
-			secretsCopy[i] = deepCopySecret(s)
-		}
+		secretsCopy := make([]string, len(*cfg.Secrets))
+		copy(secretsCopy, *cfg.Secrets)
 		result.Secrets = &secretsCopy
 	}
 

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -1011,15 +1011,11 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "gh-token-1"},
-			},
+			Secrets: &[]string{"gh-token", "slack-token"},
 		}
 
 		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "slack", Value: "slack-token-1"},
-			},
+			Secrets: &[]string{"other-token"},
 		}
 
 		result := merger.Merge(base, override)
@@ -1029,130 +1025,47 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 		}
 
 		secrets := *result.Secrets
-		if len(secrets) != 2 {
-			t.Errorf("Expected 2 secrets, got %d", len(secrets))
+		if len(secrets) != 3 {
+			t.Errorf("Expected 3 secrets, got %d", len(secrets))
 		}
 
-		if secrets[0].Type != "github" || secrets[0].Value != "gh-token-1" {
-			t.Error("First secret should be from base")
+		if secrets[0] != "gh-token" {
+			t.Errorf("Expected first secret to be %q, got %q", "gh-token", secrets[0])
 		}
-		if secrets[1].Type != "slack" || secrets[1].Value != "slack-token-1" {
-			t.Error("Second secret should be from override")
+		if secrets[1] != "slack-token" {
+			t.Errorf("Expected second secret to be %q, got %q", "slack-token", secrets[1])
 		}
-	})
-
-	t.Run("override takes precedence by type", func(t *testing.T) {
-		t.Parallel()
-
-		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "old-token"},
-				{Type: "slack", Value: "keep-this"},
-			},
-		}
-
-		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "new-token"},
-			},
-		}
-
-		result := merger.Merge(base, override)
-
-		secrets := *result.Secrets
-		if len(secrets) != 2 {
-			t.Fatalf("Expected 2 secrets, got %d", len(secrets))
-		}
-
-		if secrets[0].Type != "github" || secrets[0].Value != "new-token" {
-			t.Errorf("Expected github secret to be overridden, got value %q", secrets[0].Value)
-		}
-		if secrets[1].Type != "slack" || secrets[1].Value != "keep-this" {
-			t.Error("Slack secret should be preserved from base")
+		if secrets[2] != "other-token" {
+			t.Errorf("Expected third secret to be %q, got %q", "other-token", secrets[2])
 		}
 	})
 
-	t.Run("override by type and name tuple", func(t *testing.T) {
+	t.Run("deduplication by name", func(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("api-key"), Value: "old-key"},
-				{Type: "other", Name: strPtr("db-pass"), Value: "old-db"},
-			},
+			Secrets: &[]string{"gh-token", "slack-token"},
 		}
 
 		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("api-key"), Value: "new-key"},
-				{Type: "other", Name: strPtr("cache-key"), Value: "cache-val"},
-			},
+			Secrets: &[]string{"gh-token", "other-token"},
 		}
 
 		result := merger.Merge(base, override)
 
 		secrets := *result.Secrets
 		if len(secrets) != 3 {
-			t.Fatalf("Expected 3 secrets, got %d", len(secrets))
+			t.Fatalf("Expected 3 secrets (deduplication), got %d", len(secrets))
 		}
 
-		// api-key should be overridden
-		if secrets[0].Value != "new-key" {
-			t.Errorf("Expected api-key value to be overridden, got %q", secrets[0].Value)
+		if secrets[0] != "gh-token" {
+			t.Errorf("Expected first to be %q, got %q", "gh-token", secrets[0])
 		}
-		// db-pass preserved from base
-		if secrets[1].Value != "old-db" {
-			t.Errorf("Expected db-pass to be preserved, got %q", secrets[1].Value)
+		if secrets[1] != "slack-token" {
+			t.Errorf("Expected second to be %q, got %q", "slack-token", secrets[1])
 		}
-		// cache-key added from override
-		if secrets[2].Value != "cache-val" {
-			t.Errorf("Expected cache-key to be added, got %q", secrets[2].Value)
-		}
-	})
-
-	t.Run("same type different names are distinct", func(t *testing.T) {
-		t.Parallel()
-
-		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("key-a"), Value: "val-a"},
-			},
-		}
-
-		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("key-b"), Value: "val-b"},
-			},
-		}
-
-		result := merger.Merge(base, override)
-
-		secrets := *result.Secrets
-		if len(secrets) != 2 {
-			t.Fatalf("Expected 2 secrets (different names), got %d", len(secrets))
-		}
-	})
-
-	t.Run("nil name vs named are distinct", func(t *testing.T) {
-		t.Parallel()
-
-		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "unnamed-token"},
-			},
-		}
-
-		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Name: strPtr("org-token"), Value: "named-token"},
-			},
-		}
-
-		result := merger.Merge(base, override)
-
-		secrets := *result.Secrets
-		if len(secrets) != 2 {
-			t.Fatalf("Expected 2 secrets (nil name != named), got %d", len(secrets))
+		if secrets[2] != "other-token" {
+			t.Errorf("Expected third to be %q, got %q", "other-token", secrets[2])
 		}
 	})
 
@@ -1160,18 +1073,11 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "gh"},
-				{Type: "slack", Value: "sl"},
-				{Type: "other", Name: strPtr("x"), Value: "x-val"},
-			},
+			Secrets: &[]string{"a", "b", "c"},
 		}
 
 		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "slack", Value: "sl-override"},
-				{Type: "other", Name: strPtr("y"), Value: "y-val"},
-			},
+			Secrets: &[]string{"b", "d"},
 		}
 
 		result := merger.Merge(base, override)
@@ -1181,18 +1087,11 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 			t.Fatalf("Expected 4 secrets, got %d", len(secrets))
 		}
 
-		// Order: github (base), slack (base pos, override value), other/x (base), other/y (override)
-		if secrets[0].Type != "github" {
-			t.Errorf("Expected first to be github, got %s", secrets[0].Type)
-		}
-		if secrets[1].Type != "slack" || secrets[1].Value != "sl-override" {
-			t.Errorf("Expected second to be slack with overridden value")
-		}
-		if secrets[2].Type != "other" || *secrets[2].Name != "x" {
-			t.Errorf("Expected third to be other/x")
-		}
-		if secrets[3].Type != "other" || *secrets[3].Name != "y" {
-			t.Errorf("Expected fourth to be other/y")
+		expected := []string{"a", "b", "c", "d"}
+		for i, want := range expected {
+			if secrets[i] != want {
+				t.Errorf("secrets[%d] = %q, want %q", i, secrets[i], want)
+			}
 		}
 	})
 
@@ -1201,9 +1100,7 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 
 		base := &workspace.WorkspaceConfiguration{}
 		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "token"},
-			},
+			Secrets: &[]string{"my-token"},
 		}
 
 		result := merger.Merge(base, override)
@@ -1217,9 +1114,7 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "github", Value: "token"},
-			},
+			Secrets: &[]string{"my-token"},
 		}
 		override := &workspace.WorkspaceConfiguration{}
 
@@ -1234,10 +1129,10 @@ func TestMerger_Merge_Secrets(t *testing.T) {
 		t.Parallel()
 
 		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{},
+			Secrets: &[]string{},
 		}
 		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{},
+			Secrets: &[]string{},
 		}
 
 		result := merger.Merge(base, override)
@@ -1253,64 +1148,21 @@ func TestMerger_Merge_Secrets_DeepCopy(t *testing.T) {
 
 	merger := NewMerger()
 
-	t.Run("mutating merged secret Hosts does not affect base", func(t *testing.T) {
+	t.Run("mutating merged secrets does not affect base", func(t *testing.T) {
 		t.Parallel()
 
-		hosts := []string{"example.com"}
 		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("api"), Value: "token", Hosts: &hosts},
-			},
+			Secrets: &[]string{"original"},
 		}
 
 		result := merger.Merge(base, nil)
 
-		// Mutate the result's Hosts slice
-		(*result.Secrets)[0].Hosts = &[]string{"other.com"}
+		// Mutate the result's slice
+		(*result.Secrets)[0] = "mutated"
 
 		// Base must be unaffected
-		if (*(*base.Secrets)[0].Hosts)[0] != "example.com" {
-			t.Error("Mutating merged secret Hosts affected the base input")
-		}
-	})
-
-	t.Run("mutating merged secret Name does not affect base", func(t *testing.T) {
-		t.Parallel()
-
-		base := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("original"), Value: "token"},
-			},
-		}
-
-		result := merger.Merge(base, nil)
-
-		// Mutate the result's Name
-		*(*result.Secrets)[0].Name = "mutated"
-
-		// Base must be unaffected
-		if *(*base.Secrets)[0].Name != "original" {
-			t.Error("Mutating merged secret Name affected the base input")
-		}
-	})
-
-	t.Run("mutating merged secret Header does not affect override", func(t *testing.T) {
-		t.Parallel()
-
-		override := &workspace.WorkspaceConfiguration{
-			Secrets: &[]workspace.Secret{
-				{Type: "other", Name: strPtr("api"), Value: "token", Header: strPtr("Authorization")},
-			},
-		}
-
-		result := merger.Merge(nil, override)
-
-		// Mutate the result's Header
-		*(*result.Secrets)[0].Header = "X-Custom"
-
-		// Override must be unaffected
-		if *(*override.Secrets)[0].Header != "Authorization" {
-			t.Error("Mutating merged secret Header affected the override input")
+		if (*base.Secrets)[0] != "original" {
+			t.Error("Mutating merged secrets affected the base input")
 		}
 	})
 }

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/git"
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
@@ -101,6 +102,7 @@ type manager struct {
 	runtimeRegistry       runtime.Registry
 	agentRegistry         agent.Registry
 	secretServiceRegistry secretservice.Registry
+	secretStore           secret.Store
 	gitDetector           git.Detector
 }
 
@@ -116,12 +118,13 @@ func NewManager(storageDir string) (Manager, error) {
 	}
 	agentReg := agent.NewRegistry()
 	secretServiceReg := secretservice.NewRegistry()
-	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, agentReg, secretServiceReg, git.NewDetector())
+	secretStore := secret.NewStore(storageDir)
+	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, agentReg, secretServiceReg, secretStore, git.NewDetector())
 }
 
 // newManagerWithFactory creates a new instance manager with a custom instance factory, generator, registry, and git detector.
 // This is unexported and primarily useful for testing with fake instances, generators, runtimes, and git detector.
-func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, agentReg agent.Registry, secretServiceReg secretservice.Registry, detector git.Detector) (Manager, error) {
+func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, agentReg agent.Registry, secretServiceReg secretservice.Registry, secretStore secret.Store, detector git.Detector) (Manager, error) {
 	if storageDir == "" {
 		return nil, errors.New("storage directory cannot be empty")
 	}
@@ -139,6 +142,9 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 	}
 	if secretServiceReg == nil {
 		return nil, errors.New("secret service registry cannot be nil")
+	}
+	if secretStore == nil {
+		return nil, errors.New("secret store cannot be nil")
 	}
 	if detector == nil {
 		return nil, errors.New("git detector cannot be nil")
@@ -158,6 +164,7 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 		runtimeRegistry:       reg,
 		agentRegistry:         agentReg,
 		secretServiceRegistry: secretServiceReg,
+		secretStore:           secretStore,
 		gitDetector:           detector,
 	}, nil
 }
@@ -293,18 +300,26 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 	secretEnvVars := make(map[string]string)
 	if mergedConfig != nil && mergedConfig.Secrets != nil && len(*mergedConfig.Secrets) > 0 {
 		mapper := onecli.NewSecretMapper(m.secretServiceRegistry)
-		for i, s := range *mergedConfig.Secrets {
-			input, err := mapper.Map(s)
+		for i, name := range *mergedConfig.Secrets {
+			item, value, err := m.secretStore.Get(name)
 			if err != nil {
-				return nil, fmt.Errorf("failed to map secret at index %d: %w", i, err)
+				return nil, fmt.Errorf("failed to get secret %q at index %d: %w", name, i, err)
+			}
+			input, err := mapper.Map(item, value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map secret %q at index %d: %w", name, i, err)
 			}
 			onecliSecrets = append(onecliSecrets, input)
 
-			if s.Type != "other" {
-				if svc, svcErr := m.secretServiceRegistry.Get(s.Type); svcErr == nil {
+			if item.Type != secret.TypeOther {
+				if svc, svcErr := m.secretServiceRegistry.Get(item.Type); svcErr == nil {
 					for _, envVar := range svc.EnvVars() {
 						secretEnvVars[envVar] = "placeholder"
 					}
+				}
+			} else {
+				for _, envVar := range item.Envs {
+					secretEnvVars[envVar] = "placeholder"
 				}
 			}
 		}

--- a/pkg/instances/manager_project_test.go
+++ b/pkg/instances/manager_project_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openkaiden/kdn/pkg/agent"
 	"github.com/openkaiden/kdn/pkg/git"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
@@ -36,7 +37,7 @@ func TestManager_detectProject(t *testing.T) {
 		// Create fake git detector that returns ErrNotGitRepository
 		gitDetector := newFakeGitDetector()
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), sourceDir)
@@ -59,7 +60,7 @@ func TestManager_detectProject(t *testing.T) {
 			"", // at root, relative path is empty
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)
@@ -84,7 +85,7 @@ func TestManager_detectProject(t *testing.T) {
 			filepath.Join("pkg", "git"),
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), subDir)
@@ -108,7 +109,7 @@ func TestManager_detectProject(t *testing.T) {
 			"", // at root
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)
@@ -132,7 +133,7 @@ func TestManager_detectProject(t *testing.T) {
 			filepath.Join("pkg", "utils"),
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), subDir)
@@ -156,7 +157,7 @@ func TestManager_detectProject(t *testing.T) {
 			"",
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)
@@ -180,7 +181,7 @@ func TestManager_detectProject(t *testing.T) {
 			filepath.Join("pkg", "cmd"),
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)

--- a/pkg/instances/manager_terminal_test.go
+++ b/pkg/instances/manager_terminal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/agent"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
@@ -82,7 +83,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -131,7 +132,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -159,7 +160,7 @@ func TestManager_Terminal(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistryWithTerminal(tmpDir, nil), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistryWithTerminal(tmpDir, nil), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		err := manager.Terminal(context.Background(), "nonexistent-id", []string{"bash"})
 		if !errors.Is(err, ErrInstanceNotFound) {
@@ -177,7 +178,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -222,7 +223,7 @@ func TestManager_Terminal(t *testing.T) {
 		regularFakeRT := fake.New()
 		_ = reg.Register(regularFakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -256,7 +257,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -3987,6 +3987,444 @@ func TestManager_Add_AppliesAgentMCPServers(t *testing.T) {
 	})
 }
 
+// fakeSecretStore is a test double for the secret.Store interface.
+type fakeSecretStore struct {
+	mu    sync.RWMutex
+	items map[string]fakeSecretStoreEntry
+}
+
+type fakeSecretStoreEntry struct {
+	item  secret.ListItem
+	value string
+	err   error
+}
+
+var _ secret.Store = (*fakeSecretStore)(nil)
+
+func newFakeSecretStore() *fakeSecretStore {
+	return &fakeSecretStore{items: make(map[string]fakeSecretStoreEntry)}
+}
+
+func (s *fakeSecretStore) setSecret(name string, item secret.ListItem, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[name] = fakeSecretStoreEntry{item: item, value: value}
+}
+
+func (s *fakeSecretStore) setError(name string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[name] = fakeSecretStoreEntry{err: err}
+}
+
+func (s *fakeSecretStore) Create(_ secret.CreateParams) error { return nil }
+func (s *fakeSecretStore) List() ([]secret.ListItem, error)   { return nil, nil }
+func (s *fakeSecretStore) Remove(_ string) error              { return nil }
+
+func (s *fakeSecretStore) Get(name string) (secret.ListItem, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.items[name]
+	if !ok {
+		return secret.ListItem{}, "", fmt.Errorf("secret %q not found", name)
+	}
+	if e.err != nil {
+		return secret.ListItem{}, "", e.err
+	}
+	return e.item, e.value, nil
+}
+
+// newTestRuntimeRegistry creates a runtime registry containing only the spy runtime.
+func newTestRuntimeRegistry(t *testing.T, tmpDir string, spy *spyRuntime) runtime.Registry {
+	t.Helper()
+	runtimesDir := filepath.Join(tmpDir, RuntimesSubdirectory)
+	reg, err := runtime.NewRegistry(runtimesDir)
+	if err != nil {
+		t.Fatalf("failed to create runtime registry: %v", err)
+	}
+	if err := reg.Register(spy); err != nil {
+		t.Fatalf("failed to register spy runtime: %v", err)
+	}
+	return reg
+}
+
+// newRealInstance creates a real Instance for use in integration-style manager tests.
+func newRealInstance(t *testing.T) Instance {
+	t.Helper()
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "source")
+	configDir := filepath.Join(tmpDir, "config")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("failed to create source dir: %v", err)
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	inst, err := NewInstance(NewInstanceParams{SourceDir: sourceDir, ConfigDir: configDir})
+	if err != nil {
+		t.Fatalf("failed to create instance: %v", err)
+	}
+	return inst
+}
+
+func TestManager_Add_Secrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error when secret store get fails", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		store := newFakeSecretStore()
+		store.setError("my-secret", errors.New("keychain unavailable"))
+
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRegistry(tmpDir),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(),
+			store,
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		secretNames := []string{"my-secret"}
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: &secretNames,
+			},
+		})
+		if addErr == nil {
+			t.Fatal("Add() expected error when secret store fails, got nil")
+		}
+		if !strings.Contains(addErr.Error(), "failed to get secret") {
+			t.Errorf("Add() error = %q, want to contain %q", addErr.Error(), "failed to get secret")
+		}
+		if !strings.Contains(addErr.Error(), "my-secret") {
+			t.Errorf("Add() error = %q, want to contain secret name %q", addErr.Error(), "my-secret")
+		}
+	})
+
+	t.Run("returns error when secret mapper fails for unregistered type", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		store := newFakeSecretStore()
+		store.setSecret("gh-secret", secret.ListItem{
+			Name: "gh-secret",
+			Type: "github", // known type but not registered in the registry
+		}, "ghp_token123")
+
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRegistry(tmpDir),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(), // empty registry — mapper.Map will fail
+			store,
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		secretNames := []string{"gh-secret"}
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: &secretNames,
+			},
+		})
+		if addErr == nil {
+			t.Fatal("Add() expected error when mapper fails, got nil")
+		}
+		if !strings.Contains(addErr.Error(), "failed to map secret") {
+			t.Errorf("Add() error = %q, want to contain %q", addErr.Error(), "failed to map secret")
+		}
+	})
+
+	t.Run("passes known-type secret to runtime with env vars from service", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		store := newFakeSecretStore()
+		store.setSecret("gh-token", secret.ListItem{
+			Name: "gh-token",
+			Type: "github",
+		}, "ghp_abc123")
+
+		spy := newSpyRuntime(fake.New())
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRuntimeRegistry(t, tmpDir, spy),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(),
+			store,
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		svc := &fakeSecretServiceImpl{
+			name:           "github",
+			hostPattern:    `github\.com`,
+			headerName:     "Authorization",
+			headerTemplate: "Bearer ${value}",
+			envVars:        []string{"GITHUB_TOKEN"},
+		}
+		if err := manager.RegisterSecretService(svc); err != nil {
+			t.Fatalf("RegisterSecretService() error = %v", err)
+		}
+
+		secretNames := []string{"gh-token"}
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: &secretNames,
+			},
+		})
+		if addErr != nil {
+			t.Fatalf("Add() unexpected error = %v", addErr)
+		}
+
+		params := spy.LastCreateParams()
+		if len(params.OnecliSecrets) != 1 {
+			t.Fatalf("OnecliSecrets len = %d, want 1", len(params.OnecliSecrets))
+		}
+		got := params.OnecliSecrets[0]
+		if got.Name != "gh-token" {
+			t.Errorf("OnecliSecrets[0].Name = %q, want %q", got.Name, "gh-token")
+		}
+		if got.HostPattern != `github\.com` {
+			t.Errorf("OnecliSecrets[0].HostPattern = %q, want %q", got.HostPattern, `github\.com`)
+		}
+		if got.Value != "ghp_abc123" {
+			t.Errorf("OnecliSecrets[0].Value = %q, want %q", got.Value, "ghp_abc123")
+		}
+		if params.SecretEnvVars == nil {
+			t.Fatal("SecretEnvVars is nil, want non-nil")
+		}
+		if val, ok := params.SecretEnvVars["GITHUB_TOKEN"]; !ok {
+			t.Error("SecretEnvVars missing GITHUB_TOKEN")
+		} else if val != "placeholder" {
+			t.Errorf("SecretEnvVars[GITHUB_TOKEN] = %q, want %q", val, "placeholder")
+		}
+	})
+
+	t.Run("passes other-type secret to runtime with env vars from secret Envs", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		store := newFakeSecretStore()
+		store.setSecret("custom-token", secret.ListItem{
+			Name:   "custom-token",
+			Type:   secret.TypeOther,
+			Hosts:  []string{"api.example.com"},
+			Header: "X-Api-Key",
+			Envs:   []string{"MY_API_KEY", "EXAMPLE_TOKEN"},
+		}, "secret-value-xyz")
+
+		spy := newSpyRuntime(fake.New())
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRuntimeRegistry(t, tmpDir, spy),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(),
+			store,
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		secretNames := []string{"custom-token"}
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: &secretNames,
+			},
+		})
+		if addErr != nil {
+			t.Fatalf("Add() unexpected error = %v", addErr)
+		}
+
+		params := spy.LastCreateParams()
+		if len(params.OnecliSecrets) != 1 {
+			t.Fatalf("OnecliSecrets len = %d, want 1", len(params.OnecliSecrets))
+		}
+		got := params.OnecliSecrets[0]
+		if got.Name != "custom-token" {
+			t.Errorf("OnecliSecrets[0].Name = %q, want %q", got.Name, "custom-token")
+		}
+		if got.HostPattern != "api.example.com" {
+			t.Errorf("OnecliSecrets[0].HostPattern = %q, want %q", got.HostPattern, "api.example.com")
+		}
+		if params.SecretEnvVars == nil {
+			t.Fatal("SecretEnvVars is nil, want non-nil")
+		}
+		for _, envVar := range []string{"MY_API_KEY", "EXAMPLE_TOKEN"} {
+			if val, ok := params.SecretEnvVars[envVar]; !ok {
+				t.Errorf("SecretEnvVars missing %q", envVar)
+			} else if val != "placeholder" {
+				t.Errorf("SecretEnvVars[%q] = %q, want %q", envVar, val, "placeholder")
+			}
+		}
+	})
+
+	t.Run("does not process secrets when secrets list is nil", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		spy := newSpyRuntime(fake.New())
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRuntimeRegistry(t, tmpDir, spy),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(),
+			newFakeSecretStore(),
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: nil,
+			},
+		})
+		if addErr != nil {
+			t.Fatalf("Add() unexpected error = %v", addErr)
+		}
+
+		params := spy.LastCreateParams()
+		if len(params.OnecliSecrets) != 0 {
+			t.Errorf("OnecliSecrets len = %d, want 0", len(params.OnecliSecrets))
+		}
+	})
+
+	t.Run("does not process secrets when secrets list is empty", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		spy := newSpyRuntime(fake.New())
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRuntimeRegistry(t, tmpDir, spy),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(),
+			newFakeSecretStore(),
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		emptySecrets := []string{}
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: &emptySecrets,
+			},
+		})
+		if addErr != nil {
+			t.Fatalf("Add() unexpected error = %v", addErr)
+		}
+
+		params := spy.LastCreateParams()
+		if len(params.OnecliSecrets) != 0 {
+			t.Errorf("OnecliSecrets len = %d, want 0", len(params.OnecliSecrets))
+		}
+	})
+
+	t.Run("processes multiple secrets", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		store := newFakeSecretStore()
+		store.setSecret("gh-token", secret.ListItem{
+			Name: "gh-token",
+			Type: "github",
+		}, "ghp_token")
+		store.setSecret("custom-api", secret.ListItem{
+			Name:  "custom-api",
+			Type:  secret.TypeOther,
+			Hosts: []string{"api.example.com"},
+			Envs:  []string{"EXAMPLE_API_KEY"},
+		}, "api-key-value")
+
+		spy := newSpyRuntime(fake.New())
+		manager, err := newManagerWithFactory(
+			tmpDir,
+			fakeInstanceFactory,
+			newFakeGenerator(),
+			newTestRuntimeRegistry(t, tmpDir, spy),
+			agent.NewRegistry(),
+			secretservice.NewRegistry(),
+			store,
+			newFakeGitDetector(),
+		)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+		svc := &fakeSecretServiceImpl{
+			name:        "github",
+			hostPattern: `github\.com`,
+			headerName:  "Authorization",
+			envVars:     []string{"GITHUB_TOKEN"},
+		}
+		if err := manager.RegisterSecretService(svc); err != nil {
+			t.Fatalf("RegisterSecretService() error = %v", err)
+		}
+
+		secretNames := []string{"gh-token", "custom-api"}
+		_, addErr := manager.Add(context.Background(), AddOptions{
+			Instance:    newRealInstance(t),
+			RuntimeType: "fake",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Secrets: &secretNames,
+			},
+		})
+		if addErr != nil {
+			t.Fatalf("Add() unexpected error = %v", addErr)
+		}
+
+		params := spy.LastCreateParams()
+		if len(params.OnecliSecrets) != 2 {
+			t.Fatalf("OnecliSecrets len = %d, want 2", len(params.OnecliSecrets))
+		}
+		if params.SecretEnvVars == nil {
+			t.Fatal("SecretEnvVars is nil, want non-nil")
+		}
+		for _, envVar := range []string{"GITHUB_TOKEN", "EXAMPLE_API_KEY"} {
+			if _, ok := params.SecretEnvVars[envVar]; !ok {
+				t.Errorf("SecretEnvVars missing %q", envVar)
+			}
+		}
+	})
+}
+
 // fakeSecretServiceImpl is a test implementation of the SecretService interface
 type fakeSecretServiceImpl struct {
 	name           string

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/git"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
@@ -416,7 +417,7 @@ func TestNewManager(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() unexpected error = %v", err)
 		}
@@ -448,7 +449,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -478,7 +479,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		_, err := manager.Add(context.Background(), AddOptions{Instance: nil, RuntimeType: "fake"})
 		if err == nil {
@@ -500,7 +501,7 @@ func TestManager_Add(t *testing.T) {
 			"duplicate-id-0000000000000000000000000000000000000000000000000000000a",
 			"unique-id-1-0000000000000000000000000000000000000000000000000000000b",
 		})
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		// Create instances without IDs (empty ID)
@@ -551,7 +552,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -577,7 +578,7 @@ func TestManager_Add(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -614,7 +615,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instances, err := manager.List()
 		if err != nil {
@@ -630,7 +631,7 @@ func TestManager_List(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -660,7 +661,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		// Create empty storage file
 		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
@@ -683,7 +684,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -716,7 +717,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		_, err := manager.Get("nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -728,7 +729,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -764,7 +765,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		_, err := manager.Get("nonexistent-name")
 		if err != ErrInstanceNotFound {
@@ -776,7 +777,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		// Create first instance
@@ -820,7 +821,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -850,7 +851,7 @@ func TestManager_Delete(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		err := manager.Delete(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -863,7 +864,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		source1 := filepath.Join(instanceTmpDir, "source1")
@@ -906,7 +907,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -920,7 +921,7 @@ func TestManager_Delete(t *testing.T) {
 		manager1.Delete(ctx, generatedID)
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		_, err := manager2.Get(generatedID)
 		if err != ErrInstanceNotFound {
 			t.Errorf("Get() from new manager error = %v, want %v", err, ErrInstanceNotFound)
@@ -932,7 +933,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -974,7 +975,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1006,7 +1007,7 @@ func TestManager_Start(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		err := manager.Start(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -1036,7 +1037,7 @@ func TestManager_Start(t *testing.T) {
 				runtime:    RuntimeData{}, // Empty runtime
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1076,7 +1077,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1087,7 +1088,7 @@ func TestManager_Start(t *testing.T) {
 		manager1.Start(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "running" {
@@ -1100,7 +1101,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1129,7 +1130,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1163,7 +1164,7 @@ func TestManager_Stop(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		err := manager.Stop(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -1176,7 +1177,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1216,7 +1217,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1228,7 +1229,7 @@ func TestManager_Stop(t *testing.T) {
 		manager1.Stop(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "stopped" {
@@ -1241,7 +1242,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1272,7 +1273,7 @@ func TestManager_Stop(t *testing.T) {
 				RelativePath: "",
 			},
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1316,7 +1317,7 @@ func TestManager_Stop(t *testing.T) {
 				RelativePath: "",
 			},
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), gitDetector)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1353,7 +1354,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1403,7 +1404,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1447,7 +1448,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1491,7 +1492,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inaccessibleSource := filepath.Join(instanceTmpDir, "nonexistent-source")
@@ -1540,7 +1541,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: accessible,
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		accessibleConfig := filepath.Join(instanceTmpDir, "accessible-config")
 
@@ -1583,7 +1584,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1607,7 +1608,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		removed, err := manager.Reconcile()
 		if err != nil {
@@ -1630,7 +1631,7 @@ func TestManager_Persistence(t *testing.T) {
 		instanceTmpDir := t.TempDir()
 
 		// Create first manager and add instance
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		expectedSource := filepath.Join(instanceTmpDir, "source")
 		expectedConfig := filepath.Join(instanceTmpDir, "config")
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1643,7 +1644,7 @@ func TestManager_Persistence(t *testing.T) {
 		generatedID := added.GetID()
 
 		// Create second manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		instances, err := manager2.List()
 		if err != nil {
 			t.Fatalf("List() from second manager unexpected error = %v", err)
@@ -1664,7 +1665,7 @@ func TestManager_Persistence(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -1716,7 +1717,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		var wg sync.WaitGroup
@@ -1749,7 +1750,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		instanceTmpDir := t.TempDir()
 		// Add some instances first
@@ -1830,7 +1831,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		// Cast to concrete type to access unexported methods
 		mgr := m.(*manager)
@@ -1863,7 +1864,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1888,7 +1889,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1927,7 +1928,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1963,7 +1964,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -1984,7 +1985,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -2001,7 +2002,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -2026,7 +2027,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -2044,7 +2045,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -2065,7 +2066,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -2083,7 +2084,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		mgr := m.(*manager)
 
@@ -2105,7 +2106,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2155,7 +2156,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2216,7 +2217,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2292,7 +2293,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2391,7 +2392,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2445,7 +2446,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		result, err := mgr.mergeConfigurations("github.com/user/repo", nil, "")
@@ -2473,7 +2474,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -2503,7 +2504,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -2543,7 +2544,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -4010,7 +4011,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		svc := &fakeSecretServiceImpl{name: "github", hostPattern: `github\.com`, headerName: "Authorization"}
 
@@ -4024,7 +4025,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
 		svc1 := &fakeSecretServiceImpl{name: "github", headerName: "Authorization"}
 		svc2 := &fakeSecretServiceImpl{name: "github", headerName: "X-Token"}

--- a/pkg/onecli/mapper.go
+++ b/pkg/onecli/mapper.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 	"strings"
 
-	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
 const secretTypeOther = "other"
 
-// SecretMapper converts workspace secrets to OneCLI CreateSecretInput values.
+// SecretMapper converts stored secrets to OneCLI CreateSecretInput values.
 type SecretMapper interface {
-	Map(secret workspace.Secret) (CreateSecretInput, error)
+	Map(item secret.ListItem, value string) (CreateSecretInput, error)
 }
 
 type secretMapper struct {
@@ -45,26 +45,26 @@ func NewSecretMapper(registry secretservice.Registry) SecretMapper {
 	return &secretMapper{registry: registry}
 }
 
-// Map converts a workspace secret to a CreateSecretInput.
-// For type "other", the secret's own fields are used directly.
+// Map converts a stored secret item and its value to a CreateSecretInput.
+// For type "other", the item's own fields are used directly.
 // For all other types, the SecretService registry provides host pattern, header, and template.
-func (m *secretMapper) Map(secret workspace.Secret) (CreateSecretInput, error) {
-	if secret.Type == secretTypeOther {
-		return m.mapOtherSecret(secret)
+func (m *secretMapper) Map(item secret.ListItem, value string) (CreateSecretInput, error) {
+	if item.Type == secretTypeOther {
+		return m.mapOtherSecret(item, value)
 	}
-	return m.mapKnownSecret(secret)
+	return m.mapKnownSecret(item, value)
 }
 
-func (m *secretMapper) mapKnownSecret(secret workspace.Secret) (CreateSecretInput, error) {
-	svc, err := m.registry.Get(secret.Type)
+func (m *secretMapper) mapKnownSecret(item secret.ListItem, value string) (CreateSecretInput, error) {
+	svc, err := m.registry.Get(item.Type)
 	if err != nil {
-		return CreateSecretInput{}, fmt.Errorf("unknown secret type %q: %w", secret.Type, err)
+		return CreateSecretInput{}, fmt.Errorf("unknown secret type %q: %w", item.Type, err)
 	}
 
 	input := CreateSecretInput{
-		Name:        secretName(secret.Name, secret.Type),
+		Name:        item.Name,
 		Type:        "generic",
-		Value:       secret.Value,
+		Value:       value,
 		HostPattern: svc.HostPattern(),
 		PathPattern: svc.Path(),
 	}
@@ -79,48 +79,32 @@ func (m *secretMapper) mapKnownSecret(secret workspace.Secret) (CreateSecretInpu
 	return input, nil
 }
 
-func (m *secretMapper) mapOtherSecret(secret workspace.Secret) (CreateSecretInput, error) {
-	if secret.Hosts != nil && len(*secret.Hosts) > 1 {
-		return CreateSecretInput{}, fmt.Errorf("secret type %q supports only one host per secret; declare one secret per host (got %d hosts)", secretTypeOther, len(*secret.Hosts))
+func (m *secretMapper) mapOtherSecret(item secret.ListItem, value string) (CreateSecretInput, error) {
+	if len(item.Hosts) > 1 {
+		return CreateSecretInput{}, fmt.Errorf("secret type %q supports only one host per secret; declare one secret per host (got %d hosts)", secretTypeOther, len(item.Hosts))
+	}
+
+	hostPattern := "*"
+	if len(item.Hosts) > 0 {
+		hostPattern = item.Hosts[0]
 	}
 
 	input := CreateSecretInput{
-		Name:        secretName(secret.Name, secretTypeOther),
+		Name:        item.Name,
 		Type:        "generic",
-		Value:       secret.Value,
-		HostPattern: otherHostPattern(secret.Hosts),
-		PathPattern: derefString(secret.Path),
+		Value:       value,
+		HostPattern: hostPattern,
+		PathPattern: item.Path,
 	}
 
-	if header := derefString(secret.Header); header != "" {
+	if item.Header != "" {
 		input.InjectionConfig = &InjectionConfig{
-			HeaderName:  header,
-			ValueFormat: convertTemplate(derefString(secret.HeaderTemplate)),
+			HeaderName:  item.Header,
+			ValueFormat: convertTemplate(item.HeaderTemplate),
 		}
 	}
 
 	return input, nil
-}
-
-func secretName(name *string, fallback string) string {
-	if name != nil && *name != "" {
-		return *name
-	}
-	return fallback
-}
-
-func otherHostPattern(hosts *[]string) string {
-	if hosts != nil && len(*hosts) > 0 {
-		return (*hosts)[0]
-	}
-	return "*"
-}
-
-func derefString(s *string) string {
-	if s != nil {
-		return *s
-	}
-	return ""
 }
 
 // convertTemplate converts kdn's ${value} placeholder to OneCLI's {value} format.

--- a/pkg/onecli/mapper_test.go
+++ b/pkg/onecli/mapper_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
@@ -43,24 +43,22 @@ func registryWithGitHub(t *testing.T) secretservice.Registry {
 	return reg
 }
 
-func strPtr(s string) *string { return &s }
-
 func TestMapper_KnownType_GitHub(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(registryWithGitHub(t))
-	secret := workspace.Secret{
-		Type:  "github",
-		Value: "ghp_abc123",
+	item := secret.ListItem{
+		Name: "my-gh-token",
+		Type: "github",
 	}
 
-	got, err := mapper.Map(secret)
+	got, err := mapper.Map(item, "ghp_abc123")
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
 
-	if got.Name != "github" {
-		t.Errorf("Name = %q, want %q", got.Name, "github")
+	if got.Name != "my-gh-token" {
+		t.Errorf("Name = %q, want %q", got.Name, "my-gh-token")
 	}
 	if got.Type != "generic" {
 		t.Errorf("Type = %q, want %q", got.Type, "generic")
@@ -82,35 +80,16 @@ func TestMapper_KnownType_GitHub(t *testing.T) {
 	}
 }
 
-func TestMapper_KnownType_WithName(t *testing.T) {
-	t.Parallel()
-
-	mapper := NewSecretMapper(registryWithGitHub(t))
-	secret := workspace.Secret{
-		Type:  "github",
-		Value: "ghp_abc123",
-		Name:  strPtr("my-gh-token"),
-	}
-
-	got, err := mapper.Map(secret)
-	if err != nil {
-		t.Fatalf("Map() error: %v", err)
-	}
-	if got.Name != "my-gh-token" {
-		t.Errorf("Name = %q, want %q", got.Name, "my-gh-token")
-	}
-}
-
 func TestMapper_UnknownType(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(secretservice.NewRegistry())
-	secret := workspace.Secret{
-		Type:  "unknown-service",
-		Value: "token",
+	item := secret.ListItem{
+		Name: "my-token",
+		Type: "unknown-service",
 	}
 
-	_, err := mapper.Map(secret)
+	_, err := mapper.Map(item, "token")
 	if err == nil {
 		t.Fatal("expected error for unknown type")
 	}
@@ -120,18 +99,16 @@ func TestMapper_OtherType_AllFields(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(secretservice.NewRegistry())
-	hosts := []string{"api.example.com"}
-	secret := workspace.Secret{
+	item := secret.ListItem{
+		Name:           "custom-api",
 		Type:           "other",
-		Value:          "my-key-123",
-		Name:           strPtr("custom-api"),
-		Header:         strPtr("X-Api-Key"),
-		HeaderTemplate: strPtr("Token ${value}"),
-		Hosts:          &hosts,
-		Path:           strPtr("/v2"),
+		Hosts:          []string{"api.example.com"},
+		Path:           "/v2",
+		Header:         "X-Api-Key",
+		HeaderTemplate: "Token ${value}",
 	}
 
-	got, err := mapper.Map(secret)
+	got, err := mapper.Map(item, "my-key-123")
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
@@ -166,14 +143,13 @@ func TestMapper_OtherType_MultipleHosts_Error(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(secretservice.NewRegistry())
-	hosts := []string{"api.example.com", "api2.example.com"}
-	secret := workspace.Secret{
+	item := secret.ListItem{
+		Name:  "my-token",
 		Type:  "other",
-		Value: "my-key-123",
-		Hosts: &hosts,
+		Hosts: []string{"api.example.com", "api2.example.com"},
 	}
 
-	_, err := mapper.Map(secret)
+	_, err := mapper.Map(item, "my-key-123")
 	if err == nil {
 		t.Fatal("expected error for multiple hosts, got nil")
 	}
@@ -186,12 +162,12 @@ func TestMapper_OtherType_MinimalFields(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(secretservice.NewRegistry())
-	secret := workspace.Secret{
-		Type:  "other",
-		Value: "secret-val",
+	item := secret.ListItem{
+		Name: "other",
+		Type: "other",
 	}
 
-	got, err := mapper.Map(secret)
+	got, err := mapper.Map(item, "secret-val")
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
@@ -214,14 +190,13 @@ func TestMapper_OtherType_EmptyHosts(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(secretservice.NewRegistry())
-	emptyHosts := []string{}
-	secret := workspace.Secret{
+	item := secret.ListItem{
+		Name:  "my-token",
 		Type:  "other",
-		Value: "val",
-		Hosts: &emptyHosts,
+		Hosts: []string{},
 	}
 
-	got, err := mapper.Map(secret)
+	got, err := mapper.Map(item, "val")
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -57,6 +57,9 @@ type Store interface {
 	Create(params CreateParams) error
 	// List returns the metadata for all stored secrets.
 	List() ([]ListItem, error)
+	// Get returns the metadata and value for the named secret.
+	// Returns ErrSecretNotFound if no secret with the given name exists.
+	Get(name string) (ListItem, string, error)
 	// Remove deletes the secret value from the system keychain and removes
 	// its metadata from the storage directory.
 	Remove(name string) error

--- a/pkg/secret/store.go
+++ b/pkg/secret/store.go
@@ -42,6 +42,7 @@ const (
 
 // keyring is an internal interface so tests can inject a fake implementation.
 type keyring interface {
+	Get(service, user string) (string, error)
 	Set(service, user, password string) error
 	Delete(service, user string) error
 }
@@ -50,6 +51,10 @@ type keyring interface {
 type realKeyring struct{}
 
 var _ keyring = (*realKeyring)(nil)
+
+func (r *realKeyring) Get(service, user string) (string, error) {
+	return gokeyring.Get(service, user)
+}
 
 func (r *realKeyring) Set(service, user, password string) error {
 	return gokeyring.Set(service, user, password)
@@ -136,6 +141,35 @@ func (s *store) List() ([]ListItem, error) {
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
 	return items, nil
+}
+
+// Get returns the metadata and keychain value for the named secret.
+func (s *store) Get(name string) (ListItem, string, error) {
+	sf, err := s.loadSecretsFile()
+	if err != nil {
+		return ListItem{}, "", err
+	}
+
+	for _, rec := range sf.Secrets {
+		if rec.Name == name {
+			value, err := s.kr.Get(keyringService, name)
+			if err != nil {
+				return ListItem{}, "", fmt.Errorf("failed to get secret from keychain: %w", err)
+			}
+			return ListItem{
+				Name:           rec.Name,
+				Type:           rec.Type,
+				Description:    rec.Description,
+				Hosts:          rec.Hosts,
+				Path:           rec.Path,
+				Header:         rec.Header,
+				HeaderTemplate: rec.HeaderTemplate,
+				Envs:           rec.Envs,
+			}, value, nil
+		}
+	}
+
+	return ListItem{}, "", fmt.Errorf("secret %q: %w", name, ErrSecretNotFound)
 }
 
 // Remove deletes the secret from the system keychain and removes its metadata.

--- a/pkg/secret/store_test.go
+++ b/pkg/secret/store_test.go
@@ -34,6 +34,7 @@ type fakeKeyring struct {
 	deleteCalls []fakeKeyringDeleteCall
 	setErr      error
 	deleteErr   error
+	getErr      error
 }
 
 type fakeKeyringSetCall struct {
@@ -45,6 +46,18 @@ type fakeKeyringSetCall struct {
 type fakeKeyringDeleteCall struct {
 	service string
 	user    string
+}
+
+func (f *fakeKeyring) Get(service, user string) (string, error) {
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	for _, call := range f.setCalls {
+		if call.service == service && call.user == user {
+			return call.password, nil
+		}
+	}
+	return "", gokeyring.ErrNotFound
 }
 
 func (f *fakeKeyring) Set(service, user, password string) error {
@@ -277,6 +290,79 @@ func TestStore_Remove_DeletesFromKeychainAndFile(t *testing.T) {
 	}
 	if len(sf.Secrets) != 0 {
 		t.Errorf("expected 0 secrets after Remove, got %d", len(sf.Secrets))
+	}
+}
+
+func TestStore_Get_ReturnsMetadataAndValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	kr := &fakeKeyring{}
+	st := newStoreWithKeyring(dir, kr)
+
+	if err := st.Create(CreateParams{
+		Name:           "my-gh-token",
+		Type:           "github",
+		Value:          "ghp_secret",
+		Description:    "My token",
+		Hosts:          []string{"api.github.com"},
+		Header:         "Authorization",
+		HeaderTemplate: "Bearer ${value}",
+		Envs:           []string{"GH_TOKEN"},
+	}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	item, value, err := st.Get("my-gh-token")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if value != "ghp_secret" {
+		t.Errorf("Get() value = %q, want %q", value, "ghp_secret")
+	}
+	if item.Name != "my-gh-token" {
+		t.Errorf("Get() item.Name = %q, want %q", item.Name, "my-gh-token")
+	}
+	if item.Type != "github" {
+		t.Errorf("Get() item.Type = %q, want %q", item.Type, "github")
+	}
+	if item.Header != "Authorization" {
+		t.Errorf("Get() item.Header = %q, want %q", item.Header, "Authorization")
+	}
+	if len(item.Envs) != 1 || item.Envs[0] != "GH_TOKEN" {
+		t.Errorf("Get() item.Envs = %v, want [GH_TOKEN]", item.Envs)
+	}
+}
+
+func TestStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+
+	st := newStoreWithKeyring(t.TempDir(), &fakeKeyring{})
+
+	_, _, err := st.Get("nonexistent")
+	if err == nil {
+		t.Fatal("expected error when secret does not exist")
+	}
+	if !errors.Is(err, ErrSecretNotFound) {
+		t.Errorf("expected ErrSecretNotFound, got: %v", err)
+	}
+}
+
+func TestStore_Get_KeychainError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	kr := &fakeKeyring{}
+	st := newStoreWithKeyring(dir, kr)
+
+	if err := st.Create(CreateParams{Name: "my-token", Type: "github", Value: "v"}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	kr.getErr = os.ErrPermission
+
+	_, _, err := st.Get("my-token")
+	if err == nil {
+		t.Fatal("expected error when keychain Get fails")
 	}
 }
 


### PR DESCRIPTION
Workspace configuration secrets are now a list of secret names instead of full descriptors (type, value, hosts, headers, etc.). Secret metadata and values are resolved at workspace creation time from the store managed by `kdn secret create`.

- Update workspace-configuration/go and cli/go to v0.5.0
- Simplify secrets validation and merge to deduplicate by name
- Add Store.Get() to retrieve metadata + keychain value by name
- Update SecretMapper to accept secret.ListItem + value
- Wire secret.Store into the instance manager for name lookup
- Update all tests and skills documentation

How to test: replace a `secrets` entry in ~/.kdn/config/projects.json from the old object form to a name string, create the matching secret with `kdn secret create`, then start a workspace:

    # projects.json (before)
    "secrets": [{"type": "github", "value": "ghp_..."}]

    # projects.json (after)
    "secrets": ["gh"]

    # create the secret
    kdn secret create gh --type github --value ghp_...

    # start a workspace — the GH_TOKEN env var should be injected
    kdn workspace start <name>

Closes #336