### PR TITLE
test(cmd): add integration test for workspace with secrets

### DIFF
--- a/pkg/cmd/integration_test.go
+++ b/pkg/cmd/integration_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
+	gokeyring "github.com/zalando/go-keyring"
 )
 
 // initMu serializes "kdn init" calls so that only one podman build runs at a
@@ -46,6 +47,9 @@ const containerSourcesPath = "/workspace/sources"
 var warmupImages []string
 
 func TestMain(m *testing.M) {
+	// Use an in-memory keyring so integration tests never touch the real system
+	// keychain, which may not be available in CI environments.
+	gokeyring.MockInit()
 	if podmanAvailable() {
 		warmupBuildCache()
 	}
@@ -878,4 +882,52 @@ func TestIntegration_MultipleWorkspacesIsolated(t *testing.T) {
 	// Stop both
 	integrationExecCmd(t, "--storage", storageDir, "stop", wsID1, "--output", "json")
 	integrationExecCmd(t, "--storage", storageDir, "stop", wsID2, "--output", "json")
+}
+
+func TestIntegration_WorkspaceWithSecret(t *testing.T) {
+	skipIfNoPodman(t)
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	sourcesDir := t.TempDir()
+
+	// Create a secret using kdn secret create. Both the secret command and the
+	// workspace manager use the same storageDir, so the metadata file and the
+	// in-memory mock keyring are shared across all commands in this test.
+	integrationExecCmd(t,
+		"--storage", storageDir,
+		"secret", "create", "integration-test-token",
+		"--type", "other",
+		"--value", "supersecretvalue",
+		"--host", "api.example.com",
+		"--header", "Authorization",
+		"--output", "json",
+	)
+
+	// Create workspace configuration that references the secret.
+	configDir := filepath.Join(sourcesDir, ".kaiden")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("Failed to create config dir: %v", err)
+	}
+	workspaceJSON := `{"secrets": ["integration-test-token"]}`
+	if err := os.WriteFile(filepath.Join(configDir, "workspace.json"), []byte(workspaceJSON), 0644); err != nil {
+		t.Fatalf("Failed to write workspace.json: %v", err)
+	}
+
+	// Create the workspace; this reads the secret from the store and sets up the
+	// onecli proxy so the secret can be injected at runtime.
+	_, wsID := integrationInit(t, storageDir, sourcesDir, "workspace-with-secret", "claude")
+
+	// Start the workspace and verify it reaches the running state.
+	integrationExecCmd(t, "--storage", storageDir, "start", wsID, "--output", "json")
+
+	listResult := integrationListWorkspaces(t, storageDir)
+	if len(listResult.Items) != 1 {
+		t.Fatalf("Expected 1 workspace, got %d", len(listResult.Items))
+	}
+	if listResult.Items[0].State != "running" {
+		t.Errorf("Expected state 'running', got %q", listResult.Items[0].State)
+	}
+
+	integrationExecCmd(t, "--storage", storageDir, "stop", wsID, "--output", "json")
 }

--- a/pkg/runtime/podman/config/defaults.go
+++ b/pkg/runtime/podman/config/defaults.go
@@ -62,8 +62,6 @@ func defaultImageConfig() *ImageConfig {
 			"/bin/kill",
 			"/usr/bin/kill",
 			"/usr/bin/killall",
-			"/usr/bin/cp",
-			"/usr/bin/update-ca-trust",
 		},
 		RunCommands: []string{},
 	}

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -101,12 +101,12 @@ const caTrustAnchorPath = "/etc/pki/ca-trust/source/anchors/onecli-ca.pem"
 func (p *podmanRuntime) installCACert(ctx context.Context, containerID, caContainerPath string) error {
 	l := logger.FromContext(ctx)
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(),
-		"exec", containerID, "sudo", "cp", caContainerPath, caTrustAnchorPath,
+		"exec", "--user", "root", containerID, "cp", caContainerPath, caTrustAnchorPath,
 	); err != nil {
 		return fmt.Errorf("failed to copy CA certificate: %w", err)
 	}
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(),
-		"exec", containerID, "sudo", "update-ca-trust",
+		"exec", "--user", "root", containerID, "update-ca-trust",
 	); err != nil {
 		return fmt.Errorf("update-ca-trust failed: %w", err)
 	}


### PR DESCRIPTION
- Tests that a workspace referencing a secret created with `kdn secret create` can be initialised and started correctly. Uses gokeyring.MockInit() in TestMain so all integration tests run against an in-memory keychain instead of the real system keychain, making them CI-safe.
- To fix the problem below visible with the new integration test, copy the certificate using `podman exec --user root` instead of using `sudo cp` in the container. Also remove `cp` and `update-ca-trust` to the list of executables authorized with `sudo` 

``` 
=== FAIL: pkg/cmd TestIntegration_WorkspaceWithSecret (9.39s)
    integration_test.go:922: command [--storage /tmp/TestIntegration_WorkspaceWithSecret2266461451/001 start e4cfb007043ccde018c43dba1872fbdcf9a3e71a4a196aa8e5b39f5a6d92cfd0 --output json] failed: failed to start runtime instance: failed to install CA certificate: failed to copy CA certificate: exit status 1
        Podman stderr:
        sudo: PAM account management error: Authentication service cannot retrieve authentication info
        sudo: a password is required
        Stderr: 
```
