### PR TITLE
feat(cmd): add workspace dashboard command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 - **StorageAware**: Enables runtimes to persist data in a dedicated storage directory
 - **AgentLister**: Enables runtimes to report which agents they support
 - **Terminal**: Enables interactive terminal sessions with instances (auto-starts if needed)
+- **Dashboard**: Enables runtimes to expose a web dashboard URL (`GetURL(ctx, instanceID) (string, error)`)
 
 **For detailed runtime implementation guidance, use:** `/working-with-runtime-system`
 
@@ -358,6 +359,9 @@ manager.Delete(id)
 // Start, Stop instances
 manager.Start(ctx, id)
 manager.Stop(ctx, id)
+
+// Dashboard URL (returns ErrDashboardNotSupported if runtime does not implement Dashboard)
+manager.GetDashboardURL(ctx, id)
 
 // Interactive terminal
 manager.Terminal(ctx, id, []string{"bash"})

--- a/README.md
+++ b/README.md
@@ -3350,3 +3350,71 @@ kdn remove a1b2c3d4e5f6... --force
 - JSON output format is useful for scripting and automation
 - When using `--output json`, errors are also returned in JSON format for consistent parsing
 - **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure
+
+### `workspace dashboard` - Open the Dashboard for a Workspace
+
+Prints the dashboard URL for a running workspace and opens it in the default browser. Also available as the shorter alias `dashboard`.
+
+The dashboard is only available for runtimes that support it (e.g. Podman via the OneCLI web interface).
+
+#### Usage
+
+```bash
+kdn workspace dashboard NAME|ID [flags]
+kdn dashboard NAME|ID [flags]
+```
+
+#### Arguments
+
+- `NAME|ID` - The workspace name or unique identifier (required)
+
+#### Flags
+
+- `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
+
+#### Examples
+
+**Open dashboard by ID:**
+```bash
+kdn workspace dashboard a1b2c3d4e5f6...
+```
+Output: `http://localhost:8888` (URL printed; browser opened automatically)
+
+**Open dashboard by name:**
+```bash
+kdn workspace dashboard my-project
+```
+
+**Use the short alias:**
+```bash
+kdn dashboard my-project
+```
+
+#### Error Handling
+
+**Workspace not found:**
+```bash
+kdn dashboard invalid-id
+```
+Output:
+```text
+Error: workspace not found: invalid-id
+Use 'workspace list' to see available workspaces
+```
+
+**Runtime does not support dashboard:**
+```bash
+kdn dashboard my-project
+```
+Output:
+```text
+Error: dashboard not supported for workspace "my-project"
+```
+
+#### Notes
+
+- The workspace must be running; the command does not auto-start it
+- The URL is always printed to stdout, even when the browser opens successfully
+- Opening the browser is best-effort; errors are silently ignored
+- Tab completion suggests only running workspaces whose runtime supports the Dashboard interface
+- JSON output is **not supported** for this command

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -104,6 +104,65 @@ func completeRunningWorkspaceID(cmd *cobra.Command, args []string, toComplete st
 	})
 }
 
+// completeDashboardWorkspaceID provides completion for running workspaces whose runtime supports the Dashboard interface.
+// The args and toComplete parameters are part of Cobra's ValidArgsFunction signature but are unused
+// because Cobra's shell completion framework automatically filters results based on user input.
+func completeDashboardWorkspaceID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeDashboardWorkspaceIDWith(cmd, runtimesetup.ListDashboardRuntimeTypes)
+}
+
+// completeDashboardWorkspaceIDWith is the testable implementation of completeDashboardWorkspaceID.
+// It accepts a listDashboardTypes function so tests can inject a custom implementation.
+func completeDashboardWorkspaceIDWith(cmd *cobra.Command, listDashboardTypes func(string) ([]string, error)) ([]string, cobra.ShellCompDirective) {
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	if _, err := os.Stat(absStorageDir); os.IsNotExist(err) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	runtimesDir := filepath.Join(absStorageDir, instances.RuntimesSubdirectory)
+	dashboardTypes, err := listDashboardTypes(runtimesDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	dashboardTypeSet := make(map[string]struct{}, len(dashboardTypes))
+	for _, t := range dashboardTypes {
+		dashboardTypeSet[t] = struct{}{}
+	}
+
+	manager, err := instances.NewManager(absStorageDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	instancesList, err := manager.List()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var completions []string
+	for _, instance := range instancesList {
+		runtimeData := instance.GetRuntimeData()
+		if runtimeData.State == api.WorkspaceStateRunning {
+			if _, ok := dashboardTypeSet[runtimeData.Type]; ok {
+				completions = append(completions, instance.GetID())
+				completions = append(completions, instance.GetName())
+			}
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
 // completeRemoveWorkspaceID provides completion for the remove command.
 // When --force is set, all workspaces are suggested; otherwise only non-running workspaces.
 // The args and toComplete parameters are part of Cobra's ValidArgsFunction signature but are unused

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -742,6 +742,184 @@ func TestCompleteSecretName(t *testing.T) {
 	})
 }
 
+func TestCompleteDashboardWorkspaceID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns running instances whose runtime supports Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		storageDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+
+		sourceDir := t.TempDir()
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance: %v", err)
+		}
+		added, err := manager.Add(ctx, instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance: %v", err)
+		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("failed to start instance: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		completions, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return []string{"fake"}, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 2 {
+			t.Fatalf("Expected 2 completions (ID and name), got %d: %v", len(completions), completions)
+		}
+		completionSet := make(map[string]bool)
+		for _, c := range completions {
+			completionSet[c] = true
+		}
+		if !completionSet[added.GetID()] {
+			t.Errorf("Expected ID %q in completions, got %v", added.GetID(), completions)
+		}
+		if !completionSet[added.GetName()] {
+			t.Errorf("Expected name %q in completions, got %v", added.GetName(), completions)
+		}
+	})
+
+	t.Run("excludes running instances whose runtime does not support Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		storageDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+
+		sourceDir := t.TempDir()
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance: %v", err)
+		}
+		added, err := manager.Add(ctx, instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance: %v", err)
+		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("failed to start instance: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		completions, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return nil, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("Expected 0 completions (runtime not Dashboard-capable), got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("excludes stopped instances even if runtime supports Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		storageDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+
+		sourceDir := t.TempDir()
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance: %v", err)
+		}
+		_, err = manager.Add(ctx, instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		completions, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return []string{"fake"}, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("Expected 0 completions (instance is stopped), got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns error directive when storage flag is missing", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+
+		_, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return []string{"fake"}, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("Expected ShellCompDirectiveError, got %v", directive)
+		}
+	})
+
+	t.Run("returns no suggestions when storage does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", filepath.Join(t.TempDir(), "nonexistent"), "")
+
+		completions, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return []string{"fake"}, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("Expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+}
+
 func TestCompleteRuntimeFlag(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -19,34 +19,22 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
-func NewWorkspaceCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "workspace",
-		Short: "Manage workspaces",
-		Long:  "Manage workspaces registered with kdn init",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
-	}
+func NewDashboardCmd() *cobra.Command {
+	workspaceDashboardCmd := NewWorkspaceDashboardCmd()
 
-	// Add subcommands
-	cmd.AddCommand(NewWorkspaceDashboardCmd())
-	cmd.AddCommand(NewWorkspaceListCmd())
-	cmd.AddCommand(NewWorkspaceRemoveCmd())
-	cmd.AddCommand(NewWorkspaceStartCmd())
-	cmd.AddCommand(NewWorkspaceStopCmd())
-	cmd.AddCommand(NewWorkspaceTerminalCmd())
+	cmd := &cobra.Command{
+		Use:               "dashboard NAME|ID",
+		Short:             workspaceDashboardCmd.Short + " (alias for 'workspace dashboard')",
+		Long:              workspaceDashboardCmd.Long,
+		Example:           AdaptExampleForAlias(workspaceDashboardCmd.Example, "workspace dashboard", "dashboard"),
+		Args:              workspaceDashboardCmd.Args,
+		ValidArgsFunction: workspaceDashboardCmd.ValidArgsFunction,
+		PreRunE:           workspaceDashboardCmd.PreRunE,
+		RunE:              workspaceDashboardCmd.RunE,
+	}
 
 	return cmd
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -89,6 +89,10 @@ func NewRootCmd() *cobra.Command {
 	stopCmd.GroupID = "main"
 	rootCmd.AddCommand(stopCmd)
 
+	dashboardCmd := NewDashboardCmd()
+	dashboardCmd.GroupID = "main"
+	rootCmd.AddCommand(dashboardCmd)
+
 	terminalCmd := NewTerminalCmd()
 	terminalCmd.GroupID = "main"
 	rootCmd.AddCommand(terminalCmd)

--- a/pkg/cmd/workspace_dashboard.go
+++ b/pkg/cmd/workspace_dashboard.go
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/runtimesetup"
+	"github.com/spf13/cobra"
+)
+
+// workspaceDashboardCmd contains the configuration for the workspace dashboard command
+type workspaceDashboardCmd struct {
+	manager     instances.Manager
+	nameOrID    string
+	openBrowser func(url string) error
+}
+
+// preRun validates the parameters and flags
+func (w *workspaceDashboardCmd) preRun(cmd *cobra.Command, args []string) error {
+	w.nameOrID = args[0]
+
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return fmt.Errorf("failed to read --storage flag: %w", err)
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve absolute path for storage directory: %w", err)
+	}
+
+	manager, err := instances.NewManager(absStorageDir)
+	if err != nil {
+		return fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	if err := runtimesetup.RegisterAll(manager); err != nil {
+		return fmt.Errorf("failed to register runtimes: %w", err)
+	}
+
+	w.manager = manager
+	return nil
+}
+
+// run executes the workspace dashboard command logic
+func (w *workspaceDashboardCmd) run(cmd *cobra.Command, args []string) error {
+	url, err := w.manager.GetDashboardURL(cmd.Context(), w.nameOrID)
+	if err != nil {
+		if errors.Is(err, instances.ErrInstanceNotFound) {
+			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
+		}
+		if errors.Is(err, instances.ErrDashboardNotSupported) {
+			return fmt.Errorf("dashboard not supported for workspace %q", w.nameOrID)
+		}
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), url)
+	if w.openBrowser != nil {
+		_ = w.openBrowser(url)
+	}
+	return nil
+}
+
+// openBrowser attempts to open the URL in the user's default browser.
+// Errors are silently ignored since this is a best-effort operation.
+func openBrowser(url string) error {
+	var browserCmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		browserCmd = exec.Command("open", url)
+	case "windows":
+		browserCmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		browserCmd = exec.Command("xdg-open", url)
+	}
+	return browserCmd.Run()
+}
+
+func NewWorkspaceDashboardCmd() *cobra.Command {
+	c := &workspaceDashboardCmd{
+		openBrowser: openBrowser,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "dashboard NAME|ID",
+		Short: "Open the dashboard for a workspace",
+		Long:  "Open the dashboard for a running workspace in the default browser and print the URL",
+		Example: `# Open dashboard by workspace ID
+kdn workspace dashboard abc123
+
+# Open dashboard by workspace name
+kdn workspace dashboard my-project`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeDashboardWorkspaceID,
+		PreRunE:           c.preRun,
+		RunE:              c.run,
+	}
+
+	return cmd
+}

--- a/pkg/cmd/workspace_dashboard.go
+++ b/pkg/cmd/workspace_dashboard.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -34,7 +35,7 @@ import (
 type workspaceDashboardCmd struct {
 	manager     instances.Manager
 	nameOrID    string
-	openBrowser func(url string) error
+	openBrowser func(ctx context.Context, url string) error
 }
 
 // preRun validates the parameters and flags
@@ -79,24 +80,24 @@ func (w *workspaceDashboardCmd) run(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintln(cmd.OutOrStdout(), url)
 	if w.openBrowser != nil {
-		_ = w.openBrowser(url)
+		_ = w.openBrowser(cmd.Context(), url)
 	}
 	return nil
 }
 
 // openBrowser attempts to open the URL in the user's default browser.
-// Errors are silently ignored since this is a best-effort operation.
-func openBrowser(url string) error {
+// Start is used instead of Run so the browser process is launched non-blocking.
+func openBrowser(ctx context.Context, url string) error {
 	var browserCmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		browserCmd = exec.Command("open", url)
+		browserCmd = exec.CommandContext(ctx, "open", url)
 	case "windows":
-		browserCmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+		browserCmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url)
 	default:
-		browserCmd = exec.Command("xdg-open", url)
+		browserCmd = exec.CommandContext(ctx, "xdg-open", url)
 	}
-	return browserCmd.Run()
+	return browserCmd.Start()
 }
 
 func NewWorkspaceDashboardCmd() *cobra.Command {

--- a/pkg/cmd/workspace_dashboard_test.go
+++ b/pkg/cmd/workspace_dashboard_test.go
@@ -1,0 +1,235 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/runtime/fake"
+	"github.com/spf13/cobra"
+)
+
+func TestWorkspaceDashboardCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewWorkspaceDashboardCmd()
+	if cmd == nil {
+		t.Fatal("NewWorkspaceDashboardCmd() returned nil")
+	}
+
+	if cmd.Use != "dashboard NAME|ID" {
+		t.Errorf("Expected Use to be 'dashboard NAME|ID', got '%s'", cmd.Use)
+	}
+}
+
+func TestWorkspaceDashboardCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts name from args and creates manager", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		c := &workspaceDashboardCmd{}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		err := c.preRun(cmd, []string{"my-workspace"})
+		if err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+
+		if c.manager == nil {
+			t.Error("Expected manager to be created")
+		}
+
+		if c.nameOrID != "my-workspace" {
+			t.Errorf("Expected nameOrID to be 'my-workspace', got %s", c.nameOrID)
+		}
+	})
+}
+
+func TestWorkspaceDashboardCmd_E2E(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails for nonexistent workspace", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "dashboard", "nonexistent-id", "--storage", storageDir})
+
+		var outBuf bytes.Buffer
+		rootCmd.SetOut(&outBuf)
+		rootCmd.SetErr(&outBuf)
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error for nonexistent workspace")
+		}
+
+		if !strings.Contains(err.Error(), "workspace not found") {
+			t.Errorf("Expected 'workspace not found' error, got: %v", err)
+		}
+	})
+
+	t.Run("fails when runtime does not support dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourceDir := t.TempDir()
+
+		// Create instance using the standard fake runtime (no Dashboard support)
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		added, err := manager.Add(context.Background(), instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		// rootCmd creates its own manager via runtimesetup.RegisterAll, which also
+		// registers fake.New() (without Dashboard). The command will fail at the Dashboard check.
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "dashboard", added.GetID(), "--storage", storageDir})
+
+		var outBuf bytes.Buffer
+		rootCmd.SetOut(&outBuf)
+		rootCmd.SetErr(&outBuf)
+
+		err = rootCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error when runtime does not support dashboard")
+		}
+
+		if !strings.Contains(err.Error(), "dashboard not supported") {
+			t.Errorf("Expected 'dashboard not supported' error, got: %v", err)
+		}
+	})
+
+	t.Run("outputs dashboard URL when runtime supports dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourceDir := t.TempDir()
+
+		const dashboardURL = "http://localhost:8888"
+
+		// Build a manager with the dashboard-capable fake runtime and add an instance.
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.NewWithDashboard(dashboardURL)); err != nil {
+			t.Fatalf("Failed to register fake runtime with dashboard: %v", err)
+		}
+
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		added, err := manager.Add(context.Background(), instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		// Inject the dashboard-capable manager directly into the command struct,
+		// bypassing preRun which would register a standard fake without Dashboard support.
+		c := &workspaceDashboardCmd{
+			manager:  manager,
+			nameOrID: added.GetID(),
+		}
+
+		var outBuf bytes.Buffer
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&outBuf)
+
+		err = c.run(cobraCmd, nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		output := strings.TrimSpace(outBuf.String())
+		if output != dashboardURL {
+			t.Errorf("Expected output %q, got %q", dashboardURL, output)
+		}
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "dashboard", "--storage", storageDir})
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error when no argument provided")
+		}
+	})
+}
+
+func TestWorkspaceDashboardCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewWorkspaceDashboardCmd()
+
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("Failed to parse examples: %v", err)
+	}
+
+	expectedCount := 2
+	if len(commands) != expectedCount {
+		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	err = testutil.ValidateCommandExamples(rootCmd, cmd.Example)
+	if err != nil {
+		t.Errorf("Example validation failed: %v", err)
+	}
+}

--- a/pkg/cmd/workspace_dashboard_test.go
+++ b/pkg/cmd/workspace_dashboard_test.go
@@ -139,6 +139,9 @@ func TestWorkspaceDashboardCmd_E2E(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to add instance: %v", err)
 		}
+		if err := manager.Start(context.Background(), added.GetID()); err != nil {
+			t.Fatalf("Failed to start instance: %v", err)
+		}
 
 		// rootCmd creates its own manager via runtimesetup.RegisterAll, which also
 		// registers fake.New() (without Dashboard). The command will fail at the Dashboard check.
@@ -186,6 +189,9 @@ func TestWorkspaceDashboardCmd_E2E(t *testing.T) {
 		added, err := manager.Add(context.Background(), instances.AddOptions{Instance: inst, RuntimeType: "fake"})
 		if err != nil {
 			t.Fatalf("Failed to add instance: %v", err)
+		}
+		if err := manager.Start(context.Background(), added.GetID()); err != nil {
+			t.Fatalf("Failed to start instance: %v", err)
 		}
 
 		// Inject the dashboard-capable manager directly into the command struct,

--- a/pkg/cmd/workspace_dashboard_test.go
+++ b/pkg/cmd/workspace_dashboard_test.go
@@ -69,6 +69,23 @@ func TestWorkspaceDashboardCmd_PreRun(t *testing.T) {
 			t.Errorf("Expected nameOrID to be 'my-workspace', got %s", c.nameOrID)
 		}
 	})
+
+	t.Run("returns error when storage flag is not registered", func(t *testing.T) {
+		t.Parallel()
+
+		c := &workspaceDashboardCmd{}
+		cmd := &cobra.Command{}
+		// Intentionally omit registering the "storage" flag
+
+		err := c.preRun(cmd, []string{"my-workspace"})
+		if err == nil {
+			t.Fatal("Expected error when storage flag is not registered, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "failed to read --storage flag") {
+			t.Errorf("Expected 'failed to read --storage flag' error, got: %v", err)
+		}
+	})
 }
 
 func TestWorkspaceDashboardCmd_E2E(t *testing.T) {

--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -136,12 +136,7 @@ func (w *workspaceStartCmd) run(cmd *cobra.Command, args []string) error {
 		return w.outputJSON(cmd, instanceID)
 	}
 
-	// Output the ID and OneCLI dashboard URL if available (text mode)
-	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, instanceID)
-	if port, ok := instance.GetRuntimeData().Info["onecli_web_port"]; ok {
-		fmt.Fprintf(out, "OneCLI dashboard: http://localhost:%s\n", port)
-	}
+	fmt.Fprintln(cmd.OutOrStdout(), instanceID)
 	return nil
 }
 

--- a/pkg/instances/instance.go
+++ b/pkg/instances/instance.go
@@ -30,6 +30,8 @@ var (
 	ErrInstanceExists = errors.New("instance already exists")
 	// ErrInvalidPath is returned when a path is invalid or empty
 	ErrInvalidPath = errors.New("invalid path")
+	// ErrDashboardNotSupported is returned when the runtime does not implement the Dashboard interface
+	ErrDashboardNotSupported = errors.New("dashboard not supported by this runtime")
 )
 
 // InstancePaths represents the paths in an instance

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -733,6 +733,10 @@ func (m *manager) GetDashboardURL(ctx context.Context, nameOrID string) (string,
 	}
 
 	runtimeData := instance.GetRuntimeData()
+	if runtimeData.State != api.WorkspaceStateRunning {
+		return "", fmt.Errorf("workspace is not running (state: %s)", runtimeData.State)
+	}
+
 	rt, err := m.runtimeRegistry.Get(runtimeData.Type)
 	if err != nil {
 		return "", fmt.Errorf("failed to get runtime: %w", err)

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,6 +85,10 @@ type Manager interface {
 	// Reconcile removes instances with inaccessible directories
 	// Returns the list of removed instance IDs
 	Reconcile() ([]string, error)
+	// GetDashboardURL returns the dashboard URL for a workspace instance by name or ID.
+	// Returns ErrInstanceNotFound if the workspace does not exist.
+	// Returns ErrDashboardNotSupported if the runtime does not implement the Dashboard interface.
+	GetDashboardURL(ctx context.Context, nameOrID string) (string, error)
 	// RegisterRuntime registers a runtime with the manager's registry
 	RegisterRuntime(rt runtime.Runtime) error
 	// RegisterAgent registers an agent with the manager's registry
@@ -418,6 +423,12 @@ func (m *manager) Start(ctx context.Context, id string) error {
 		return fmt.Errorf("runtime %q returned invalid state: %w", runtimeData.Type, err)
 	}
 
+	// Merge info: preserve existing fields (e.g. onecli_web_port set at Create time),
+	// then overlay any updated fields returned by Start.
+	mergedInfo := make(map[string]string, len(runtimeData.Info)+len(runtimeInfo.Info))
+	maps.Copy(mergedInfo, runtimeData.Info)
+	maps.Copy(mergedInfo, runtimeInfo.Info)
+
 	// Update the instance with new runtime state
 	updatedInstance := &instance{
 		ID:        instanceToStart.GetID(),
@@ -428,7 +439,7 @@ func (m *manager) Start(ctx context.Context, id string) error {
 			Type:       runtimeData.Type,
 			InstanceID: runtimeData.InstanceID,
 			State:      runtimeInfo.State,
-			Info:       runtimeInfo.Info,
+			Info:       mergedInfo,
 		},
 		Project: instanceToStart.GetProject(),
 		Agent:   instanceToStart.GetAgent(),
@@ -494,6 +505,12 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 		return fmt.Errorf("runtime %q returned invalid state: %w", runtimeData.Type, err)
 	}
 
+	// Merge info: preserve existing fields (e.g. onecli_web_port set at Create time),
+	// then overlay any updated fields returned by Stop.
+	mergedInfo := make(map[string]string, len(runtimeData.Info)+len(runtimeInfo.Info))
+	maps.Copy(mergedInfo, runtimeData.Info)
+	maps.Copy(mergedInfo, runtimeInfo.Info)
+
 	// Update the instance with new runtime state
 	updatedInstance := &instance{
 		ID:        instanceToStop.GetID(),
@@ -504,7 +521,7 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 			Type:       runtimeData.Type,
 			InstanceID: runtimeData.InstanceID,
 			State:      runtimeInfo.State,
-			Info:       runtimeInfo.Info,
+			Info:       mergedInfo,
 		},
 		Project: instanceToStop.GetProject(),
 		Agent:   instanceToStop.GetAgent(),
@@ -706,6 +723,27 @@ func (m *manager) Reconcile() ([]string, error) {
 	}
 
 	return removed, nil
+}
+
+// GetDashboardURL returns the dashboard URL for a workspace instance by name or ID.
+func (m *manager) GetDashboardURL(ctx context.Context, nameOrID string) (string, error) {
+	instance, err := m.Get(nameOrID)
+	if err != nil {
+		return "", err
+	}
+
+	runtimeData := instance.GetRuntimeData()
+	rt, err := m.runtimeRegistry.Get(runtimeData.Type)
+	if err != nil {
+		return "", fmt.Errorf("failed to get runtime: %w", err)
+	}
+
+	dashboardRuntime, ok := rt.(runtime.Dashboard)
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrDashboardNotSupported, runtimeData.Type)
+	}
+
+	return dashboardRuntime.GetURL(ctx, runtimeData.InstanceID)
 }
 
 // RegisterRuntime registers a runtime with the manager's registry.

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -4544,6 +4544,9 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Add() error = %v", err)
 		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
 
 		url, err := manager.GetDashboardURL(ctx, added.GetID())
 		if err != nil {
@@ -4551,6 +4554,42 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		}
 		if url != dashboardURL {
 			t.Errorf("GetDashboardURL() = %q, want %q", url, dashboardURL)
+		}
+	})
+
+	t.Run("returns error when instance is not running", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		const dashboardURL = "http://localhost:8080"
+		runtimesDir := filepath.Join(tmpDir, RuntimesSubdirectory)
+		reg, err := runtime.NewRegistry(runtimesDir)
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  filepath.Join(instanceTmpDir, "source"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config"),
+			Accessible: true,
+		})
+		added, err := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		_, err = manager.GetDashboardURL(ctx, added.GetID())
+		if err == nil {
+			t.Fatal("GetDashboardURL() error = nil, want error for stopped instance")
+		}
+		if !strings.Contains(err.Error(), "workspace is not running") {
+			t.Errorf("GetDashboardURL() error = %v, want 'workspace is not running'", err)
 		}
 	})
 
@@ -4570,6 +4609,9 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		added, err := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
 		if err != nil {
 			t.Fatalf("Add() error = %v", err)
+		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("Start() error = %v", err)
 		}
 
 		_, err = manager.GetDashboardURL(ctx, added.GetID())
@@ -4614,8 +4656,12 @@ func TestManager_GetDashboardURL(t *testing.T) {
 			Accessible: true,
 			Name:       "my-workspace",
 		})
-		if _, err = manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"}); err != nil {
+		added, err := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
 			t.Fatalf("Add() error = %v", err)
+		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("Start() error = %v", err)
 		}
 
 		url, err := manager.GetDashboardURL(ctx, "my-workspace")

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -1120,6 +1120,41 @@ func TestManager_Start(t *testing.T) {
 			t.Errorf("After Start, GetModel() = %q, want %q", updated.GetModel(), "claude-sonnet-4-20250514")
 		}
 	})
+
+	t.Run("preserves info fields not returned by runtime Start", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  filepath.Join(instanceTmpDir, "source"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config"),
+			Accessible: true,
+		})
+		added, _ := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
+
+		// Inject an extra Info field into storage (simulates onecli_web_port set at Create time
+		// by the Podman runtime but not returned by the runtime's Start call).
+		stored, _ := manager.Get(added.GetID())
+		storedData := stored.Dump()
+		storedData.Runtime.Info["onecli_web_port"] = "8080"
+		data := []InstanceData{storedData}
+		jsonData, _ := json.Marshal(data)
+		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
+		os.WriteFile(storageFile, jsonData, 0644)
+
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("Start() unexpected error = %v", err)
+		}
+
+		updated, _ := manager.Get(added.GetID())
+		if updated.GetRuntimeData().Info["onecli_web_port"] != "8080" {
+			t.Errorf("After Start, onecli_web_port = %q, want %q", updated.GetRuntimeData().Info["onecli_web_port"], "8080")
+		}
+	})
 }
 
 func TestManager_Stop(t *testing.T) {
@@ -1374,6 +1409,42 @@ func TestManager_Stop(t *testing.T) {
 		updated, _ := manager.Get(added.GetID())
 		if updated.GetModel() != "claude-sonnet-4-20250514" {
 			t.Errorf("After Stop, GetModel() = %q, want %q", updated.GetModel(), "claude-sonnet-4-20250514")
+		}
+	})
+
+	t.Run("preserves info fields not returned by runtime Stop", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  filepath.Join(instanceTmpDir, "source"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config"),
+			Accessible: true,
+		})
+		added, _ := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
+		manager.Start(ctx, added.GetID())
+
+		// Inject an extra Info field into storage (simulates onecli_web_port set at Create time
+		// by the Podman runtime but not returned by the runtime's Stop/Info call).
+		running, _ := manager.Get(added.GetID())
+		runningData := running.Dump()
+		runningData.Runtime.Info["onecli_web_port"] = "8080"
+		data := []InstanceData{runningData}
+		jsonData, _ := json.Marshal(data)
+		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
+		os.WriteFile(storageFile, jsonData, 0644)
+
+		if err := manager.Stop(ctx, added.GetID()); err != nil {
+			t.Fatalf("Stop() unexpected error = %v", err)
+		}
+
+		updated, _ := manager.Get(added.GetID())
+		if updated.GetRuntimeData().Info["onecli_web_port"] != "8080" {
+			t.Errorf("After Stop, onecli_web_port = %q, want %q", updated.GetRuntimeData().Info["onecli_web_port"], "8080")
 		}
 	})
 }
@@ -4441,6 +4512,121 @@ func (f *fakeSecretServiceImpl) Path() string           { return f.path }
 func (f *fakeSecretServiceImpl) EnvVars() []string      { return f.envVars }
 func (f *fakeSecretServiceImpl) HeaderName() string     { return f.headerName }
 func (f *fakeSecretServiceImpl) HeaderTemplate() string { return f.headerTemplate }
+
+func TestManager_GetDashboardURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns URL when runtime supports Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		const dashboardURL = "http://localhost:8080"
+		// Use an empty registry and register the dashboard runtime directly to avoid
+		// a duplicate "fake" registration conflict with newTestRegistry.
+		runtimesDir := filepath.Join(tmpDir, RuntimesSubdirectory)
+		reg, err := runtime.NewRegistry(runtimesDir)
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  filepath.Join(instanceTmpDir, "source"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config"),
+			Accessible: true,
+		})
+		added, err := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		url, err := manager.GetDashboardURL(ctx, added.GetID())
+		if err != nil {
+			t.Fatalf("GetDashboardURL() error = %v", err)
+		}
+		if url != dashboardURL {
+			t.Errorf("GetDashboardURL() = %q, want %q", url, dashboardURL)
+		}
+	})
+
+	t.Run("returns ErrDashboardNotSupported when runtime does not implement Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  filepath.Join(instanceTmpDir, "source"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config"),
+			Accessible: true,
+		})
+		added, err := manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		_, err = manager.GetDashboardURL(ctx, added.GetID())
+		if !errors.Is(err, ErrDashboardNotSupported) {
+			t.Errorf("GetDashboardURL() error = %v, want ErrDashboardNotSupported", err)
+		}
+	})
+
+	t.Run("returns ErrInstanceNotFound for nonexistent instance", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		_, err := manager.GetDashboardURL(ctx, "nonexistent-id")
+		if !errors.Is(err, ErrInstanceNotFound) {
+			t.Errorf("GetDashboardURL() error = %v, want ErrInstanceNotFound", err)
+		}
+	})
+
+	t.Run("resolves by name", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		const dashboardURL = "http://localhost:7777"
+		runtimesDir := filepath.Join(tmpDir, RuntimesSubdirectory)
+		reg, err := runtime.NewRegistry(runtimesDir)
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+
+		instanceTmpDir := t.TempDir()
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  filepath.Join(instanceTmpDir, "source"),
+			ConfigDir:  filepath.Join(instanceTmpDir, "config"),
+			Accessible: true,
+			Name:       "my-workspace",
+		})
+		if _, err = manager.Add(ctx, AddOptions{Instance: inst, RuntimeType: "fake"}); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		url, err := manager.GetDashboardURL(ctx, "my-workspace")
+		if err != nil {
+			t.Fatalf("GetDashboardURL() by name error = %v", err)
+		}
+		if url != dashboardURL {
+			t.Errorf("GetDashboardURL() = %q, want %q", url, dashboardURL)
+		}
+	})
+}
 
 func TestManager_RegisterSecretService(t *testing.T) {
 	t.Parallel()

--- a/pkg/runtime/fake/dashboard.go
+++ b/pkg/runtime/fake/dashboard.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	"github.com/openkaiden/kdn/pkg/runtime"
+)
+
+// runtimeWithDashboard wraps fakeRuntime and adds Dashboard support.
+type runtimeWithDashboard struct {
+	*fakeRuntime
+	url string
+}
+
+// Ensure runtimeWithDashboard implements runtime.Dashboard at compile time.
+var _ runtime.Dashboard = (*runtimeWithDashboard)(nil)
+
+// NewWithDashboard creates a fake runtime that implements the Dashboard interface.
+// The url parameter is returned by GetURL for all instances.
+func NewWithDashboard(url string) runtime.Runtime {
+	return &runtimeWithDashboard{
+		fakeRuntime: &fakeRuntime{
+			instances: make(map[string]*instanceState),
+			nextID:    1,
+		},
+		url: url,
+	}
+}
+
+// GetURL implements runtime.Dashboard.
+func (r *runtimeWithDashboard) GetURL(_ context.Context, _ string) (string, error) {
+	return r.url, nil
+}

--- a/pkg/runtime/fake/dashboard.go
+++ b/pkg/runtime/fake/dashboard.go
@@ -33,11 +33,8 @@ var _ runtime.Dashboard = (*runtimeWithDashboard)(nil)
 // The url parameter is returned by GetURL for all instances.
 func NewWithDashboard(url string) runtime.Runtime {
 	return &runtimeWithDashboard{
-		fakeRuntime: &fakeRuntime{
-			instances: make(map[string]*instanceState),
-			nextID:    1,
-		},
-		url: url,
+		fakeRuntime: New().(*fakeRuntime),
+		url:         url,
 	}
 }
 

--- a/pkg/runtime/fake/fake_test.go
+++ b/pkg/runtime/fake/fake_test.go
@@ -806,3 +806,71 @@ func TestFakeRuntime_LoadWithNilInfoMap(t *testing.T) {
 		t.Error("Expected stopped_at timestamp to be set")
 	}
 }
+
+func TestNewWithDashboard_GetURL(t *testing.T) {
+	t.Parallel()
+
+	const dashboardURL = "http://localhost:8888"
+	rt := NewWithDashboard(dashboardURL)
+
+	d, ok := rt.(interface {
+		GetURL(ctx context.Context, instanceID string) (string, error)
+	})
+	if !ok {
+		t.Fatal("NewWithDashboard() returned a runtime that does not implement Dashboard")
+	}
+
+	url, err := d.GetURL(context.Background(), "any-instance-id")
+	if err != nil {
+		t.Fatalf("GetURL() failed: %v", err)
+	}
+	if url != dashboardURL {
+		t.Errorf("GetURL() = %q, want %q", url, dashboardURL)
+	}
+}
+
+func TestNewWithDashboard_IsFullRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rt := NewWithDashboard("http://localhost:9999")
+
+	info, err := rt.Create(ctx, runtime.CreateParams{
+		Name:       "test-ws",
+		SourcePath: "/tmp/src",
+	})
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if _, err := rt.Start(ctx, info.ID); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+	if err := rt.Stop(ctx, info.ID); err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+	if err := rt.Remove(ctx, info.ID); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+}
+
+func TestNewWithDashboard_GetURL_AnyInstance(t *testing.T) {
+	t.Parallel()
+
+	const dashboardURL = "http://localhost:7777"
+	rt := NewWithDashboard(dashboardURL)
+
+	d := rt.(interface {
+		GetURL(ctx context.Context, instanceID string) (string, error)
+	})
+
+	for _, id := range []string{"", "fake-001", "some-other-id"} {
+		url, err := d.GetURL(context.Background(), id)
+		if err != nil {
+			t.Errorf("GetURL(%q) failed: %v", id, err)
+		}
+		if url != dashboardURL {
+			t.Errorf("GetURL(%q) = %q, want %q", id, url, dashboardURL)
+		}
+	}
+}

--- a/pkg/runtime/podman/dashboard.go
+++ b/pkg/runtime/podman/dashboard.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtime"
+)
+
+// Ensure podmanRuntime implements runtime.Dashboard at compile time.
+var _ runtime.Dashboard = (*podmanRuntime)(nil)
+
+// GetURL implements runtime.Dashboard.
+// It returns the dashboard URL for the given workspace container.
+// Returns an error if the container is not running or the URL cannot be determined.
+func (p *podmanRuntime) GetURL(ctx context.Context, instanceID string) (string, error) {
+	info, err := p.getContainerInfo(ctx, instanceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get container info: %w", err)
+	}
+	if info.State != api.WorkspaceStateRunning {
+		return "", fmt.Errorf("workspace is not running")
+	}
+	tmplData, err := p.readPodTemplateData(instanceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to read pod template data: %w", err)
+	}
+	return fmt.Sprintf("http://localhost:%d", tmplData.OnecliWebPort), nil
+}

--- a/pkg/runtime/podman/dashboard.go
+++ b/pkg/runtime/podman/dashboard.go
@@ -26,8 +26,8 @@ import (
 var _ runtime.Dashboard = (*podmanRuntime)(nil)
 
 // GetURL implements runtime.Dashboard.
-// It returns the dashboard URL for the given workspace container.
-// Returns an error if the container is not running or the URL cannot be determined.
+// It performs a live container inspection to confirm the actual runtime state
+// before reading the stored port, guarding against stale persisted state.
 func (p *podmanRuntime) GetURL(ctx context.Context, instanceID string) (string, error) {
 	info, err := p.getContainerInfo(ctx, instanceID)
 	if err != nil {

--- a/pkg/runtime/podman/dashboard.go
+++ b/pkg/runtime/podman/dashboard.go
@@ -38,7 +38,7 @@ func (p *podmanRuntime) GetURL(ctx context.Context, instanceID string) (string, 
 	}
 	tmplData, err := p.readPodTemplateData(instanceID)
 	if err != nil {
-		return "", fmt.Errorf("failed to read pod template data: %w", err)
+		return "", fmt.Errorf("failed to get dashboard URL: %w", err)
 	}
 	return fmt.Sprintf("http://localhost:%d", tmplData.OnecliWebPort), nil
 }

--- a/pkg/runtime/podman/dashboard_test.go
+++ b/pkg/runtime/podman/dashboard_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
+)
+
+func TestGetURL_Success(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte(fmt.Sprintf("%s|running|kdn-test\n", containerID)), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	setupPodFiles(t, p, containerID, "my-project")
+
+	url, err := p.GetURL(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("GetURL() failed: %v", err)
+	}
+
+	const expectedPort = 20254
+	expected := fmt.Sprintf("http://localhost:%d", expectedPort)
+	if url != expected {
+		t.Errorf("GetURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestGetURL_ReturnsCorrectPort(t *testing.T) {
+	t.Parallel()
+
+	containerID := "porttest123"
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte(fmt.Sprintf("%s|running|kdn-test\n", containerID)), nil
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	if p.storageDir == "" {
+		p.storageDir = t.TempDir()
+	}
+
+	const customPort = 31337
+	data := podTemplateData{
+		Name:          "port-test",
+		OnecliWebPort: customPort,
+		OnecliVersion: defaultOnecliVersion,
+	}
+	if err := p.writePodFiles(containerID, data); err != nil {
+		t.Fatalf("writePodFiles() failed: %v", err)
+	}
+
+	url, err := p.GetURL(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("GetURL() failed: %v", err)
+	}
+
+	expected := fmt.Sprintf("http://localhost:%d", customPort)
+	if url != expected {
+		t.Errorf("GetURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestGetURL_ContainerInfoFailure(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("container not found")
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	_, err := p.GetURL(context.Background(), containerID)
+	if err == nil {
+		t.Fatal("Expected error when getContainerInfo fails, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to get container info") {
+		t.Errorf("Expected error to contain 'failed to get container info', got: %v", err)
+	}
+}
+
+func TestGetURL_NotRunning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{"stopped container", "exited"},
+		{"created container", "created"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			containerID := "abc123"
+			fakeExec := exec.NewFake()
+			fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+				return []byte(fmt.Sprintf("%s|%s|kdn-test\n", containerID, tt.state)), nil
+			}
+
+			p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+			_, err := p.GetURL(context.Background(), containerID)
+			if err == nil {
+				t.Fatal("Expected error for non-running container, got nil")
+			}
+
+			if !strings.Contains(err.Error(), "workspace is not running") {
+				t.Errorf("Expected 'workspace is not running' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetURL_PodTemplateDataMissing(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte(fmt.Sprintf("%s|running|kdn-test\n", containerID)), nil
+	}
+
+	// storageDir set but no pod template data written
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.storageDir = t.TempDir()
+
+	_, err := p.GetURL(context.Background(), containerID)
+	if err == nil {
+		t.Fatal("Expected error when pod template data is missing, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to read pod template data") {
+		t.Errorf("Expected 'failed to read pod template data' error, got: %v", err)
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -123,6 +123,10 @@ type AgentLister interface {
 // Dashboard is an optional interface for runtimes that provide a web dashboard.
 // Runtimes implementing this interface expose a URL for accessing the workspace dashboard.
 //
+// Callers (e.g. the instances manager) are responsible for verifying that the
+// instance is in the running state before invoking GetURL. Implementations
+// may assume the instance is running and focus solely on resolving the URL.
+//
 // Example implementation:
 //
 //	func (r *myRuntime) GetURL(ctx context.Context, instanceID string) (string, error) {
@@ -134,6 +138,7 @@ type AgentLister interface {
 //	}
 type Dashboard interface {
 	// GetURL returns the dashboard URL for the given runtime instance ID.
+	// The instance is guaranteed to be running when this method is called.
 	// Returns an error if the dashboard URL cannot be determined.
 	GetURL(ctx context.Context, instanceID string) (string, error)
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -120,6 +120,24 @@ type AgentLister interface {
 	ListAgents() ([]string, error)
 }
 
+// Dashboard is an optional interface for runtimes that provide a web dashboard.
+// Runtimes implementing this interface expose a URL for accessing the workspace dashboard.
+//
+// Example implementation:
+//
+//	func (r *myRuntime) GetURL(ctx context.Context, instanceID string) (string, error) {
+//	    port, err := r.readStoredPort(instanceID)
+//	    if err != nil {
+//	        return "", err
+//	    }
+//	    return fmt.Sprintf("http://localhost:%d", port), nil
+//	}
+type Dashboard interface {
+	// GetURL returns the dashboard URL for the given runtime instance ID.
+	// Returns an error if the dashboard URL cannot be determined.
+	GetURL(ctx context.Context, instanceID string) (string, error)
+}
+
 // Terminal is an optional interface for runtimes that support interactive terminal sessions.
 // Runtimes implementing this interface enable the terminal command for connecting to running instances.
 //

--- a/pkg/runtimesetup/register.go
+++ b/pkg/runtimesetup/register.go
@@ -148,6 +148,41 @@ func listAgentsWithFactories(runtimeStorageDir string, factories []runtimeFactor
 	return agents, nil
 }
 
+// ListDashboardRuntimeTypes returns the type names of all available runtimes
+// that implement the Dashboard interface.
+// It instantiates each runtime and checks for the interface, skipping unavailable runtimes.
+func ListDashboardRuntimeTypes(runtimeStorageDir string) ([]string, error) {
+	return listDashboardRuntimeTypesWithFactories(runtimeStorageDir, availableRuntimes)
+}
+
+// listDashboardRuntimeTypesWithFactories returns Dashboard-capable runtime type names
+// from the given factories. This function is internal and used for testing.
+func listDashboardRuntimeTypesWithFactories(runtimeStorageDir string, factories []runtimeFactory) ([]string, error) {
+	registry, err := runtime.NewRegistry(runtimeStorageDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var types []string
+	for _, factory := range factories {
+		rt := factory()
+
+		if avail, ok := rt.(Available); ok && !avail.Available() {
+			continue
+		}
+
+		if err := registry.Register(rt); err != nil {
+			continue
+		}
+
+		if _, ok := rt.(runtime.Dashboard); ok {
+			types = append(types, rt.Type())
+		}
+	}
+
+	return types, nil
+}
+
 // RegisterAll registers all available runtimes to the given registrar.
 // It skips runtimes that implement the Available interface and report false.
 // Returns an error if any runtime fails to register.

--- a/pkg/runtimesetup/register_test.go
+++ b/pkg/runtimesetup/register_test.go
@@ -71,6 +71,85 @@ func (t *testRuntime) Available() bool {
 	return t.available
 }
 
+// testRuntimeWithDashboard wraps testRuntime and implements runtime.Dashboard.
+type testRuntimeWithDashboard struct {
+	*testRuntime
+}
+
+func (t *testRuntimeWithDashboard) GetURL(_ context.Context, _ string) (string, error) {
+	return "http://localhost:8888", nil
+}
+
+func TestListDashboardRuntimeTypesWithFactories(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns type names of runtimes that implement Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithDashboard{&testRuntime{runtimeType: "dashboard-rt", available: true}}
+			},
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "no-dashboard-rt", available: true}
+			},
+		}
+
+		types, err := listDashboardRuntimeTypesWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(types) != 1 {
+			t.Fatalf("expected 1 type, got %d: %v", len(types), types)
+		}
+		if types[0] != "dashboard-rt" {
+			t.Errorf("expected 'dashboard-rt', got %q", types[0])
+		}
+	})
+
+	t.Run("returns empty when no runtimes implement Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "no-dashboard-rt", available: true}
+			},
+		}
+
+		types, err := listDashboardRuntimeTypesWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(types) != 0 {
+			t.Errorf("expected 0 types, got %d: %v", len(types), types)
+		}
+	})
+
+	t.Run("skips unavailable runtimes even if they implement Dashboard", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithDashboard{&testRuntime{runtimeType: "dashboard-rt", available: false}}
+			},
+		}
+
+		types, err := listDashboardRuntimeTypesWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(types) != 0 {
+			t.Errorf("expected 0 types (runtime unavailable), got %d: %v", len(types), types)
+		}
+	})
+}
+
 func TestRegisterAll(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds `kdn workspace dashboard NAME|ID` (alias: `kdn dashboard`) to print the dashboard URL for a running workspace and open it in the default browser.

Introduces an optional `Dashboard` runtime interface that runtimes implement to expose a URL. The Podman runtime implements it by reading the OneCLI web port from persisted pod template data. A `NewWithDashboard` fake runtime variant is provided for testing.

Fixes a bug where `manager.Start()` and `manager.Stop()` replaced the full `RuntimeData.Info` map, discarding persisted fields like `onecli_web_port` set at creation time. Info maps are now merged instead of replaced.

Tab completion only suggests running workspaces whose runtime implements the Dashboard interface (`ListDashboardRuntimeTypes`).

Closes #346