### PR TITLE
feat(secretservice)!: replace HostPattern string with HostsPatterns []string

### DIFF
--- a/.agents/skills/working-with-onecli/SKILL.md
+++ b/.agents/skills/working-with-onecli/SKILL.md
@@ -113,10 +113,10 @@ inputs, err := mapper.Map(item, value) // item: secret.ListItem, value: string f
 
 ### Mapping rules
 
-- **Known type** (e.g. `github`): looks up the `SecretService` in the registry; uses its `HostPattern()`, `Path()`, `HeaderName()`, and `HeaderTemplate()` fields. Returns a single-element slice.
+- **Known type** (e.g. `github`): looks up the `SecretService` in the registry; uses its `HostsPatterns()`, `Path()`, `HeaderName()`, and `HeaderTemplate()` fields. If the service has a single host pattern, returns a single-element slice; if multiple patterns, returns one `CreateSecretInput` per pattern with the name `<secret-name>-<sanitized-pattern>`. Returns an error if `HostsPatterns()` is empty.
 - **`other` type**: uses the secret's own `Hosts`, `Path`, `Header`, `HeaderTemplate` fields. When multiple hosts are provided, one `CreateSecretInput` is returned per host with the name `<secret-name>-<sanitized-host>`; a single or empty `Hosts` returns a single element using `item.Name` unchanged.
 - Template conversion: kdn uses `${value}`, OneCLI uses `{value}` — the mapper converts automatically.
-- `HostPattern` is always `"*"` when `Hosts` is nil or empty.
+- `HostPattern` is `"*"` for `other` type when `Hosts` is nil or empty.
 
 ## SecretProvisioner
 

--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -102,7 +102,7 @@ Add an entry to `pkg/secretservicesetup/secretservices.json`:
 ```json
 {
   "name": "my-service",
-  "hostPattern": "api.my-service.com",
+  "hostsPatterns": ["api.my-service.com"],
   "headerName": "Authorization",
   "headerTemplate": "Bearer ${value}",
   "envVars": ["MY_SERVICE_TOKEN"]
@@ -114,7 +114,7 @@ All fields:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | yes | Identifier used as `--type` value |
-| `hostPattern` | yes | Regex matched against request host |
+| `hostsPatterns` | yes | List of regex patterns matched against the request host |
 | `headerName` | yes | HTTP header to set |
 | `headerTemplate` | yes | Header value template; `${value}` is replaced with the secret value |
 | `path` | no | URL path prefix restriction |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 The secret service system provides a pluggable architecture for managing secret service definitions that describe how secrets are applied to workspace requests.
 
 **Key Components:**
-- **SecretService Interface** (`pkg/secretservice/secretservice.go`): Contract all secret services must implement (`Name()`, `HostPattern()`, `Path()`, `EnvVars()`, `HeaderName()`, `HeaderTemplate()`)
+- **SecretService Interface** (`pkg/secretservice/secretservice.go`): Contract all secret services must implement (`Name()`, `HostsPatterns()`, `Path()`, `EnvVars()`, `HeaderName()`, `HeaderTemplate()`)
 - **Registry** (`pkg/secretservice/registry.go`): Manages secret service registration and discovery
 - **Centralized Registration** (`pkg/secretservicesetup/register.go`): Automatically registers all available secret services; `ListAvailable()` returns the names of all registered services (used by commands to derive valid `--type` values dynamically)
 

--- a/README.md
+++ b/README.md
@@ -2326,7 +2326,7 @@ Output:
   "items": [
     {
       "name": "github",
-      "hostPattern": "api.github.com",
+      "hostsPatterns": ["api.github.com"],
       "headerName": "Authorization",
       "headerTemplate": "Bearer ${value}",
       "envVars": ["GH_TOKEN", "GITHUB_TOKEN"]

--- a/pkg/cmd/service_list.go
+++ b/pkg/cmd/service_list.go
@@ -49,7 +49,7 @@ func (r *registryRegistrar) RegisterSecretService(service secretservice.SecretSe
 // serviceDetail represents a secret service in JSON output
 type serviceDetail struct {
 	Name           string   `json:"name"`
-	HostPattern    string   `json:"hostPattern"`
+	HostsPatterns  []string `json:"hostsPatterns"`
 	HeaderName     string   `json:"headerName"`
 	HeaderTemplate string   `json:"headerTemplate,omitempty"`
 	Path           string   `json:"path,omitempty"`
@@ -117,14 +117,15 @@ func (s *serviceListCmd) displayTable(cmd *cobra.Command, services []secretservi
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 	columnFmt := color.New(color.FgYellow).SprintfFunc()
 
-	tbl := table.New("NAME", "HOST PATTERN", "PATH", "HEADER", "HEADER TEMPLATE", "ENV VARS")
+	tbl := table.New("NAME", "HOST PATTERNS", "PATH", "HEADER", "HEADER TEMPLATE", "ENV VARS")
 	tbl.WithWriter(out)
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
 	// Add each service as a row
 	for _, svc := range services {
+		hostsPatterns := strings.Join(svc.HostsPatterns(), ", ")
 		envVars := strings.Join(svc.EnvVars(), ", ")
-		tbl.AddRow(svc.Name(), svc.HostPattern(), svc.Path(), svc.HeaderName(), svc.HeaderTemplate(), envVars)
+		tbl.AddRow(svc.Name(), hostsPatterns, svc.Path(), svc.HeaderName(), svc.HeaderTemplate(), envVars)
 	}
 
 	// Print the table
@@ -139,7 +140,7 @@ func (s *serviceListCmd) outputJSON(cmd *cobra.Command, services []secretservice
 	for _, svc := range services {
 		items = append(items, serviceDetail{
 			Name:           svc.Name(),
-			HostPattern:    svc.HostPattern(),
+			HostsPatterns:  svc.HostsPatterns(),
 			HeaderName:     svc.HeaderName(),
 			HeaderTemplate: svc.HeaderTemplate(),
 			Path:           svc.Path(),

--- a/pkg/cmd/service_list_test.go
+++ b/pkg/cmd/service_list_test.go
@@ -181,8 +181,8 @@ func TestServiceListCmd_E2E(t *testing.T) {
 		for _, svc := range response.Items {
 			if svc.Name == "github" {
 				found = true
-				if svc.HostPattern != "api.github.com" {
-					t.Errorf("Expected HostPattern %q, got %q", "api.github.com", svc.HostPattern)
+				if len(svc.HostsPatterns) == 0 || svc.HostsPatterns[0] != "api.github.com" {
+					t.Errorf("Expected HostsPatterns %v, got %v", []string{"api.github.com"}, svc.HostsPatterns)
 				}
 				if svc.HeaderName != "Authorization" {
 					t.Errorf("Expected HeaderName %q, got %q", "Authorization", svc.HeaderName)

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -4248,7 +4248,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 
 		svc := &fakeSecretServiceImpl{
 			name:           "github",
-			hostPattern:    `github\.com`,
+			hostsPatterns:  []string{"github.com"},
 			headerName:     "Authorization",
 			headerTemplate: "Bearer ${value}",
 			envVars:        []string{"GITHUB_TOKEN"},
@@ -4277,8 +4277,8 @@ func TestManager_Add_Secrets(t *testing.T) {
 		if got.Name != "gh-token" {
 			t.Errorf("OnecliSecrets[0].Name = %q, want %q", got.Name, "gh-token")
 		}
-		if got.HostPattern != `github\.com` {
-			t.Errorf("OnecliSecrets[0].HostPattern = %q, want %q", got.HostPattern, `github\.com`)
+		if got.HostPattern != "github.com" {
+			t.Errorf("OnecliSecrets[0].HostPattern = %q, want %q", got.HostPattern, "github.com")
 		}
 		if got.Value != "ghp_abc123" {
 			t.Errorf("OnecliSecrets[0].Value = %q, want %q", got.Value, "ghp_abc123")
@@ -4460,10 +4460,10 @@ func TestManager_Add_Secrets(t *testing.T) {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
 		}
 		svc := &fakeSecretServiceImpl{
-			name:        "github",
-			hostPattern: `github\.com`,
-			headerName:  "Authorization",
-			envVars:     []string{"GITHUB_TOKEN"},
+			name:          "github",
+			hostsPatterns: []string{"github.com"},
+			headerName:    "Authorization",
+			envVars:       []string{"GITHUB_TOKEN"},
 		}
 		if err := manager.RegisterSecretService(svc); err != nil {
 			t.Fatalf("RegisterSecretService() error = %v", err)
@@ -4499,19 +4499,19 @@ func TestManager_Add_Secrets(t *testing.T) {
 // fakeSecretServiceImpl is a test implementation of the SecretService interface
 type fakeSecretServiceImpl struct {
 	name           string
-	hostPattern    string
+	hostsPatterns  []string
 	path           string
 	envVars        []string
 	headerName     string
 	headerTemplate string
 }
 
-func (f *fakeSecretServiceImpl) Name() string           { return f.name }
-func (f *fakeSecretServiceImpl) HostPattern() string    { return f.hostPattern }
-func (f *fakeSecretServiceImpl) Path() string           { return f.path }
-func (f *fakeSecretServiceImpl) EnvVars() []string      { return f.envVars }
-func (f *fakeSecretServiceImpl) HeaderName() string     { return f.headerName }
-func (f *fakeSecretServiceImpl) HeaderTemplate() string { return f.headerTemplate }
+func (f *fakeSecretServiceImpl) Name() string            { return f.name }
+func (f *fakeSecretServiceImpl) HostsPatterns() []string { return f.hostsPatterns }
+func (f *fakeSecretServiceImpl) Path() string            { return f.path }
+func (f *fakeSecretServiceImpl) EnvVars() []string       { return f.envVars }
+func (f *fakeSecretServiceImpl) HeaderName() string      { return f.headerName }
+func (f *fakeSecretServiceImpl) HeaderTemplate() string  { return f.headerTemplate }
 
 func TestManager_GetDashboardURL(t *testing.T) {
 	t.Parallel()
@@ -4683,7 +4683,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		tmpDir := t.TempDir()
 		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
 
-		svc := &fakeSecretServiceImpl{name: "github", hostPattern: `github\.com`, headerName: "Authorization"}
+		svc := &fakeSecretServiceImpl{name: "github", hostsPatterns: []string{"github.com"}, headerName: "Authorization"}
 
 		err := manager.RegisterSecretService(svc)
 		if err != nil {

--- a/pkg/onecli/mapper.go
+++ b/pkg/onecli/mapper.go
@@ -62,22 +62,56 @@ func (m *secretMapper) mapKnownSecret(item secret.ListItem, value string) ([]Cre
 		return nil, fmt.Errorf("unknown secret type %q: %w", item.Type, err)
 	}
 
-	input := CreateSecretInput{
-		Name:        item.Name,
-		Type:        "generic",
-		Value:       value,
-		HostPattern: svc.HostPattern(),
-		PathPattern: svc.Path(),
+	patterns := svc.HostsPatterns()
+	if len(patterns) == 0 {
+		return nil, fmt.Errorf("secret service %q has no host patterns defined", item.Type)
 	}
 
-	if headerName := svc.HeaderName(); headerName != "" {
-		input.InjectionConfig = &InjectionConfig{
-			HeaderName:  headerName,
-			ValueFormat: convertTemplate(svc.HeaderTemplate()),
+	if len(patterns) == 1 {
+		input := CreateSecretInput{
+			Name:        item.Name,
+			Type:        "generic",
+			Value:       value,
+			HostPattern: patterns[0],
+			PathPattern: svc.Path(),
 		}
+		if headerName := svc.HeaderName(); headerName != "" {
+			input.InjectionConfig = &InjectionConfig{
+				HeaderName:  headerName,
+				ValueFormat: convertTemplate(svc.HeaderTemplate()),
+			}
+		}
+		return []CreateSecretInput{input}, nil
 	}
 
-	return []CreateSecretInput{input}, nil
+	inputs := make([]CreateSecretInput, 0, len(patterns))
+	seen := make(map[string]string, len(patterns))
+	for _, pattern := range patterns {
+		suffix := sanitizeName(pattern)
+		if suffix == "" {
+			return nil, fmt.Errorf("host pattern %q sanitizes to an empty name segment", pattern)
+		}
+		name := item.Name + "-" + suffix
+		if prev, ok := seen[name]; ok {
+			return nil, fmt.Errorf("host patterns %q and %q produce duplicate secret name %q", prev, pattern, name)
+		}
+		seen[name] = pattern
+		input := CreateSecretInput{
+			Name:        name,
+			Type:        "generic",
+			Value:       value,
+			HostPattern: pattern,
+			PathPattern: svc.Path(),
+		}
+		if headerName := svc.HeaderName(); headerName != "" {
+			input.InjectionConfig = &InjectionConfig{
+				HeaderName:  headerName,
+				ValueFormat: convertTemplate(svc.HeaderTemplate()),
+			}
+		}
+		inputs = append(inputs, input)
+	}
+	return inputs, nil
 }
 
 func (m *secretMapper) mapOtherSecret(item secret.ListItem, value string) ([]CreateSecretInput, error) {

--- a/pkg/onecli/mapper_test.go
+++ b/pkg/onecli/mapper_test.go
@@ -30,7 +30,7 @@ func registryWithGitHub(t *testing.T) secretservice.Registry {
 	reg := secretservice.NewRegistry()
 	svc := secretservice.NewSecretService(
 		"github",
-		"api.github.com",
+		[]string{"api.github.com"},
 		"",
 		[]string{"GH_TOKEN", "GITHUB_TOKEN"},
 		"Authorization",
@@ -79,6 +79,64 @@ func TestMapper_KnownType_GitHub(t *testing.T) {
 	}
 	if got[0].InjectionConfig.ValueFormat != "Bearer {value}" {
 		t.Errorf("ValueFormat = %q, want %q", got[0].InjectionConfig.ValueFormat, "Bearer {value}")
+	}
+}
+
+func TestMapper_KnownType_MultiplePatterns(t *testing.T) {
+	t.Parallel()
+
+	reg := secretservice.NewRegistry()
+	svc := secretservice.NewSecretService(
+		"multi",
+		[]string{"api.example.com", "api2.example.com"},
+		"",
+		nil,
+		"Authorization",
+		"Bearer ${value}",
+	)
+	if err := reg.Register(svc); err != nil {
+		t.Fatal(err)
+	}
+
+	mapper := NewSecretMapper(reg)
+	item := secret.ListItem{Name: "my-token", Type: "multi"}
+
+	got, err := mapper.Map(item, "val")
+	if err != nil {
+		t.Fatalf("Map() error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Map() returned %d inputs, want 2", len(got))
+	}
+	if got[0].Name != "my-token-api-example-com" {
+		t.Errorf("got[0].Name = %q, want %q", got[0].Name, "my-token-api-example-com")
+	}
+	if got[0].HostPattern != "api.example.com" {
+		t.Errorf("got[0].HostPattern = %q, want %q", got[0].HostPattern, "api.example.com")
+	}
+	if got[1].Name != "my-token-api2-example-com" {
+		t.Errorf("got[1].Name = %q, want %q", got[1].Name, "my-token-api2-example-com")
+	}
+	if got[1].HostPattern != "api2.example.com" {
+		t.Errorf("got[1].HostPattern = %q, want %q", got[1].HostPattern, "api2.example.com")
+	}
+}
+
+func TestMapper_KnownType_EmptyPatterns(t *testing.T) {
+	t.Parallel()
+
+	reg := secretservice.NewRegistry()
+	svc := secretservice.NewSecretService("empty", nil, "", nil, "X-Token", "${value}")
+	if err := reg.Register(svc); err != nil {
+		t.Fatal(err)
+	}
+
+	mapper := NewSecretMapper(reg)
+	item := secret.ListItem{Name: "my-token", Type: "empty"}
+
+	_, err := mapper.Map(item, "val")
+	if err == nil {
+		t.Fatal("expected error for service with no host patterns")
 	}
 }
 

--- a/pkg/secretservice/registry_test.go
+++ b/pkg/secretservice/registry_test.go
@@ -26,19 +26,19 @@ import (
 // fakeSecretService is a test implementation of the SecretService interface
 type fakeSecretService struct {
 	name           string
-	hostPattern    string
+	hostsPatterns  []string
 	path           string
 	envVars        []string
 	headerName     string
 	headerTemplate string
 }
 
-func (f *fakeSecretService) Name() string           { return f.name }
-func (f *fakeSecretService) HostPattern() string    { return f.hostPattern }
-func (f *fakeSecretService) Path() string           { return f.path }
-func (f *fakeSecretService) EnvVars() []string      { return f.envVars }
-func (f *fakeSecretService) HeaderName() string     { return f.headerName }
-func (f *fakeSecretService) HeaderTemplate() string { return f.headerTemplate }
+func (f *fakeSecretService) Name() string            { return f.name }
+func (f *fakeSecretService) HostsPatterns() []string { return f.hostsPatterns }
+func (f *fakeSecretService) Path() string            { return f.path }
+func (f *fakeSecretService) EnvVars() []string       { return f.envVars }
+func (f *fakeSecretService) HeaderName() string      { return f.headerName }
+func (f *fakeSecretService) HeaderTemplate() string  { return f.headerTemplate }
 
 func TestNewRegistry(t *testing.T) {
 	t.Parallel()
@@ -113,7 +113,7 @@ func TestRegistry_Get(t *testing.T) {
 		t.Parallel()
 
 		reg := NewRegistry()
-		svc := &fakeSecretService{name: "github", hostPattern: `github\.com`}
+		svc := &fakeSecretService{name: "github", hostsPatterns: []string{"github.com"}}
 
 		err := reg.Register(svc)
 		if err != nil {
@@ -133,8 +133,8 @@ func TestRegistry_Get(t *testing.T) {
 			t.Errorf("Get() returned service with name %q, want %q", retrieved.Name(), "github")
 		}
 
-		if retrieved.HostPattern() != `github\.com` {
-			t.Errorf("Get() returned service with host pattern %q, want %q", retrieved.HostPattern(), `github\.com`)
+		if len(retrieved.HostsPatterns()) == 0 || retrieved.HostsPatterns()[0] != "github.com" {
+			t.Errorf("Get() returned service with host patterns %v, want %v", retrieved.HostsPatterns(), []string{"github.com"})
 		}
 	})
 

--- a/pkg/secretservice/secretservice.go
+++ b/pkg/secretservice/secretservice.go
@@ -27,8 +27,9 @@ type SecretService interface {
 	// Name returns the identifier of the secret service.
 	Name() string
 
-	// HostPattern returns a regular expression pattern for matching hosts.
-	HostPattern() string
+	// HostsPatterns returns the list of regular expression patterns for matching hosts.
+	// Returns nil if not set.
+	HostsPatterns() []string
 
 	// Path returns the optional path for the secret service.
 	// Returns an empty string if not set.
@@ -50,7 +51,7 @@ type SecretService interface {
 // service is the concrete implementation of SecretService.
 type service struct {
 	name           string
-	hostPattern    string
+	hostsPatterns  []string
 	path           string
 	envVars        []string
 	headerName     string
@@ -61,10 +62,10 @@ type service struct {
 var _ SecretService = (*service)(nil)
 
 // NewSecretService creates a new SecretService implementation with the given parameters.
-func NewSecretService(name, hostPattern, path string, envVars []string, headerName, headerTemplate string) SecretService {
+func NewSecretService(name string, hostsPatterns []string, path string, envVars []string, headerName, headerTemplate string) SecretService {
 	return &service{
 		name:           name,
-		hostPattern:    hostPattern,
+		hostsPatterns:  hostsPatterns,
 		path:           path,
 		envVars:        envVars,
 		headerName:     headerName,
@@ -77,9 +78,9 @@ func (s *service) Name() string {
 	return s.name
 }
 
-// HostPattern returns a regular expression pattern for matching hosts.
-func (s *service) HostPattern() string {
-	return s.hostPattern
+// HostsPatterns returns the list of regular expression patterns for matching hosts.
+func (s *service) HostsPatterns() []string {
+	return s.hostsPatterns
 }
 
 // Path returns the optional path for the secret service.

--- a/pkg/secretservicesetup/register.go
+++ b/pkg/secretservicesetup/register.go
@@ -42,7 +42,7 @@ var secretServicesJSON []byte
 // secretServiceDefinition represents a secret service entry in the embedded JSON file.
 type secretServiceDefinition struct {
 	Name           string   `json:"name"`
-	HostPattern    string   `json:"hostPattern"`
+	HostsPatterns  []string `json:"hostsPatterns"`
 	Path           string   `json:"path"`
 	HeaderName     string   `json:"headerName"`
 	HeaderTemplate string   `json:"headerTemplate"`
@@ -76,7 +76,7 @@ func loadSecretServices() ([]secretServiceFactory, error) {
 		factories = append(factories, func() secretservice.SecretService {
 			return secretservice.NewSecretService(
 				d.Name,
-				d.HostPattern,
+				d.HostsPatterns,
 				d.Path,
 				d.EnvVars,
 				d.HeaderName,

--- a/pkg/secretservicesetup/register_test.go
+++ b/pkg/secretservicesetup/register_test.go
@@ -276,8 +276,8 @@ func TestAvailableSecretServicesContainAnthropic(t *testing.T) {
 	if svc.Name() != "anthropic" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "anthropic")
 	}
-	if svc.HostPattern() != "api.anthropic.com" {
-		t.Errorf("HostPattern() = %q, want %q", svc.HostPattern(), "api.anthropic.com")
+	if len(svc.HostsPatterns()) == 0 || svc.HostsPatterns()[0] != "api.anthropic.com" {
+		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"api.anthropic.com"})
 	}
 	if svc.Path() != "" {
 		t.Errorf("Path() = %q, want empty string", svc.Path())

--- a/pkg/secretservicesetup/register_test.go
+++ b/pkg/secretservicesetup/register_test.go
@@ -28,19 +28,19 @@ import (
 // fakeSecretService is a test implementation of the SecretService interface
 type fakeSecretService struct {
 	name           string
-	hostPattern    string
+	hostsPatterns  []string
 	path           string
 	envVars        []string
 	headerName     string
 	headerTemplate string
 }
 
-func (f *fakeSecretService) Name() string           { return f.name }
-func (f *fakeSecretService) HostPattern() string    { return f.hostPattern }
-func (f *fakeSecretService) Path() string           { return f.path }
-func (f *fakeSecretService) EnvVars() []string      { return f.envVars }
-func (f *fakeSecretService) HeaderName() string     { return f.headerName }
-func (f *fakeSecretService) HeaderTemplate() string { return f.headerTemplate }
+func (f *fakeSecretService) Name() string            { return f.name }
+func (f *fakeSecretService) HostsPatterns() []string { return f.hostsPatterns }
+func (f *fakeSecretService) Path() string            { return f.path }
+func (f *fakeSecretService) EnvVars() []string       { return f.envVars }
+func (f *fakeSecretService) HeaderName() string      { return f.headerName }
+func (f *fakeSecretService) HeaderTemplate() string  { return f.headerTemplate }
 
 // fakeRegistrar implements SecretServiceRegistrar for testing
 type fakeRegistrar struct {
@@ -103,7 +103,7 @@ func TestRegisterAllWithFactories(t *testing.T) {
 
 		factories := []secretServiceFactory{
 			func() secretservice.SecretService {
-				return &fakeSecretService{name: "github", hostPattern: `github\.com`, headerName: "Authorization"}
+				return &fakeSecretService{name: "github", hostsPatterns: []string{"github.com"}, headerName: "Authorization"}
 			},
 		}
 
@@ -196,8 +196,8 @@ func TestAvailableSecretServicesContainGitHub(t *testing.T) {
 	if svc.Name() != "github" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "github")
 	}
-	if svc.HostPattern() != "api.github.com" {
-		t.Errorf("HostPattern() = %q, want %q", svc.HostPattern(), "api.github.com")
+	if len(svc.HostsPatterns()) == 0 || svc.HostsPatterns()[0] != "api.github.com" {
+		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"api.github.com"})
 	}
 	if svc.Path() != "" {
 		t.Errorf("Path() = %q, want empty string", svc.Path())
@@ -236,8 +236,8 @@ func TestAvailableSecretServicesContainGemini(t *testing.T) {
 	if svc.Name() != "gemini" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "gemini")
 	}
-	if svc.HostPattern() != "generativelanguage.googleapis.com" {
-		t.Errorf("HostPattern() = %q, want %q", svc.HostPattern(), "generativelanguage.googleapis.com")
+	if len(svc.HostsPatterns()) == 0 || svc.HostsPatterns()[0] != "generativelanguage.googleapis.com" {
+		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"generativelanguage.googleapis.com"})
 	}
 	if svc.Path() != "" {
 		t.Errorf("Path() = %q, want empty string", svc.Path())

--- a/pkg/secretservicesetup/secretservices.json
+++ b/pkg/secretservicesetup/secretservices.json
@@ -15,7 +15,7 @@
   },
   {
     "name": "anthropic",
-    "hostPattern": "api.anthropic.com",
+    "hostsPatterns": ["api.anthropic.com"],
     "headerName": "x-api-key",
     "envVars": ["ANTHROPIC_API_KEY"]
   }

--- a/pkg/secretservicesetup/secretservices.json
+++ b/pkg/secretservicesetup/secretservices.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "github",
-    "hostPattern": "api.github.com",
+    "hostsPatterns": ["api.github.com"],
     "headerName": "Authorization",
     "headerTemplate": "Bearer ${value}",
     "envVars": ["GH_TOKEN", "GITHUB_TOKEN"]
   },
   {
     "name": "gemini",
-    "hostPattern": "generativelanguage.googleapis.com",
+    "hostsPatterns": ["generativelanguage.googleapis.com"],
     "headerName": "x-goog-api-key",
     "headerTemplate": "${value}",
     "envVars": ["GEMINI_API_KEY", "GOOGLE_API_KEY"]


### PR DESCRIPTION
A secret service can now declare multiple host patterns instead of a single one. The mapper handles 0 patterns as an error, 1 pattern as before (same secret name), and N patterns by creating one CreateSecretInput per pattern with a sanitized name suffix.

The JSON definition field and the JSON output field are both renamed from hostPattern to hostsPatterns (array). All tests, skills, and documentation are updated accordingly.

BREAKING CHANGE: SecretService interface method HostPattern() string is replaced by HostsPatterns() []string. The secretservices.json field hostPattern is replaced by hostsPatterns (array).

Fixes #342 