### PR TITLE
feat(network): allow secrets hosts when network is denied

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 
 ### Podman Runtime — Deny-mode Networking
 
-When a workspace has `network.mode = deny` with at least one allowed host (from `network.hosts` or automatically derived from configured secrets), the Podman runtime enforces outbound traffic filtering on every `Start()` using two layers:
+When a workspace has `network.mode = deny`, the Podman runtime enforces outbound traffic filtering on every `Start()` using two layers. Allowed hosts come from `network.hosts` and are automatically augmented by host patterns derived from configured secrets. With no allowed hosts at all, the approval-handler denies every request (fully-isolated workspace).
 
 1. **nftables firewall (kernel level)**: A `network-guard` sidecar with `CAP_NET_ADMIN` runs nftables rules that DROP outbound traffic from the agent's UID. Loopback and `host.containers.internal` are always allowed. This prevents bypassing the proxy by unsetting `HTTP_PROXY`.
 2. **OneCLI proxy (application level)**: All existing OneCLI rules are deleted, a single `manual_approval` rule for `*` is created (**`"allow"` is not a valid OneCLI action**), and the `approval-handler` sidecar approves/denies intercepted requests by hostname pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,13 +180,15 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 
 ### Podman Runtime — Deny-mode Networking
 
-When a workspace has `network.mode = deny` with at least one host in `network.hosts`, the Podman runtime enforces outbound traffic filtering on every `Start()` using two layers:
+When a workspace has `network.mode = deny` with at least one allowed host (from `network.hosts` or automatically derived from configured secrets), the Podman runtime enforces outbound traffic filtering on every `Start()` using two layers:
 
 1. **nftables firewall (kernel level)**: A `network-guard` sidecar with `CAP_NET_ADMIN` runs nftables rules that DROP outbound traffic from the agent's UID. Loopback and `host.containers.internal` are always allowed. This prevents bypassing the proxy by unsetting `HTTP_PROXY`.
 2. **OneCLI proxy (application level)**: All existing OneCLI rules are deleted, a single `manual_approval` rule for `*` is created (**`"allow"` is not a valid OneCLI action**), and the `approval-handler` sidecar approves/denies intercepted requests by hostname pattern.
 
+**Secret host auto-injection:** When secrets are configured, `collectSecretHosts()` (in `network.go`) reads their host patterns from the secret service registry (known types) or stored metadata (`other` type) and merges them with the explicit `network.hosts` list. The `podmanRuntime` receives the `secretservice.Registry` via `SetSecretServiceRegistry()`, called by `manager.RegisterRuntime()` for runtimes that implement the `secretServiceRegistryAware` interface.
+
 **Key files:**
-- `pkg/runtime/podman/network.go` — `configureNetworking` / `clearNetworkingRules` / `setupFirewallRules` / `clearFirewallRules` / `buildNftScript`
+- `pkg/runtime/podman/network.go` — `configureNetworking` / `clearNetworkingRules` / `setupFirewallRules` / `clearFirewallRules` / `buildNftScript` / `collectSecretHosts` / `mergeHosts`
 - `pkg/runtime/podman/pods/approval-handler.ts` — Node.js sidecar (TypeScript, runs via `tsx`)
 - `pkg/runtime/podman/pods/onecli-pod.yaml` — pod manifest with the approval-handler, network-guard, and OneCLI containers
 - `pkg/runtime/podman/system/path.go` / `path_windows.go` — `HostPathToMachinePath` / `MachinePathToHostPath` for translating host paths to Podman Machine (WSL2) paths on Windows; no-ops on Linux/macOS

--- a/README.md
+++ b/README.md
@@ -1796,6 +1796,8 @@ Control network access for the workspace. By default, network access is denied (
   - Only meaningful when mode is `"deny"`
   - Each entry must be a non-empty string
 
+**Automatic secret host injection:** When `mode` is `"deny"` and secrets are configured, kdn automatically adds the hosts associated with those secrets to the allowed list. You do not need to list them explicitly under `hosts`. For example, a `github` secret automatically allows `api.github.com` without any `hosts` entry.
+
 **Validation Rules:**
 - If `mode` is set, it must be either `"allow"` or `"deny"`
 - If `mode` is `"allow"`, `hosts` must not be set (they are meaningless in allow mode)
@@ -1804,6 +1806,8 @@ Control network access for the workspace. By default, network access is denied (
 ### Secrets
 
 Configure secrets to inject into the workspace. Each entry is the name of a secret previously created with `kdn secret create`. At workspace creation time, kdn looks up the secret value from the system keychain and provisions it into the workspace via OneCLI, which injects it as an HTTP header into matching outbound requests. This is distinct from the `secret` field in environment variables, which references runtime secrets by name for environment variable injection.
+
+When `network.mode` is `"deny"`, the hosts associated with each secret are automatically added to the allowed list — you do not need to duplicate them under `network.hosts`.
 
 **Structure:**
 ```json
@@ -1983,6 +1987,18 @@ mount at index 0 is missing host
 }
 ```
 
+**Network access - deny with secrets (hosts inferred automatically):**
+```json
+{
+  "network": {
+    "mode": "deny"
+  },
+  "secrets": ["my-github-token"]
+}
+```
+
+The `my-github-token` secret (type `github`) automatically allows `api.github.com` without any `hosts` entry.
+
 **Secrets:**
 ```json
 {
@@ -2024,12 +2040,13 @@ mount at index 0 is missing host
     ]
   },
   "network": {
-    "mode": "deny",
-    "hosts": ["api.github.com"]
+    "mode": "deny"
   },
   "secrets": ["my-github-token"]
 }
 ```
+
+The `my-github-token` secret (type `github`) automatically allows `api.github.com`, so no explicit `hosts` entry is needed.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -1791,10 +1791,11 @@ Control network access for the workspace. By default, network access is denied (
 **Fields:**
 - `mode` (optional) - Network access mode
   - `"allow"` - Permits all network access (no restrictions)
-  - `"deny"` - Blocks all network access except the specified hosts (default)
+  - `"deny"` - Blocks all outbound network access from the workspace agent, except for the hosts listed in `hosts` and the hosts associated with configured secrets
 - `hosts` (optional) - List of hostnames to allow when in deny mode
   - Only meaningful when mode is `"deny"`
   - Each entry must be a non-empty string
+  - Omitting `hosts` (or leaving it empty) is valid: the workspace is fully isolated, with no outbound access permitted unless secrets contribute hosts
 
 **Automatic secret host injection:** When `mode` is `"deny"` and secrets are configured, kdn automatically adds the hosts associated with those secrets to the allowed list. You do not need to list them explicitly under `hosts`. For example, a `github` secret automatically allows `api.github.com` without any `hosts` entry.
 
@@ -1983,6 +1984,15 @@ mount at index 0 is missing host
   "network": {
     "mode": "deny",
     "hosts": ["api.github.com", "registry.npmjs.org"]
+  }
+}
+```
+
+**Network access - fully isolated (deny, no hosts):**
+```json
+{
+  "network": {
+    "mode": "deny"
   }
 }
 ```

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -752,18 +752,12 @@ func (m *manager) GetDashboardURL(ctx context.Context, nameOrID string) (string,
 	return dashboardRuntime.GetURL(ctx, runtimeData.InstanceID)
 }
 
-// secretServiceRegistryAware is an optional interface for runtimes that need the
-// secret service registry to resolve host patterns for networking decisions.
-type secretServiceRegistryAware interface {
-	SetSecretServiceRegistry(secretservice.Registry)
-}
-
 // RegisterRuntime registers a runtime with the manager's registry.
 func (m *manager) RegisterRuntime(rt runtime.Runtime) error {
 	if err := m.runtimeRegistry.Register(rt); err != nil {
 		return err
 	}
-	if aware, ok := rt.(secretServiceRegistryAware); ok {
+	if aware, ok := rt.(runtime.SecretServiceRegistryAware); ok {
 		aware.SetSecretServiceRegistry(m.secretServiceRegistry)
 	}
 	return nil

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -752,9 +752,21 @@ func (m *manager) GetDashboardURL(ctx context.Context, nameOrID string) (string,
 	return dashboardRuntime.GetURL(ctx, runtimeData.InstanceID)
 }
 
+// secretServiceRegistryAware is an optional interface for runtimes that need the
+// secret service registry to resolve host patterns for networking decisions.
+type secretServiceRegistryAware interface {
+	SetSecretServiceRegistry(secretservice.Registry)
+}
+
 // RegisterRuntime registers a runtime with the manager's registry.
 func (m *manager) RegisterRuntime(rt runtime.Runtime) error {
-	return m.runtimeRegistry.Register(rt)
+	if err := m.runtimeRegistry.Register(rt); err != nil {
+		return err
+	}
+	if aware, ok := rt.(secretServiceRegistryAware); ok {
+		aware.SetSecretServiceRegistry(m.secretServiceRegistry)
+	}
+	return nil
 }
 
 // RegisterAgent registers an agent with the manager's registry.

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -40,7 +40,7 @@ const defaultOnecliVersion = "1.17"
 
 // podTemplateData holds the values used to render the pod YAML template
 // and is also persisted as per-pod metadata (pod-template-data.json) so
-// that Start() can recover SourcePath, ProjectID and ApprovalHandlerDir
+// that Start() can recover SourcePath, ProjectID, Agent and ApprovalHandlerDir
 // without re-reading the original CreateParams.
 type podTemplateData struct {
 	Name               string
@@ -51,6 +51,7 @@ type podTemplateData struct {
 	BaseImageVersion   string
 	SourcePath         string
 	ProjectID          string
+	Agent              string
 	ApprovalHandlerDir string
 }
 
@@ -416,6 +417,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		BaseImageVersion:   imageConfig.Version,
 		SourcePath:         params.SourcePath,
 		ProjectID:          params.ProjectID,
+		Agent:              params.Agent,
 		ApprovalHandlerDir: podmanSystem.HostPathToMachinePath(approvalHandlerDir),
 	}
 

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -31,11 +31,11 @@ import (
 )
 
 // loadNetworkConfig reads the merged workspace configuration for a project by
-// combining the workspace-level config (.kaiden/workspace.json) with the
-// project-level config from projects.json. It mirrors the merge logic used
-// at workspace creation time so that edits to projects.json are picked up on
+// combining workspace-level, project-level, and agent-level configs. It mirrors
+// the merge logic used at workspace creation time so that edits take effect on
 // the next Start() without recreating the workspace.
-func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.WorkspaceConfiguration, error) {
+// Precedence (highest to lowest): agent > project > workspace.
+func loadNetworkConfig(sourcePath, storageDir, projectID, agentName string) (*workspace.WorkspaceConfiguration, error) {
 	merger := config.NewMerger()
 
 	var merged *workspace.WorkspaceConfiguration
@@ -56,6 +56,16 @@ func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.Wor
 		merged = merger.Merge(merged, pc)
 	}
 
+	if agentName != "" {
+		agentLoader, err := config.NewAgentConfigLoader(storageDir)
+		if err != nil {
+			return nil, fmt.Errorf("initializing agent config loader: %w", err)
+		}
+		if ac, loadErr := agentLoader.Load(agentName); loadErr == nil {
+			merged = merger.Merge(merged, ac)
+		}
+	}
+
 	return merged, nil
 }
 
@@ -63,17 +73,17 @@ func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.Wor
 // listed in wsCfg. For known secret types, patterns come from the secret
 // service registry; for "other" secrets, they come from the stored metadata.
 // Returns nil when any required input is nil or when no secrets are configured.
-func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.Store, registry secretservice.Registry) []string {
+func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.Store, registry secretservice.Registry) ([]string, error) {
 	if wsCfg == nil || wsCfg.Secrets == nil || len(*wsCfg.Secrets) == 0 {
-		return nil
+		return nil, nil
 	}
 	if store == nil || registry == nil {
-		return nil
+		return nil, nil
 	}
 
 	items, err := store.List()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("listing secrets: %w", err)
 	}
 
 	byName := make(map[string]secret.ListItem, len(items))
@@ -105,7 +115,7 @@ func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.St
 			}
 		}
 	}
-	return hosts
+	return hosts, nil
 }
 
 // mergeHosts returns a deduplicated list of all hosts from a and b,

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -26,6 +26,8 @@ import (
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/config"
 	"github.com/openkaiden/kdn/pkg/onecli"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
 // loadNetworkConfig reads the merged workspace configuration for a project by
@@ -55,6 +57,78 @@ func loadNetworkConfig(sourcePath, storageDir, projectID string) (*workspace.Wor
 	}
 
 	return merged, nil
+}
+
+// collectSecretHosts returns the host patterns contributed by the secrets
+// listed in wsCfg. For known secret types, patterns come from the secret
+// service registry; for "other" secrets, they come from the stored metadata.
+// Returns nil when any required input is nil or when no secrets are configured.
+func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.Store, registry secretservice.Registry) []string {
+	if wsCfg == nil || wsCfg.Secrets == nil || len(*wsCfg.Secrets) == 0 {
+		return nil
+	}
+	if store == nil || registry == nil {
+		return nil
+	}
+
+	items, err := store.List()
+	if err != nil {
+		return nil
+	}
+
+	byName := make(map[string]secret.ListItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	seen := make(map[string]bool)
+	var hosts []string
+	for _, name := range *wsCfg.Secrets {
+		item, ok := byName[name]
+		if !ok {
+			continue
+		}
+		var itemHosts []string
+		if item.Type == secret.TypeOther {
+			itemHosts = item.Hosts
+		} else {
+			svc, svcErr := registry.Get(item.Type)
+			if svcErr != nil {
+				continue
+			}
+			itemHosts = svc.HostsPatterns()
+		}
+		for _, h := range itemHosts {
+			if !seen[h] {
+				seen[h] = true
+				hosts = append(hosts, h)
+			}
+		}
+	}
+	return hosts
+}
+
+// mergeHosts returns a deduplicated list of all hosts from a and b,
+// preserving order (a first, then new entries from b).
+func mergeHosts(a, b []string) []string {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	result := make([]string, 0, len(a)+len(b))
+	for _, h := range a {
+		if !seen[h] {
+			seen[h] = true
+			result = append(result, h)
+		}
+	}
+	for _, h := range b {
+		if !seen[h] {
+			seen[h] = true
+			result = append(result, h)
+		}
+	}
+	return result
 }
 
 // approvalHandlerConfig is serialized to config.json in the approval-handler

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -545,10 +545,13 @@ func makeSecretService(name string, patterns []string) secretservice.SecretServi
 	return secretservice.NewSecretService(name, patterns, "", nil, "", "")
 }
 
-func makeRegistry(services ...secretservice.SecretService) secretservice.Registry {
+func makeRegistry(t *testing.T, services ...secretservice.SecretService) secretservice.Registry {
+	t.Helper()
 	reg := secretservice.NewRegistry()
 	for _, svc := range services {
-		_ = reg.Register(svc)
+		if err := reg.Register(svc); err != nil {
+			t.Fatalf("makeRegistry: failed to register %q: %v", svc.Name(), err)
+		}
 	}
 	return reg
 }
@@ -557,9 +560,7 @@ func denyConfig(secrets []string) *workspace.WorkspaceConfiguration {
 	mode := workspace.Deny
 	cfg := &workspace.WorkspaceConfiguration{
 		Network: &workspace.NetworkConfiguration{Mode: &mode},
-	}
-	if len(secrets) > 0 {
-		cfg.Secrets = &secrets
+		Secrets: &secrets,
 	}
 	return cfg
 }
@@ -569,7 +570,11 @@ func TestCollectSecretHosts(t *testing.T) {
 
 	t.Run("nil config returns nil", func(t *testing.T) {
 		t.Parallel()
-		if got := collectSecretHosts(nil, &fakeSecretStore{}, makeRegistry()); got != nil {
+		got, err := collectSecretHosts(nil, &fakeSecretStore{}, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -577,7 +582,11 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("nil secrets field returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := &workspace.WorkspaceConfiguration{}
-		if got := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry()); got != nil {
+		got, err := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -585,7 +594,11 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("empty secrets list returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := denyConfig([]string{})
-		if got := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry()); got != nil {
+		got, err := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -593,7 +606,11 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("nil store returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := denyConfig([]string{"mysecret"})
-		if got := collectSecretHosts(cfg, nil, makeRegistry()); got != nil {
+		got, err := collectSecretHosts(cfg, nil, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -601,7 +618,11 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("nil registry returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := denyConfig([]string{"mysecret"})
-		if got := collectSecretHosts(cfg, &fakeSecretStore{}, nil); got != nil {
+		got, err := collectSecretHosts(cfg, &fakeSecretStore{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -609,8 +630,11 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("known type secret returns service host patterns", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{items: []secret.ListItem{{Name: "mygithub", Type: "github"}}}
-		reg := makeRegistry(makeSecretService("github", []string{"api.github.com"}))
-		got := collectSecretHosts(denyConfig([]string{"mygithub"}), store, reg)
+		reg := makeRegistry(t, makeSecretService("github", []string{"api.github.com"}))
+		got, err := collectSecretHosts(denyConfig([]string{"mygithub"}), store, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if len(got) != 1 || got[0] != "api.github.com" {
 			t.Errorf("got %v, want [api.github.com]", got)
 		}
@@ -623,7 +647,10 @@ func TestCollectSecretHosts(t *testing.T) {
 				{Name: "mykey", Type: secret.TypeOther, Hosts: []string{"api.example.com", "api2.example.com"}},
 			},
 		}
-		got := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry())
+		got, err := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if len(got) != 2 || got[0] != "api.example.com" || got[1] != "api2.example.com" {
 			t.Errorf("got %v, want [api.example.com api2.example.com]", got)
 		}
@@ -637,8 +664,11 @@ func TestCollectSecretHosts(t *testing.T) {
 				{Name: "gh2", Type: "github"},
 			},
 		}
-		reg := makeRegistry(makeSecretService("github", []string{"api.github.com"}))
-		got := collectSecretHosts(denyConfig([]string{"gh1", "gh2"}), store, reg)
+		reg := makeRegistry(t, makeSecretService("github", []string{"api.github.com"}))
+		got, err := collectSecretHosts(denyConfig([]string{"gh1", "gh2"}), store, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if len(got) != 1 || got[0] != "api.github.com" {
 			t.Errorf("got %v, want [api.github.com] (deduplicated)", got)
 		}
@@ -652,8 +682,11 @@ func TestCollectSecretHosts(t *testing.T) {
 				{Name: "myother", Type: secret.TypeOther, Hosts: []string{"custom.example.com"}},
 			},
 		}
-		reg := makeRegistry(makeSecretService("github", []string{"api.github.com"}))
-		got := collectSecretHosts(denyConfig([]string{"mygithub", "myother"}), store, reg)
+		reg := makeRegistry(t, makeSecretService("github", []string{"api.github.com"}))
+		got, err := collectSecretHosts(denyConfig([]string{"mygithub", "myother"}), store, reg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		want := []string{"api.github.com", "custom.example.com"}
 		if len(got) != len(want) {
 			t.Fatalf("got %v, want %v", got, want)
@@ -668,7 +701,11 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("skips secrets not found in store", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{items: []secret.ListItem{}}
-		if got := collectSecretHosts(denyConfig([]string{"missing"}), store, makeRegistry()); got != nil {
+		got, err := collectSecretHosts(denyConfig([]string{"missing"}), store, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -676,16 +713,21 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("skips secrets with type not in registry", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{items: []secret.ListItem{{Name: "mykey", Type: "unknown-type"}}}
-		if got := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry()); got != nil {
+		got, err := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
 
-	t.Run("store list error returns nil", func(t *testing.T) {
+	t.Run("store list error returns error", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{err: errors.New("disk error")}
-		if got := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry()); got != nil {
-			t.Errorf("got %v, want nil on store error", got)
+		_, err := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry(t))
+		if err == nil {
+			t.Error("expected error from store.List(), got nil")
 		}
 	})
 }

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -17,6 +17,7 @@ package podman
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -25,8 +26,11 @@ import (
 	"strings"
 	"testing"
 
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
 func assertAuth(t *testing.T, r *http.Request) {
@@ -518,6 +522,205 @@ func TestClearFirewallRules(t *testing.T) {
 		err := rt.clearFirewallRules(context.Background(), "my-pod")
 		if err == nil {
 			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+// fakeSecretStore implements secret.Store using a pre-populated list.
+type fakeSecretStore struct {
+	items []secret.ListItem
+	err   error
+}
+
+var _ secret.Store = (*fakeSecretStore)(nil)
+
+func (f *fakeSecretStore) List() ([]secret.ListItem, error) { return f.items, f.err }
+func (f *fakeSecretStore) Get(string) (secret.ListItem, string, error) {
+	return secret.ListItem{}, "", nil
+}
+func (f *fakeSecretStore) Create(secret.CreateParams) error { return nil }
+func (f *fakeSecretStore) Remove(string) error              { return nil }
+
+func makeSecretService(name string, patterns []string) secretservice.SecretService {
+	return secretservice.NewSecretService(name, patterns, "", nil, "", "")
+}
+
+func makeRegistry(services ...secretservice.SecretService) secretservice.Registry {
+	reg := secretservice.NewRegistry()
+	for _, svc := range services {
+		_ = reg.Register(svc)
+	}
+	return reg
+}
+
+func denyConfig(secrets []string) *workspace.WorkspaceConfiguration {
+	mode := workspace.Deny
+	cfg := &workspace.WorkspaceConfiguration{
+		Network: &workspace.NetworkConfiguration{Mode: &mode},
+	}
+	if len(secrets) > 0 {
+		cfg.Secrets = &secrets
+	}
+	return cfg
+}
+
+func TestCollectSecretHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := collectSecretHosts(nil, &fakeSecretStore{}, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("nil secrets field returns nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := &workspace.WorkspaceConfiguration{}
+		if got := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("empty secrets list returns nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := denyConfig([]string{})
+		if got := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("nil store returns nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := denyConfig([]string{"mysecret"})
+		if got := collectSecretHosts(cfg, nil, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("nil registry returns nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := denyConfig([]string{"mysecret"})
+		if got := collectSecretHosts(cfg, &fakeSecretStore{}, nil); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("known type secret returns service host patterns", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{items: []secret.ListItem{{Name: "mygithub", Type: "github"}}}
+		reg := makeRegistry(makeSecretService("github", []string{"api.github.com"}))
+		got := collectSecretHosts(denyConfig([]string{"mygithub"}), store, reg)
+		if len(got) != 1 || got[0] != "api.github.com" {
+			t.Errorf("got %v, want [api.github.com]", got)
+		}
+	})
+
+	t.Run("other type secret returns item hosts", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{
+			items: []secret.ListItem{
+				{Name: "mykey", Type: secret.TypeOther, Hosts: []string{"api.example.com", "api2.example.com"}},
+			},
+		}
+		got := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry())
+		if len(got) != 2 || got[0] != "api.example.com" || got[1] != "api2.example.com" {
+			t.Errorf("got %v, want [api.example.com api2.example.com]", got)
+		}
+	})
+
+	t.Run("deduplicates hosts across multiple secrets of the same type", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{
+			items: []secret.ListItem{
+				{Name: "gh1", Type: "github"},
+				{Name: "gh2", Type: "github"},
+			},
+		}
+		reg := makeRegistry(makeSecretService("github", []string{"api.github.com"}))
+		got := collectSecretHosts(denyConfig([]string{"gh1", "gh2"}), store, reg)
+		if len(got) != 1 || got[0] != "api.github.com" {
+			t.Errorf("got %v, want [api.github.com] (deduplicated)", got)
+		}
+	})
+
+	t.Run("mixes known and other type secrets", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{
+			items: []secret.ListItem{
+				{Name: "mygithub", Type: "github"},
+				{Name: "myother", Type: secret.TypeOther, Hosts: []string{"custom.example.com"}},
+			},
+		}
+		reg := makeRegistry(makeSecretService("github", []string{"api.github.com"}))
+		got := collectSecretHosts(denyConfig([]string{"mygithub", "myother"}), store, reg)
+		want := []string{"api.github.com", "custom.example.com"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i, h := range want {
+			if got[i] != h {
+				t.Errorf("got[%d] = %q, want %q", i, got[i], h)
+			}
+		}
+	})
+
+	t.Run("skips secrets not found in store", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{items: []secret.ListItem{}}
+		if got := collectSecretHosts(denyConfig([]string{"missing"}), store, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("skips secrets with type not in registry", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{items: []secret.ListItem{{Name: "mykey", Type: "unknown-type"}}}
+		if got := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("store list error returns nil", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSecretStore{err: errors.New("disk error")}
+		if got := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry()); got != nil {
+			t.Errorf("got %v, want nil on store error", got)
+		}
+	})
+}
+
+func TestMergeHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns a when b is empty", func(t *testing.T) {
+		t.Parallel()
+		a := []string{"a.com", "b.com"}
+		got := mergeHosts(a, nil)
+		if len(got) != 2 || got[0] != "a.com" || got[1] != "b.com" {
+			t.Errorf("got %v, want %v", got, a)
+		}
+	})
+
+	t.Run("deduplicates overlapping entries", func(t *testing.T) {
+		t.Parallel()
+		got := mergeHosts([]string{"a.com", "b.com"}, []string{"b.com", "c.com"})
+		want := []string{"a.com", "b.com", "c.com"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i, h := range want {
+			if got[i] != h {
+				t.Errorf("got[%d] = %q, want %q", i, got[i], h)
+			}
+		}
+	})
+
+	t.Run("preserves order a first then new entries from b", func(t *testing.T) {
+		t.Parallel()
+		got := mergeHosts([]string{"x.com"}, []string{"y.com"})
+		if len(got) != 2 || got[0] != "x.com" || got[1] != "y.com" {
+			t.Errorf("got %v, want [x.com y.com]", got)
 		}
 	})
 }

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -60,6 +60,9 @@ var _ runtime.StorageAware = (*podmanRuntime)(nil)
 // Ensure podmanRuntime implements runtime.AgentLister at compile time.
 var _ runtime.AgentLister = (*podmanRuntime)(nil)
 
+// Ensure podmanRuntime implements runtime.SecretServiceRegistryAware at compile time.
+var _ runtime.SecretServiceRegistryAware = (*podmanRuntime)(nil)
+
 // New creates a new Podman runtime instance.
 func New() runtime.Runtime {
 	return newWithDeps(system.New(), exec.New())

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -26,17 +26,21 @@ import (
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
 	podmanSystem "github.com/openkaiden/kdn/pkg/runtime/podman/system"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
 	"github.com/openkaiden/kdn/pkg/system"
 )
 
 // podmanRuntime implements the runtime.Runtime interface for Podman.
 type podmanRuntime struct {
-	system           system.System
-	executor         exec.Executor
-	storageDir       string                // Runtime-specific storage: <globalStorageDir>/runtimes/podman
-	globalStorageDir string                // Top-level kdn storage dir: where config/projects.json lives
-	config           config.Config         // Configuration manager for runtime settings
-	onecliBaseURLFn  func(port int) string // overridable in tests; nil uses default http://localhost:<port>
+	system                system.System
+	executor              exec.Executor
+	storageDir            string                // Runtime-specific storage: <globalStorageDir>/runtimes/podman
+	globalStorageDir      string                // Top-level kdn storage dir: where config/projects.json lives
+	config                config.Config         // Configuration manager for runtime settings
+	onecliBaseURLFn       func(port int) string // overridable in tests; nil uses default http://localhost:<port>
+	secretStore           secret.Store
+	secretServiceRegistry secretservice.Registry
 }
 
 // onecliURL returns the base URL for the OneCLI service on the given port.
@@ -75,6 +79,12 @@ func (p *podmanRuntime) Available() bool {
 	return p.system.CommandExists("podman")
 }
 
+// SetSecretServiceRegistry injects the secret service registry so that Start()
+// can resolve host patterns for secrets when configuring deny-mode networking.
+func (p *podmanRuntime) SetSecretServiceRegistry(reg secretservice.Registry) {
+	p.secretServiceRegistry = reg
+}
+
 // Initialize implements runtime.StorageAware.
 // It sets up the storage directory for persisting runtime-specific data.
 func (p *podmanRuntime) Initialize(storageDir string) error {
@@ -84,6 +94,7 @@ func (p *podmanRuntime) Initialize(storageDir string) error {
 	p.storageDir = storageDir
 	// storageDir is <globalStorageDir>/runtimes/podman; the global dir is two levels up.
 	p.globalStorageDir = filepath.Dir(filepath.Dir(storageDir))
+	p.secretStore = secret.NewStore(p.globalStorageDir)
 
 	// Create config directory
 	configDir := filepath.Join(storageDir, "config")

--- a/pkg/runtime/podman/pods/approval-handler.ts
+++ b/pkg/runtime/podman/pods/approval-handler.ts
@@ -26,53 +26,57 @@ interface Config {
 const CONFIG_PATH = join(__dirname, "config.json");
 
 if (!existsSync(CONFIG_PATH)) {
-  console.log("approval-handler: no config.json found, exiting (allow mode)");
-  process.exit(0);
-}
+  // Allow mode: no config.json means no proxy rules are active. Keep the
+  // process alive so the container stays running and the pod remains healthy.
+  console.log("approval-handler: no config.json found (allow mode), running idle");
+  const keepalive = setInterval(() => {}, 1 << 30);
+  process.on("SIGTERM", () => { clearInterval(keepalive); });
+  process.on("SIGINT", () => { clearInterval(keepalive); });
+} else {
+  const config: Config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  const allowedHosts = new Set(config.hosts ?? []);
 
-const config: Config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
-const allowedHosts = new Set(config.hosts ?? []);
+  console.log(
+    `approval-handler: loaded ${allowedHosts.size} allowed host(s), connecting to ${config.onecliUrl}`,
+  );
 
-console.log(
-  `approval-handler: loaded ${allowedHosts.size} allowed host(s), connecting to ${config.onecliUrl}`,
-);
+  const onecli = new OneCLI({
+    url: config.onecliUrl,
+    gatewayUrl: config.gatewayUrl,
+    apiKey: config.apiKey,
+  });
 
-const onecli = new OneCLI({
-  url: config.onecliUrl,
-  gatewayUrl: config.gatewayUrl,
-  apiKey: config.apiKey,
-});
-
-function matchesPattern(pattern: string, hostname: string): boolean {
-  if (pattern === "*") return true;
-  // *.github.com matches api.github.com but not github.com itself
-  if (pattern.startsWith("*.")) {
-    const suffix = pattern.slice(1); // ".github.com"
-    return hostname.endsWith(suffix) && hostname.length > suffix.length;
+  function matchesPattern(pattern: string, hostname: string): boolean {
+    if (pattern === "*") return true;
+    // *.github.com matches api.github.com but not github.com itself
+    if (pattern.startsWith("*.")) {
+      const suffix = pattern.slice(1); // ".github.com"
+      return hostname.endsWith(suffix) && hostname.length > suffix.length;
+    }
+    return pattern === hostname;
   }
-  return pattern === hostname;
+
+  const handle = onecli.configureManualApproval(async (request) => {
+    // Strip port from host (e.g. "api.github.com:443" → "api.github.com")
+    const hostname = request.host.split(":")[0];
+    const decision = [...allowedHosts].some((p) => matchesPattern(p, hostname)) ? "approve" : "deny";
+    console.log(`approval-handler: ${decision} ${request.host} (hostname: ${hostname})`);
+    return decision;
+  });
+
+  console.log("approval-handler: listening for approval requests");
+
+  // Keep the process alive — the SDK polls for approval requests but may not
+  // hold the event loop open on its own.
+  const keepalive = setInterval(() => {}, 1 << 30);
+
+  function shutdown(signal: string): void {
+    console.log(`approval-handler: received ${signal}, stopping`);
+    clearInterval(keepalive);
+    handle.stop();
+  }
+
+  // SIGTERM on Linux/macOS; SIGINT covers Ctrl+C on all platforms including Windows.
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
 }
-
-const handle = onecli.configureManualApproval(async (request) => {
-  // Strip port from host (e.g. "api.github.com:443" → "api.github.com")
-  const hostname = request.host.split(":")[0];
-  const decision = [...allowedHosts].some((p) => matchesPattern(p, hostname)) ? "approve" : "deny";
-  console.log(`approval-handler: ${decision} ${request.host} (hostname: ${hostname})`);
-  return decision;
-});
-
-console.log("approval-handler: listening for approval requests");
-
-// Keep the process alive — the SDK polls for approval requests but may not
-// hold the event loop open on its own.
-const keepalive = setInterval(() => {}, 1 << 30);
-
-function shutdown(signal: string): void {
-  console.log(`approval-handler: received ${signal}, stopping`);
-  clearInterval(keepalive);
-  handle.stop();
-}
-
-// SIGTERM on Linux/macOS; SIGINT covers Ctrl+C on all platforms including Windows.
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -105,15 +105,15 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	secretHosts := collectSecretHosts(wsCfg, p.secretStore, p.secretServiceRegistry)
 	allHosts := mergeHosts(explicitHosts, secretHosts)
 
-	// Networking rules are only configured when mode is explicitly deny AND at
-	// least one allowed host is available (from explicit config or secrets).
-	// All other cases (allow, no config, deny without any hosts) clear any
-	// stale rules so that mode switches take effect without recreating the workspace.
+	// Networking rules are configured whenever mode is explicitly deny, regardless
+	// of whether any hosts are allowed. An empty host list causes the
+	// approval-handler to deny all requests, which is the correct behaviour for
+	// a fully-isolated workspace. Allow mode (or no config) clears any stale
+	// rules so that mode switches take effect without recreating the workspace.
 	shouldConfigureNetworking := wsCfg != nil &&
 		wsCfg.Network != nil &&
 		wsCfg.Network.Mode != nil &&
-		*wsCfg.Network.Mode == workspace.Deny &&
-		len(allHosts) > 0
+		*wsCfg.Network.Mode == workspace.Deny
 
 	// Start the network-guard container so we can exec nftables commands into it.
 	networkGuardContainer := podName + "-network-guard"

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -89,7 +89,7 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	// unless the network mode is explicitly set to allow in the workspace config.
 	// The policy is read fresh from projects.json on each start so edits take effect
 	// without recreating the workspace.
-	wsCfg, loadErr := loadNetworkConfig(tmplData.SourcePath, p.globalStorageDir, tmplData.ProjectID)
+	wsCfg, loadErr := loadNetworkConfig(tmplData.SourcePath, p.globalStorageDir, tmplData.ProjectID, tmplData.Agent)
 	if loadErr != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load network config: %w", loadErr)
 	}
@@ -102,7 +102,10 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 
 	// Automatically add host patterns from secrets so users do not need to
 	// list them explicitly under network.hosts.
-	secretHosts := collectSecretHosts(wsCfg, p.secretStore, p.secretServiceRegistry)
+	secretHosts, err := collectSecretHosts(wsCfg, p.secretStore, p.secretServiceRegistry)
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to collect secret hosts: %w", err)
+	}
 	allHosts := mergeHosts(explicitHosts, secretHosts)
 
 	// Networking rules are configured whenever mode is explicitly deny, regardless

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -94,16 +94,26 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to load network config: %w", loadErr)
 	}
 
+	// Collect explicit allowed hosts from the workspace network config.
+	var explicitHosts []string
+	if wsCfg != nil && wsCfg.Network != nil && wsCfg.Network.Hosts != nil {
+		explicitHosts = *wsCfg.Network.Hosts
+	}
+
+	// Automatically add host patterns from secrets so users do not need to
+	// list them explicitly under network.hosts.
+	secretHosts := collectSecretHosts(wsCfg, p.secretStore, p.secretServiceRegistry)
+	allHosts := mergeHosts(explicitHosts, secretHosts)
+
 	// Networking rules are only configured when mode is explicitly deny AND at
-	// least one allowed host is specified. All other cases (allow, no config,
-	// deny without hosts) clear any stale rules so that mode switches take
-	// effect without recreating the workspace.
+	// least one allowed host is available (from explicit config or secrets).
+	// All other cases (allow, no config, deny without any hosts) clear any
+	// stale rules so that mode switches take effect without recreating the workspace.
 	shouldConfigureNetworking := wsCfg != nil &&
 		wsCfg.Network != nil &&
 		wsCfg.Network.Mode != nil &&
 		*wsCfg.Network.Mode == workspace.Deny &&
-		wsCfg.Network.Hosts != nil &&
-		len(*wsCfg.Network.Hosts) > 0
+		len(allHosts) > 0
 
 	// Start the network-guard container so we can exec nftables commands into it.
 	networkGuardContainer := podName + "-network-guard"
@@ -124,10 +134,8 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	}
 
 	if shouldConfigureNetworking {
-		hosts := *wsCfg.Network.Hosts
-
 		stepLogger.Start("Configuring network rules", "Network rules configured")
-		if err := p.configureNetworking(ctx, onecliBaseURL, hosts, tmplData.ApprovalHandlerDir); err != nil {
+		if err := p.configureNetworking(ctx, onecliBaseURL, allHosts, tmplData.ApprovalHandlerDir); err != nil {
 			stepLogger.Fail(err)
 			return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure networking: %w", err)
 		}

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -662,6 +662,81 @@ func TestStart_DenyMode_ConfiguresNetworking(t *testing.T) {
 	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
 }
 
+func TestStart_DenyMode_NoHosts_ConfiguresNetworking(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: deny mode with no allowed hosts must still configure
+	// networking (write config.json and start the approval-handler) so that
+	// the approval-handler container has a config file available and does not
+	// exit immediately, causing it to be set as stopped.
+	containerID := "abc123def456"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "exec" {
+			return []byte("accepting connections\n"), nil
+		}
+		output := fmt.Sprintf("%s|running|kdn-test\n", containerID)
+		return []byte(output), nil
+	}
+
+	var ruleActions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/user/api-key":
+			_ = json.NewEncoder(w).Encode(map[string]string{"apiKey": "oc_testkey"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/rules":
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/rules":
+			var body struct {
+				Action string `json:"action"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			ruleActions = append(ruleActions, body.Action)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "new-rule"})
+		default:
+			t.Errorf("unexpected OneCLI request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	p.onecliBaseURLFn = func(_ int) string { return server.URL }
+	// Deny mode with no hosts field at all.
+	podName := setupPodFilesWithSource(t, p, containerID, "test-ws", `{"network":{"mode":"deny"}}`)
+
+	_, err := p.Start(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// manual_approval rule must still be created even with no allowed hosts.
+	if len(ruleActions) != 1 || ruleActions[0] != "manual_approval" {
+		t.Errorf("expected one manual_approval rule, got: %v", ruleActions)
+	}
+
+	// config.json must be written with an empty hosts list.
+	approvalDir := filepath.Join(p.storageDir, "approval-handler", "test-ws")
+	data, readErr := os.ReadFile(filepath.Join(approvalDir, "config.json"))
+	if readErr != nil {
+		t.Fatalf("reading config.json: %v", readErr)
+	}
+	var cfg approvalHandlerConfig
+	if jsonErr := json.Unmarshal(data, &cfg); jsonErr != nil {
+		t.Fatalf("unmarshaling config.json: %v", jsonErr)
+	}
+	if len(cfg.Hosts) != 0 {
+		t.Errorf("config.hosts = %v, want empty", cfg.Hosts)
+	}
+
+	// Approval-handler must be started before pod start so it has config.json.
+	fakeExec.AssertRunCalledWith(t, "start", podName+"-approval-handler")
+	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
+}
+
 func TestStart_DenyMode_StepLogger(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/onecli"
+	"github.com/openkaiden/kdn/pkg/secretservice"
 )
 
 // Runtime manages the lifecycle of workspace instances in a specific execution environment.
@@ -182,6 +183,14 @@ type Terminal interface {
 	//   - command: The command to execute (e.g., ["bash"], ["claude-code", "--debug"]).
 	//              If empty, the runtime will use the agent's configured terminal command.
 	Terminal(ctx context.Context, instanceID string, agent string, command []string) error
+}
+
+// SecretServiceRegistryAware is an optional interface for runtimes that need the
+// secret service registry to resolve host patterns for networking decisions.
+// Runtimes implementing this interface receive the registry via SetSecretServiceRegistry
+// during registration, enabling them to look up host patterns for secret-derived hosts.
+type SecretServiceRegistryAware interface {
+	SetSecretServiceRegistry(secretservice.Registry)
 }
 
 // ValidateState validates that a runtime state is one of the valid WorkspaceState values.


### PR DESCRIPTION
## Fix deny-mode networking with no explicit hosts and auto-inject secret hosts

Closes #367

### Summary

- **Auto-inject secret hosts in deny mode:** When `network.mode` is `"deny"` and secrets are configured, kdn now automatically adds the hosts associated with those secrets to the allowed list. Users no longer need to duplicate entries like `"api.github.com"` under `network.hosts` when a `github` secret is already configured. Host patterns for known secret types are resolved via the secret service registry; `other`-type secrets use the hosts stored in their metadata.

- **Fix deny mode with no explicit hosts:** Previously, `network.mode: deny` with no `hosts` field skipped networking setup entirely, leaving the approval-handler container without a `config.json`. It would exit immediately on start, marking the pod as stopped. Networking is now configured unconditionally when `mode` is `"deny"` — an empty host list is a valid, fully-isolated configuration that causes the approval-handler to deny all outbound requests.

- **Fix approval-handler in allow mode:** Instead of exiting with code 0 when no `config.json` is found (allow mode), the approval-handler now keeps the process alive with an idle keepalive interval, so the container stays running and the pod remains healthy.
