### PR TITLE
feat(autocomplete): add KDN_AUTOCOMPLETE_IGNORE_IDS  + extract envvars helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,12 @@ type Logger interface {
 
 **Context integration** (`pkg/logger/context.go`): `WithLogger()` / `FromContext()` — mirrors the StepLogger pattern.
 
+### Environment Variable Utilities
+
+The `pkg/envvars` package provides shared helpers for reading environment variables.
+
+**`IsTruthy(key string) bool`** — returns `true` if the environment variable named by `key` is set to a recognised truthy string (`1`, `true`, `True`, `TRUE`, `yes`, `Yes`, `YES`). Use this instead of inlining a `switch` whenever a boolean env var controls behaviour.
+
 ### OneCLI System
 
 The OneCLI system (`pkg/onecli`) provides a typed HTTP client and higher-level abstractions for interacting with the OneCLI API, which proxies outbound HTTP requests and injects secrets as headers inside workspace containers.

--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,41 @@ kdn init /path/to/another-project --runtime podman --agent claude --start
 - If the workspace fails to start, the registration still succeeds, but an error is returned
 - The `--start` flag always takes precedence over the environment variable
 
+### `KDN_AUTOCOMPLETE_IGNORE_IDS`
+
+Hides workspace IDs from shell autocompletion, so only names are suggested.
+
+By default, commands like `kdn start`, `kdn stop`, and `kdn remove` autocomplete both workspace IDs and names. If only one workspace exists, the shell cannot complete the argument immediately because there are two candidates (ID and name). Setting `KDN_AUTOCOMPLETE_IGNORE_IDS` removes IDs from the suggestions, allowing instant completion when a single workspace is registered.
+
+**Usage:**
+
+```bash
+export KDN_AUTOCOMPLETE_IGNORE_IDS=1
+kdn start <TAB>   # suggests names only
+```
+
+**Supported Values:**
+
+The environment variable accepts the following truthy values (case-insensitive):
+- `1`
+- `true`, `True`, `TRUE`
+- `yes`, `Yes`, `YES`
+
+Any other value (including `0`, `false`, `no`, or empty string) keeps the default behaviour of suggesting both IDs and names.
+
+**Example:**
+
+```bash
+# Show only names during tab-completion
+export KDN_AUTOCOMPLETE_IGNORE_IDS=1
+kdn start <TAB>      # completes to the workspace name immediately if only one exists
+kdn stop <TAB>
+kdn remove <TAB>
+
+# Restore default behaviour (show IDs and names)
+unset KDN_AUTOCOMPLETE_IGNORE_IDS
+```
+
 ## Podman Runtime
 
 The Podman runtime provides a container-based development environment for workspaces. It creates an isolated environment with all necessary tools pre-installed and configured.

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -32,6 +32,15 @@ import (
 // stateFilter is a function that determines if an instance with the given state should be included
 type stateFilter func(state api.WorkspaceState) bool
 
+// isTruthyEnv returns true if val is a recognised truthy string ("1", "true", "yes" in any case).
+func isTruthyEnv(val string) bool {
+	switch val {
+	case "1", "true", "True", "TRUE", "yes", "Yes", "YES":
+		return true
+	}
+	return false
+}
+
 // getFilteredWorkspaceIDs retrieves workspace IDs and names, optionally filtered by state
 func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, cobra.ShellCompDirective) {
 	// Get storage directory from global flag
@@ -64,14 +73,17 @@ func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, 
 		return nil, cobra.ShellCompDirectiveError
 	}
 
+	ignoreIDs := isTruthyEnv(os.Getenv("KDN_AUTOCOMPLETE_IGNORE_IDS"))
+
 	// Extract IDs and names with optional filtering
 	var completions []string
 	for _, instance := range instancesList {
 		state := instance.GetRuntimeData().State
 		// Apply filter if provided, otherwise include all
 		if filter == nil || filter(state) {
-			// Add both ID and name for better discoverability
-			completions = append(completions, instance.GetID())
+			if !ignoreIDs {
+				completions = append(completions, instance.GetID())
+			}
 			completions = append(completions, instance.GetName())
 		}
 	}
@@ -149,12 +161,16 @@ func completeDashboardWorkspaceIDWith(cmd *cobra.Command, listDashboardTypes fun
 		return nil, cobra.ShellCompDirectiveError
 	}
 
+	ignoreIDs := isTruthyEnv(os.Getenv("KDN_AUTOCOMPLETE_IGNORE_IDS"))
+
 	var completions []string
 	for _, instance := range instancesList {
 		runtimeData := instance.GetRuntimeData()
 		if runtimeData.State == api.WorkspaceStateRunning {
 			if _, ok := dashboardTypeSet[runtimeData.Type]; ok {
-				completions = append(completions, instance.GetID())
+				if !ignoreIDs {
+					completions = append(completions, instance.GetID())
+				}
 				completions = append(completions, instance.GetName())
 			}
 		}

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/envvars"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -31,15 +32,6 @@ import (
 
 // stateFilter is a function that determines if an instance with the given state should be included
 type stateFilter func(state api.WorkspaceState) bool
-
-// isTruthyEnv returns true if val is a recognised truthy string ("1", "true", "yes" in any case).
-func isTruthyEnv(val string) bool {
-	switch val {
-	case "1", "true", "True", "TRUE", "yes", "Yes", "YES":
-		return true
-	}
-	return false
-}
 
 // getFilteredWorkspaceIDs retrieves workspace IDs and names, optionally filtered by state
 func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, cobra.ShellCompDirective) {
@@ -73,7 +65,7 @@ func getFilteredWorkspaceIDs(cmd *cobra.Command, filter stateFilter) ([]string, 
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	ignoreIDs := isTruthyEnv(os.Getenv("KDN_AUTOCOMPLETE_IGNORE_IDS"))
+	ignoreIDs := envvars.IsTruthy("KDN_AUTOCOMPLETE_IGNORE_IDS")
 
 	// Extract IDs and names with optional filtering
 	var completions []string
@@ -161,7 +153,7 @@ func completeDashboardWorkspaceIDWith(cmd *cobra.Command, listDashboardTypes fun
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	ignoreIDs := isTruthyEnv(os.Getenv("KDN_AUTOCOMPLETE_IGNORE_IDS"))
+	ignoreIDs := envvars.IsTruthy("KDN_AUTOCOMPLETE_IGNORE_IDS")
 
 	var completions []string
 	for _, instance := range instancesList {

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -920,32 +920,6 @@ func TestCompleteDashboardWorkspaceID(t *testing.T) {
 	})
 }
 
-func TestIsTruthyEnv(t *testing.T) {
-	t.Parallel()
-
-	truthy := []string{"1", "true", "True", "TRUE", "yes", "Yes", "YES"}
-	for _, v := range truthy {
-		v := v
-		t.Run("truthy_"+v, func(t *testing.T) {
-			t.Parallel()
-			if !isTruthyEnv(v) {
-				t.Errorf("expected isTruthyEnv(%q) to be true", v)
-			}
-		})
-	}
-
-	falsy := []string{"0", "false", "no", "", "random"}
-	for _, v := range falsy {
-		v := v
-		t.Run("falsy_"+v, func(t *testing.T) {
-			t.Parallel()
-			if isTruthyEnv(v) {
-				t.Errorf("expected isTruthyEnv(%q) to be false", v)
-			}
-		})
-	}
-}
-
 func TestCompleteWorkspaceIDIgnoreIDs(t *testing.T) {
 	// Cannot use t.Parallel() on the parent because subtests use t.Setenv.
 

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -920,6 +920,243 @@ func TestCompleteDashboardWorkspaceID(t *testing.T) {
 	})
 }
 
+func TestIsTruthyEnv(t *testing.T) {
+	t.Parallel()
+
+	truthy := []string{"1", "true", "True", "TRUE", "yes", "Yes", "YES"}
+	for _, v := range truthy {
+		v := v
+		t.Run("truthy_"+v, func(t *testing.T) {
+			t.Parallel()
+			if !isTruthyEnv(v) {
+				t.Errorf("expected isTruthyEnv(%q) to be true", v)
+			}
+		})
+	}
+
+	falsy := []string{"0", "false", "no", "", "random"}
+	for _, v := range falsy {
+		v := v
+		t.Run("falsy_"+v, func(t *testing.T) {
+			t.Parallel()
+			if isTruthyEnv(v) {
+				t.Errorf("expected isTruthyEnv(%q) to be false", v)
+			}
+		})
+	}
+}
+
+func TestCompleteWorkspaceIDIgnoreIDs(t *testing.T) {
+	// Cannot use t.Parallel() on the parent because subtests use t.Setenv.
+
+	ctx := context.Background()
+
+	setup := func(t *testing.T) (storageDir string, id1, name1, id2, name2 string) {
+		t.Helper()
+		storageDir = t.TempDir()
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+
+		src1 := t.TempDir()
+		inst1, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: src1,
+			ConfigDir: filepath.Join(src1, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance1: %v", err)
+		}
+		added1, err := manager.Add(ctx, instances.AddOptions{Instance: inst1, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance1: %v", err)
+		}
+
+		src2 := t.TempDir()
+		inst2, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: src2,
+			ConfigDir: filepath.Join(src2, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance2: %v", err)
+		}
+		added2, err := manager.Add(ctx, instances.AddOptions{Instance: inst2, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance2: %v", err)
+		}
+
+		return storageDir, added1.GetID(), added1.GetName(), added2.GetID(), added2.GetName()
+	}
+
+	t.Run("returns IDs and names when KDN_AUTOCOMPLETE_IGNORE_IDS is not set", func(t *testing.T) {
+		t.Setenv("KDN_AUTOCOMPLETE_IGNORE_IDS", "")
+
+		storageDir, id1, name1, id2, name2 := setup(t)
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeWorkspaceID(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 4 {
+			t.Errorf("Expected 4 completions (ID+name for each), got %d: %v", len(completions), completions)
+		}
+		set := make(map[string]bool)
+		for _, c := range completions {
+			set[c] = true
+		}
+		for _, v := range []string{id1, name1, id2, name2} {
+			if !set[v] {
+				t.Errorf("Expected %q in completions, got %v", v, completions)
+			}
+		}
+	})
+
+	t.Run("returns only names when KDN_AUTOCOMPLETE_IGNORE_IDS is truthy", func(t *testing.T) {
+		t.Setenv("KDN_AUTOCOMPLETE_IGNORE_IDS", "1")
+
+		storageDir, id1, name1, id2, name2 := setup(t)
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeWorkspaceID(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 2 {
+			t.Errorf("Expected 2 completions (names only), got %d: %v", len(completions), completions)
+		}
+		set := make(map[string]bool)
+		for _, c := range completions {
+			set[c] = true
+		}
+		for _, name := range []string{name1, name2} {
+			if !set[name] {
+				t.Errorf("Expected name %q in completions, got %v", name, completions)
+			}
+		}
+		for _, id := range []string{id1, id2} {
+			if set[id] {
+				t.Errorf("Did not expect ID %q in completions when KDN_AUTOCOMPLETE_IGNORE_IDS=1", id)
+			}
+		}
+	})
+}
+
+func TestCompleteDashboardWorkspaceIDIgnoreIDs(t *testing.T) {
+	// Cannot use t.Parallel() on the parent because subtests use t.Setenv.
+
+	ctx := context.Background()
+
+	t.Run("returns ID and name when KDN_AUTOCOMPLETE_IGNORE_IDS is not set", func(t *testing.T) {
+		t.Setenv("KDN_AUTOCOMPLETE_IGNORE_IDS", "")
+
+		storageDir := t.TempDir()
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+		src := t.TempDir()
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: src,
+			ConfigDir: filepath.Join(src, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance: %v", err)
+		}
+		added, err := manager.Add(ctx, instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance: %v", err)
+		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("failed to start instance: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return []string{"fake"}, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 2 {
+			t.Errorf("Expected 2 completions (ID and name), got %d: %v", len(completions), completions)
+		}
+		set := make(map[string]bool)
+		for _, c := range completions {
+			set[c] = true
+		}
+		if !set[added.GetID()] {
+			t.Errorf("Expected ID %q in completions, got %v", added.GetID(), completions)
+		}
+		if !set[added.GetName()] {
+			t.Errorf("Expected name %q in completions, got %v", added.GetName(), completions)
+		}
+	})
+
+	t.Run("returns only name when KDN_AUTOCOMPLETE_IGNORE_IDS is truthy", func(t *testing.T) {
+		t.Setenv("KDN_AUTOCOMPLETE_IGNORE_IDS", "true")
+
+		storageDir := t.TempDir()
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+		src := t.TempDir()
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: src,
+			ConfigDir: filepath.Join(src, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance: %v", err)
+		}
+		added, err := manager.Add(ctx, instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance: %v", err)
+		}
+		if err := manager.Start(ctx, added.GetID()); err != nil {
+			t.Fatalf("failed to start instance: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return []string{"fake"}, nil
+		})
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("Expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 1 {
+			t.Errorf("Expected 1 completion (name only), got %d: %v", len(completions), completions)
+		}
+		if len(completions) > 0 && completions[0] != added.GetName() {
+			t.Errorf("Expected name %q, got %q", added.GetName(), completions[0])
+		}
+		for _, c := range completions {
+			if c == added.GetID() {
+				t.Errorf("Did not expect ID %q in completions when KDN_AUTOCOMPLETE_IGNORE_IDS=true", added.GetID())
+			}
+		}
+	})
+}
+
 func TestCompleteRuntimeFlag(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -28,6 +28,7 @@ import (
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/agentsetup"
 	"github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/envvars"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
@@ -131,14 +132,7 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 
 	// Determine start behavior: if flag is not set to true, check environment variable
 	if !i.start {
-		// Check environment variable
-		if envStart := os.Getenv("KDN_INIT_AUTO_START"); envStart != "" {
-			// Accept "1", "true", "yes" as truthy values (case-insensitive)
-			switch envStart {
-			case "1", "true", "True", "TRUE", "yes", "Yes", "YES":
-				i.start = true
-			}
-		}
+		i.start = envvars.IsTruthy("KDN_INIT_AUTO_START")
 	}
 
 	// Get sources directory (default to current directory)

--- a/pkg/envvars/envvars.go
+++ b/pkg/envvars/envvars.go
@@ -1,0 +1,31 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package envvars
+
+import "os"
+
+// IsTruthy returns true if the environment variable named by key is set to a recognised truthy string
+// ("1", "true", "yes" in any case).
+func IsTruthy(key string) bool {
+	switch os.Getenv(key) {
+	case "1", "true", "True", "TRUE", "yes", "Yes", "YES":
+		return true
+	}
+	return false
+}

--- a/pkg/envvars/envvars_test.go
+++ b/pkg/envvars/envvars_test.go
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package envvars_test
+
+import (
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/envvars"
+)
+
+func TestIsTruthy(t *testing.T) {
+	// Cannot use t.Parallel() on the parent because subtests use t.Setenv.
+
+	const key = "TEST_ISTRUTHY_ENV"
+
+	truthy := []string{"1", "true", "True", "TRUE", "yes", "Yes", "YES"}
+	for _, v := range truthy {
+		t.Run("truthy_"+v, func(t *testing.T) {
+			t.Setenv(key, v)
+			if !envvars.IsTruthy(key) {
+				t.Errorf("expected IsTruthy(%q) to be true when %s=%q", key, key, v)
+			}
+		})
+	}
+
+	falsy := []string{"0", "false", "no", "", "random"}
+	for _, v := range falsy {
+		t.Run("falsy_"+v, func(t *testing.T) {
+			t.Setenv(key, v)
+			if envvars.IsTruthy(key) {
+				t.Errorf("expected IsTruthy(%q) to be false when %s=%q", key, key, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Adds the KDN_AUTOCOMPLETE_IGNORE_IDS environment variable. When set to a truthy value (1, true, yes), shell completion for workspace IDs returns only workspace names, suppressing the hex IDs. This is useful when names are unique and long IDs clutter tab-completion.
- Extracts the truthy-env-var check into a new pkg/envvars package (IsTruthy(key string) bool), replacing duplicate inline switch statements in autocomplete.go and init.go.

Fixes #356 