### PR TITLE
fix(onecli): support multiple hosts for type=other secrets

### DIFF
--- a/.agents/skills/working-with-onecli/SKILL.md
+++ b/.agents/skills/working-with-onecli/SKILL.md
@@ -108,13 +108,13 @@ apiKey, err := provider.APIKey(ctx)
 
 ```go
 mapper := onecli.NewSecretMapper(secretServiceRegistry)
-input, err := mapper.Map(secret)
+inputs, err := mapper.Map(secret)  // returns []CreateSecretInput
 ```
 
 ### Mapping rules
 
-- **Known type** (e.g. `github`): looks up the `SecretService` in the registry; uses its `HostPattern()`, `Path()`, `HeaderName()`, and `HeaderTemplate()` fields. The secret's `Name` field overrides the type name if set.
-- **`other` type**: uses the secret's own `Hosts`, `Path`, `Header`, `HeaderTemplate` fields. Only one host is allowed — split multi-host secrets into separate entries.
+- **Known type** (e.g. `github`): looks up the `SecretService` in the registry; uses its `HostPattern()`, `Path()`, `HeaderName()`, and `HeaderTemplate()` fields. Returns a single-element slice.
+- **`other` type**: uses the secret's own `Hosts`, `Path`, `Header`, `HeaderTemplate` fields. When multiple hosts are provided, one `CreateSecretInput` is returned per host with the name `<secret-name>-<sanitized-host>`; a single or empty `Hosts` returns a single element using `item.Name` unchanged.
 - Template conversion: kdn uses `${value}`, OneCLI uses `{value}` — the mapper converts automatically.
 - `HostPattern` is always `"*"` when `Hosts` is nil or empty.
 
@@ -155,9 +155,8 @@ The instances manager converts workspace-level secrets before calling the runtim
 ```go
 mapper := onecli.NewSecretMapper(secretServiceRegistry)
 for _, s := range workspaceConfig.Secrets {
-    input, err := mapper.Map(s)
-    // collect input.InjectionConfig env vars for the workspace environment
-    // pass inputs to runtime.CreateParams.OnecliSecrets
+    inputs, err := mapper.Map(s)  // []CreateSecretInput — one per host for type=other
+    // collect env vars, then append inputs... to runtime.CreateParams.OnecliSecrets
 }
 ```
 

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -305,11 +305,11 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to get secret %q at index %d: %w", name, i, err)
 			}
-			input, err := mapper.Map(item, value)
+			inputs, err := mapper.Map(item, value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to map secret %q at index %d: %w", name, i, err)
 			}
-			onecliSecrets = append(onecliSecrets, input)
+			onecliSecrets = append(onecliSecrets, inputs...)
 
 			if item.Type != secret.TypeOther {
 				if svc, svcErr := m.secretServiceRegistry.Get(item.Type); svcErr == nil {

--- a/pkg/onecli/mapper.go
+++ b/pkg/onecli/mapper.go
@@ -20,6 +20,7 @@ package onecli
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -30,7 +31,7 @@ const secretTypeOther = "other"
 
 // SecretMapper converts stored secrets to OneCLI CreateSecretInput values.
 type SecretMapper interface {
-	Map(item secret.ListItem, value string) (CreateSecretInput, error)
+	Map(item secret.ListItem, value string) ([]CreateSecretInput, error)
 }
 
 type secretMapper struct {
@@ -45,20 +46,20 @@ func NewSecretMapper(registry secretservice.Registry) SecretMapper {
 	return &secretMapper{registry: registry}
 }
 
-// Map converts a stored secret item and its value to a CreateSecretInput.
-// For type "other", the item's own fields are used directly.
+// Map converts a stored secret item and its value to a slice of CreateSecretInputs.
+// For type "other" with multiple hosts, one input is returned per host.
 // For all other types, the SecretService registry provides host pattern, header, and template.
-func (m *secretMapper) Map(item secret.ListItem, value string) (CreateSecretInput, error) {
+func (m *secretMapper) Map(item secret.ListItem, value string) ([]CreateSecretInput, error) {
 	if item.Type == secretTypeOther {
 		return m.mapOtherSecret(item, value)
 	}
 	return m.mapKnownSecret(item, value)
 }
 
-func (m *secretMapper) mapKnownSecret(item secret.ListItem, value string) (CreateSecretInput, error) {
+func (m *secretMapper) mapKnownSecret(item secret.ListItem, value string) ([]CreateSecretInput, error) {
 	svc, err := m.registry.Get(item.Type)
 	if err != nil {
-		return CreateSecretInput{}, fmt.Errorf("unknown secret type %q: %w", item.Type, err)
+		return nil, fmt.Errorf("unknown secret type %q: %w", item.Type, err)
 	}
 
 	input := CreateSecretInput{
@@ -76,35 +77,58 @@ func (m *secretMapper) mapKnownSecret(item secret.ListItem, value string) (Creat
 		}
 	}
 
-	return input, nil
+	return []CreateSecretInput{input}, nil
 }
 
-func (m *secretMapper) mapOtherSecret(item secret.ListItem, value string) (CreateSecretInput, error) {
-	if len(item.Hosts) > 1 {
-		return CreateSecretInput{}, fmt.Errorf("secret type %q supports only one host per secret; declare one secret per host (got %d hosts)", secretTypeOther, len(item.Hosts))
-	}
-
-	hostPattern := "*"
-	if len(item.Hosts) > 0 {
-		hostPattern = item.Hosts[0]
-	}
-
-	input := CreateSecretInput{
-		Name:        item.Name,
-		Type:        "generic",
-		Value:       value,
-		HostPattern: hostPattern,
-		PathPattern: item.Path,
-	}
-
-	if item.Header != "" {
-		input.InjectionConfig = &InjectionConfig{
-			HeaderName:  item.Header,
-			ValueFormat: convertTemplate(item.HeaderTemplate),
+func (m *secretMapper) mapOtherSecret(item secret.ListItem, value string) ([]CreateSecretInput, error) {
+	if len(item.Hosts) <= 1 {
+		hostPattern := "*"
+		if len(item.Hosts) == 1 {
+			hostPattern = item.Hosts[0]
 		}
+		input := CreateSecretInput{
+			Name:        item.Name,
+			Type:        "generic",
+			Value:       value,
+			HostPattern: hostPattern,
+			PathPattern: item.Path,
+		}
+		if item.Header != "" {
+			input.InjectionConfig = &InjectionConfig{
+				HeaderName:  item.Header,
+				ValueFormat: convertTemplate(item.HeaderTemplate),
+			}
+		}
+		return []CreateSecretInput{input}, nil
 	}
 
-	return input, nil
+	inputs := make([]CreateSecretInput, 0, len(item.Hosts))
+	for _, host := range item.Hosts {
+		input := CreateSecretInput{
+			Name:        item.Name + "-" + sanitizeName(host),
+			Type:        "generic",
+			Value:       value,
+			HostPattern: host,
+			PathPattern: item.Path,
+		}
+		if item.Header != "" {
+			input.InjectionConfig = &InjectionConfig{
+				HeaderName:  item.Header,
+				ValueFormat: convertTemplate(item.HeaderTemplate),
+			}
+		}
+		inputs = append(inputs, input)
+	}
+	return inputs, nil
+}
+
+var nonAlphanumRun = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// sanitizeName converts an arbitrary string to a DNS-safe name segment by
+// replacing runs of non-alphanumeric characters with a single hyphen and
+// trimming leading/trailing hyphens.
+func sanitizeName(s string) string {
+	return strings.Trim(nonAlphanumRun.ReplaceAllString(s, "-"), "-")
 }
 
 // convertTemplate converts kdn's ${value} placeholder to OneCLI's {value} format.

--- a/pkg/onecli/mapper.go
+++ b/pkg/onecli/mapper.go
@@ -103,9 +103,19 @@ func (m *secretMapper) mapOtherSecret(item secret.ListItem, value string) ([]Cre
 	}
 
 	inputs := make([]CreateSecretInput, 0, len(item.Hosts))
+	seen := make(map[string]string, len(item.Hosts))
 	for _, host := range item.Hosts {
+		suffix := sanitizeName(host)
+		if suffix == "" {
+			return nil, fmt.Errorf("host %q sanitizes to an empty name segment", host)
+		}
+		name := item.Name + "-" + suffix
+		if prev, ok := seen[name]; ok {
+			return nil, fmt.Errorf("hosts %q and %q produce duplicate secret name %q", prev, host, name)
+		}
+		seen[name] = host
 		input := CreateSecretInput{
-			Name:        item.Name + "-" + sanitizeName(host),
+			Name:        name,
 			Type:        "generic",
 			Value:       value,
 			HostPattern: host,

--- a/pkg/onecli/mapper_test.go
+++ b/pkg/onecli/mapper_test.go
@@ -19,7 +19,6 @@
 package onecli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -56,27 +55,30 @@ func TestMapper_KnownType_GitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
+	if len(got) != 1 {
+		t.Fatalf("Map() returned %d inputs, want 1", len(got))
+	}
 
-	if got.Name != "my-gh-token" {
-		t.Errorf("Name = %q, want %q", got.Name, "my-gh-token")
+	if got[0].Name != "my-gh-token" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "my-gh-token")
 	}
-	if got.Type != "generic" {
-		t.Errorf("Type = %q, want %q", got.Type, "generic")
+	if got[0].Type != "generic" {
+		t.Errorf("Type = %q, want %q", got[0].Type, "generic")
 	}
-	if got.Value != "ghp_abc123" {
-		t.Errorf("Value = %q, want %q", got.Value, "ghp_abc123")
+	if got[0].Value != "ghp_abc123" {
+		t.Errorf("Value = %q, want %q", got[0].Value, "ghp_abc123")
 	}
-	if got.HostPattern != "api.github.com" {
-		t.Errorf("HostPattern = %q, want %q", got.HostPattern, "api.github.com")
+	if got[0].HostPattern != "api.github.com" {
+		t.Errorf("HostPattern = %q, want %q", got[0].HostPattern, "api.github.com")
 	}
-	if got.InjectionConfig == nil {
+	if got[0].InjectionConfig == nil {
 		t.Fatal("InjectionConfig is nil")
 	}
-	if got.InjectionConfig.HeaderName != "Authorization" {
-		t.Errorf("HeaderName = %q, want %q", got.InjectionConfig.HeaderName, "Authorization")
+	if got[0].InjectionConfig.HeaderName != "Authorization" {
+		t.Errorf("HeaderName = %q, want %q", got[0].InjectionConfig.HeaderName, "Authorization")
 	}
-	if got.InjectionConfig.ValueFormat != "Bearer {value}" {
-		t.Errorf("ValueFormat = %q, want %q", got.InjectionConfig.ValueFormat, "Bearer {value}")
+	if got[0].InjectionConfig.ValueFormat != "Bearer {value}" {
+		t.Errorf("ValueFormat = %q, want %q", got[0].InjectionConfig.ValueFormat, "Bearer {value}")
 	}
 }
 
@@ -112,34 +114,37 @@ func TestMapper_OtherType_AllFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
+	if len(got) != 1 {
+		t.Fatalf("Map() returned %d inputs, want 1", len(got))
+	}
 
-	if got.Name != "custom-api" {
-		t.Errorf("Name = %q, want %q", got.Name, "custom-api")
+	if got[0].Name != "custom-api" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "custom-api")
 	}
-	if got.Type != "generic" {
-		t.Errorf("Type = %q, want %q", got.Type, "generic")
+	if got[0].Type != "generic" {
+		t.Errorf("Type = %q, want %q", got[0].Type, "generic")
 	}
-	if got.Value != "my-key-123" {
-		t.Errorf("Value = %q, want %q", got.Value, "my-key-123")
+	if got[0].Value != "my-key-123" {
+		t.Errorf("Value = %q, want %q", got[0].Value, "my-key-123")
 	}
-	if got.HostPattern != "api.example.com" {
-		t.Errorf("HostPattern = %q, want %q", got.HostPattern, "api.example.com")
+	if got[0].HostPattern != "api.example.com" {
+		t.Errorf("HostPattern = %q, want %q", got[0].HostPattern, "api.example.com")
 	}
-	if got.PathPattern != "/v2" {
-		t.Errorf("PathPattern = %q, want %q", got.PathPattern, "/v2")
+	if got[0].PathPattern != "/v2" {
+		t.Errorf("PathPattern = %q, want %q", got[0].PathPattern, "/v2")
 	}
-	if got.InjectionConfig == nil {
+	if got[0].InjectionConfig == nil {
 		t.Fatal("InjectionConfig is nil")
 	}
-	if got.InjectionConfig.HeaderName != "X-Api-Key" {
-		t.Errorf("HeaderName = %q, want %q", got.InjectionConfig.HeaderName, "X-Api-Key")
+	if got[0].InjectionConfig.HeaderName != "X-Api-Key" {
+		t.Errorf("HeaderName = %q, want %q", got[0].InjectionConfig.HeaderName, "X-Api-Key")
 	}
-	if got.InjectionConfig.ValueFormat != "Token {value}" {
-		t.Errorf("ValueFormat = %q, want %q", got.InjectionConfig.ValueFormat, "Token {value}")
+	if got[0].InjectionConfig.ValueFormat != "Token {value}" {
+		t.Errorf("ValueFormat = %q, want %q", got[0].InjectionConfig.ValueFormat, "Token {value}")
 	}
 }
 
-func TestMapper_OtherType_MultipleHosts_Error(t *testing.T) {
+func TestMapper_OtherType_MultipleHosts(t *testing.T) {
 	t.Parallel()
 
 	mapper := NewSecretMapper(secretservice.NewRegistry())
@@ -149,12 +154,25 @@ func TestMapper_OtherType_MultipleHosts_Error(t *testing.T) {
 		Hosts: []string{"api.example.com", "api2.example.com"},
 	}
 
-	_, err := mapper.Map(item, "my-key-123")
-	if err == nil {
-		t.Fatal("expected error for multiple hosts, got nil")
+	got, err := mapper.Map(item, "my-key-123")
+	if err != nil {
+		t.Fatalf("Map() unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "one host per secret") {
-		t.Errorf("error should mention 'one host per secret', got: %v", err)
+	if len(got) != 2 {
+		t.Fatalf("Map() returned %d inputs, want 2", len(got))
+	}
+
+	if got[0].Name != "my-token-api-example-com" {
+		t.Errorf("got[0].Name = %q, want %q", got[0].Name, "my-token-api-example-com")
+	}
+	if got[0].HostPattern != "api.example.com" {
+		t.Errorf("got[0].HostPattern = %q, want %q", got[0].HostPattern, "api.example.com")
+	}
+	if got[1].Name != "my-token-api2-example-com" {
+		t.Errorf("got[1].Name = %q, want %q", got[1].Name, "my-token-api2-example-com")
+	}
+	if got[1].HostPattern != "api2.example.com" {
+		t.Errorf("got[1].HostPattern = %q, want %q", got[1].HostPattern, "api2.example.com")
 	}
 }
 
@@ -171,18 +189,21 @@ func TestMapper_OtherType_MinimalFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
+	if len(got) != 1 {
+		t.Fatalf("Map() returned %d inputs, want 1", len(got))
+	}
 
-	if got.Name != "other" {
-		t.Errorf("Name = %q, want %q", got.Name, "other")
+	if got[0].Name != "other" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "other")
 	}
-	if got.HostPattern != "*" {
-		t.Errorf("HostPattern = %q, want %q", got.HostPattern, "*")
+	if got[0].HostPattern != "*" {
+		t.Errorf("HostPattern = %q, want %q", got[0].HostPattern, "*")
 	}
-	if got.PathPattern != "" {
-		t.Errorf("PathPattern = %q, want empty", got.PathPattern)
+	if got[0].PathPattern != "" {
+		t.Errorf("PathPattern = %q, want empty", got[0].PathPattern)
 	}
-	if got.InjectionConfig != nil {
-		t.Errorf("InjectionConfig should be nil for other type without header, got %+v", got.InjectionConfig)
+	if got[0].InjectionConfig != nil {
+		t.Errorf("InjectionConfig should be nil for other type without header, got %+v", got[0].InjectionConfig)
 	}
 }
 
@@ -200,8 +221,11 @@ func TestMapper_OtherType_EmptyHosts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Map() error: %v", err)
 	}
-	if got.HostPattern != "*" {
-		t.Errorf("HostPattern = %q, want %q for empty hosts", got.HostPattern, "*")
+	if len(got) != 1 {
+		t.Fatalf("Map() returned %d inputs, want 1", len(got))
+	}
+	if got[0].HostPattern != "*" {
+		t.Errorf("HostPattern = %q, want %q for empty hosts", got[0].HostPattern, "*")
 	}
 }
 
@@ -222,6 +246,28 @@ func TestConvertTemplate(t *testing.T) {
 	for _, tt := range tests {
 		if got := convertTemplate(tt.input); got != tt.want {
 			t.Errorf("convertTemplate(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"api.example.com", "api-example-com"},
+		{"*.example.com", "example-com"},
+		{"api2.example.com", "api2-example-com"},
+		{"api.example.com/v2", "api-example-com-v2"},
+		{"already-safe", "already-safe"},
+		{"UPPER.case.com", "UPPER-case-com"},
+	}
+
+	for _, tt := range tests {
+		if got := sanitizeName(tt.input); got != tt.want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/pkg/onecli/mapper_test.go
+++ b/pkg/onecli/mapper_test.go
@@ -176,6 +176,40 @@ func TestMapper_OtherType_MultipleHosts(t *testing.T) {
 	}
 }
 
+func TestMapper_OtherType_EmptyNameSegment(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	// "***" sanitizes to "" (all non-alphanumeric, trimmed to empty)
+	item := secret.ListItem{
+		Name:  "my-token",
+		Type:  "other",
+		Hosts: []string{"api.example.com", "***"},
+	}
+
+	_, err := mapper.Map(item, "val")
+	if err == nil {
+		t.Fatal("expected error for host that sanitizes to empty, got nil")
+	}
+}
+
+func TestMapper_OtherType_DuplicateNameSegment(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewSecretMapper(secretservice.NewRegistry())
+	// Both hosts sanitize to "example-com", producing the same secret name
+	item := secret.ListItem{
+		Name:  "my-token",
+		Type:  "other",
+		Hosts: []string{"example.com", "example-com"},
+	}
+
+	_, err := mapper.Map(item, "val")
+	if err == nil {
+		t.Fatal("expected error for duplicate sanitized name, got nil")
+	}
+}
+
 func TestMapper_OtherType_MinimalFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
SecretMapper.Map() errored when a type=other secret had more than one host, even though the CLI and store both allowed it. Map() now returns []CreateSecretInput, emitting one entry per host when multiple are present. Names are disambiguated as <name>-<sanitized-host>. Single-host and no-host behavior is unchanged.

Part of #342