### PR TITLE
fix(podman): stop containers individually to fix NOP on partial stop

### DIFF
--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -17,6 +17,7 @@ package podman
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -38,12 +39,25 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to resolve pod name: %w", err)
 	}
 
-	// Stop the entire pod (all containers at once)
-	stepLogger.Start(fmt.Sprintf("Stopping pod: %s", podName), "Pod stopped")
 	l := logger.FromContext(ctx)
-	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "stop", podName); err != nil {
-		stepLogger.Fail(err)
-		return fmt.Errorf("failed to stop pod: %w", err)
+
+	// Query container names dynamically so the list stays correct if the pod
+	// definition gains or loses containers in the future.
+	// `podman pod stop` is a NOP when any container is already stopped/exited,
+	// so we stop each container individually instead.
+	output, err := p.executor.Output(ctx, l.Stderr(),
+		"pod", "inspect", "--format", "{{range .Containers}}{{.Name}}\n{{end}}", podName)
+	if err != nil {
+		return fmt.Errorf("failed to inspect pod %s: %w", podName, err)
+	}
+	containerNames := strings.Fields(string(output))
+
+	stepLogger.Start(fmt.Sprintf("Stopping pod: %s", podName), "Pod stopped")
+	for _, c := range containerNames {
+		if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "stop", c); err != nil {
+			stepLogger.Fail(err)
+			return fmt.Errorf("failed to stop container %s: %w", c, err)
+		}
 	}
 
 	return nil

--- a/pkg/runtime/podman/stop_test.go
+++ b/pkg/runtime/podman/stop_test.go
@@ -25,6 +25,12 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
+// podInspectOutput returns a fake `podman pod inspect` output listing the
+// three containers that kdn pods always contain.
+func podInspectOutput(podName string) []byte {
+	return []byte(fmt.Sprintf("%s\n%s-onecli\n%s-postgres\n", podName, podName, podName))
+}
+
 func TestStop_ValidatesID(t *testing.T) {
 	t.Parallel()
 
@@ -53,22 +59,38 @@ func TestStop_Success(t *testing.T) {
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 	podName := setupPodFiles(t, p, containerID, "my-project")
 
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return podInspectOutput(podName), nil
+	}
+
 	err := p.Stop(context.Background(), containerID)
 	if err != nil {
 		t.Fatalf("Stop() failed: %v", err)
 	}
 
-	fakeExec.AssertRunCalledWith(t, "pod", "stop", podName)
+	// Verify pod inspect was called to discover containers dynamically.
+	fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{range .Containers}}{{.Name}}\n{{end}}", podName)
+
+	// Verify each container was stopped individually (not via pod stop).
+	fakeExec.AssertRunCalledWith(t, "stop", podName)
+	fakeExec.AssertRunCalledWith(t, "stop", podName+"-onecli")
+	fakeExec.AssertRunCalledWith(t, "stop", podName+"-postgres")
+
+	for _, call := range fakeExec.RunCalls {
+		if len(call) >= 2 && call[0] == "pod" && call[1] == "stop" {
+			t.Errorf("Expected podman pod stop NOT to be called, but it was called with: %v", call)
+		}
+	}
 }
 
-func TestStop_PodStopFailure(t *testing.T) {
+func TestStop_PodInspectFailure(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("pod not found")
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("pod not found")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -76,10 +98,37 @@ func TestStop_PodStopFailure(t *testing.T) {
 
 	err := p.Stop(context.Background(), containerID)
 	if err == nil {
-		t.Fatal("Expected error when pod stop fails, got nil")
+		t.Fatal("Expected error when pod inspect fails, got nil")
 	}
 
-	fakeExec.AssertRunCalledWith(t, "pod", "stop", podName)
+	fakeExec.AssertOutputCalledWith(t, "pod", "inspect", "--format", "{{range .Containers}}{{.Name}}\n{{end}}", podName)
+
+	if len(fakeExec.RunCalls) != 0 {
+		t.Errorf("Expected no Run calls when inspect fails, got: %v", fakeExec.RunCalls)
+	}
+}
+
+func TestStop_ContainerStopFailure(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "test-ws")
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return podInspectOutput(podName), nil
+	}
+
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return fmt.Errorf("container stop failed")
+	}
+
+	err := p.Stop(context.Background(), containerID)
+	if err == nil {
+		t.Fatal("Expected error when container stop fails, got nil")
+	}
 }
 
 func TestStop_StepLogger_Success(t *testing.T) {
@@ -90,6 +139,10 @@ func TestStop_StepLogger_Success(t *testing.T) {
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 	podName := setupPodFiles(t, p, containerID, "test-ws")
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return podInspectOutput(podName), nil
+	}
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)
@@ -129,18 +182,22 @@ func TestStop_StepLogger_Success(t *testing.T) {
 	}
 }
 
-func TestStop_StepLogger_FailOnPodStop(t *testing.T) {
+func TestStop_StepLogger_FailOnContainerStop(t *testing.T) {
 	t.Parallel()
 
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
-		return fmt.Errorf("pod not found")
-	}
-
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 	podName := setupPodFiles(t, p, containerID, "test-ws")
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return podInspectOutput(podName), nil
+	}
+
+	fakeExec.RunFunc = func(ctx context.Context, args ...string) error {
+		return fmt.Errorf("container not found")
+	}
 
 	fakeLogger := &fakeStepLogger{}
 	ctx := steplogger.WithLogger(context.Background(), fakeLogger)


### PR DESCRIPTION
`podman pod stop` is a no-op when any container in the pod is already stopped or exited. Fix this by inspecting the pod at runtime to get the container list, then stopping each container individually. `podman stop` is idempotent on already-stopped containers, so this works correctly in all mixed-state scenarios.

Fixes #362