### PR TITLE
feat(secretservice): add description field to secret services

### DIFF
--- a/.agents/skills/working-with-secrets/SKILL.md
+++ b/.agents/skills/working-with-secrets/SKILL.md
@@ -19,7 +19,7 @@ The secrets system uses a two-layer architecture: a **Store** that persists secr
 
 - **Store interface** (`pkg/secret/secret.go`): `Create(CreateParams) error`, `List() ([]ListItem, error)`, `Get(name string) (ListItem, string, error)`, `Remove(name string) error`
 - **Store implementation** (`pkg/secret/store.go`): writes the value to the keychain, metadata to `secrets.json`
-- **SecretService interface** (`pkg/secretservice/secretservice.go`): describes a named type — host pattern, path, header name, header template, env vars
+- **SecretService interface** (`pkg/secretservice/secretservice.go`): describes a named type — description, host pattern, path, header name, header template, env vars
 - **Registry** (`pkg/secretservice/registry.go`): maps names to `SecretService` implementations
 - **Centralized registration** (`pkg/secretservicesetup/register.go`): loads definitions from the embedded `secretservices.json` and exposes `ListAvailable()` and `RegisterAll()`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ When a workspace has `network.mode = deny` with at least one host in `network.ho
 The secret service system provides a pluggable architecture for managing secret service definitions that describe how secrets are applied to workspace requests.
 
 **Key Components:**
-- **SecretService Interface** (`pkg/secretservice/secretservice.go`): Contract all secret services must implement (`Name()`, `HostsPatterns()`, `Path()`, `EnvVars()`, `HeaderName()`, `HeaderTemplate()`)
+- **SecretService Interface** (`pkg/secretservice/secretservice.go`): Contract all secret services must implement (`Name()`, `Description()`, `HostsPatterns()`, `Path()`, `EnvVars()`, `HeaderName()`, `HeaderTemplate()`)
 - **Registry** (`pkg/secretservice/registry.go`): Manages secret service registration and discovery
 - **Centralized Registration** (`pkg/secretservicesetup/register.go`): Automatically registers all available secret services; `ListAvailable()` returns the names of all registered services (used by commands to derive valid `--type` values dynamically)
 

--- a/README.md
+++ b/README.md
@@ -2347,8 +2347,8 @@ kdn service list
 ```
 Output:
 ```text
-NAME    HOST PATTERN       PATH  HEADER          HEADER TEMPLATE    ENV VARS
-github  api.github.com         Authorization   Bearer ${value}    GH_TOKEN, GITHUB_TOKEN
+NAME    HOST PATTERN       PATH  HEADER          HEADER TEMPLATE    ENV VARS                DESCRIPTION
+github  api.github.com         Authorization   Bearer ${value}    GH_TOKEN, GITHUB_TOKEN  GitHub API token for accessing GitHub repositories and services
 ```
 
 **List services in JSON format:**
@@ -2361,6 +2361,7 @@ Output:
   "items": [
     {
       "name": "github",
+      "description": "GitHub API token for accessing GitHub repositories and services",
       "hostsPatterns": ["api.github.com"],
       "headerName": "Authorization",
       "headerTemplate": "Bearer ${value}",

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.1
 require (
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.7.0
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.7.0
+	github.com/openkaiden/kdn-api/cli/go v0.8.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.8.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/openkaiden/kdn-api/cli/go v0.7.0 h1:18F9581VI+rYoL95MWw6qJ7+1QLJD0Jo1enrSCaT1Z8=
-github.com/openkaiden/kdn-api/cli/go v0.7.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.7.0 h1:Gfp4FFmYb9OrpJ2F4Xj86bikUxrEMVZbZgBzB5vwO2k=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.7.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.8.0 h1:pOV2mFSGnUcxqvvgmaGVg2wo5rO5m8NGjkGloS+3Pbk=
+github.com/openkaiden/kdn-api/cli/go v0.8.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.8.0 h1:GYRftTPsJV3+o7XwafNnOL0hF52j+lfJ4IgdlxUMt4Q=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.8.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=

--- a/pkg/cmd/service_list.go
+++ b/pkg/cmd/service_list.go
@@ -49,6 +49,7 @@ func (r *registryRegistrar) RegisterSecretService(service secretservice.SecretSe
 // serviceDetail represents a secret service in JSON output
 type serviceDetail struct {
 	Name           string   `json:"name"`
+	Description    string   `json:"description,omitempty"`
 	HostsPatterns  []string `json:"hostsPatterns"`
 	HeaderName     string   `json:"headerName"`
 	HeaderTemplate string   `json:"headerTemplate,omitempty"`
@@ -117,7 +118,7 @@ func (s *serviceListCmd) displayTable(cmd *cobra.Command, services []secretservi
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 	columnFmt := color.New(color.FgYellow).SprintfFunc()
 
-	tbl := table.New("NAME", "HOST PATTERNS", "PATH", "HEADER", "HEADER TEMPLATE", "ENV VARS")
+	tbl := table.New("NAME", "HOST PATTERNS", "PATH", "HEADER", "HEADER TEMPLATE", "ENV VARS", "DESCRIPTION")
 	tbl.WithWriter(out)
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
@@ -125,7 +126,7 @@ func (s *serviceListCmd) displayTable(cmd *cobra.Command, services []secretservi
 	for _, svc := range services {
 		hostsPatterns := strings.Join(svc.HostsPatterns(), ", ")
 		envVars := strings.Join(svc.EnvVars(), ", ")
-		tbl.AddRow(svc.Name(), hostsPatterns, svc.Path(), svc.HeaderName(), svc.HeaderTemplate(), envVars)
+		tbl.AddRow(svc.Name(), hostsPatterns, svc.Path(), svc.HeaderName(), svc.HeaderTemplate(), envVars, svc.Description())
 	}
 
 	// Print the table
@@ -140,6 +141,7 @@ func (s *serviceListCmd) outputJSON(cmd *cobra.Command, services []secretservice
 	for _, svc := range services {
 		items = append(items, serviceDetail{
 			Name:           svc.Name(),
+			Description:    svc.Description(),
 			HostsPatterns:  svc.HostsPatterns(),
 			HeaderName:     svc.HeaderName(),
 			HeaderTemplate: svc.HeaderTemplate(),

--- a/pkg/cmd/service_list_test.go
+++ b/pkg/cmd/service_list_test.go
@@ -146,6 +146,9 @@ func TestServiceListCmd_E2E(t *testing.T) {
 		if !strings.Contains(output, "ENV VARS") {
 			t.Errorf("Expected output to contain 'ENV VARS' header, got: %s", output)
 		}
+		if !strings.Contains(output, "DESCRIPTION") {
+			t.Errorf("Expected output to contain 'DESCRIPTION' header, got: %s", output)
+		}
 		if !strings.Contains(output, "Bearer ${value}") {
 			t.Errorf("Expected output to contain 'Bearer ${value}', got: %s", output)
 		}
@@ -181,6 +184,9 @@ func TestServiceListCmd_E2E(t *testing.T) {
 		for _, svc := range response.Items {
 			if svc.Name == "github" {
 				found = true
+				if svc.Description == "" {
+					t.Error("Expected non-empty Description for github service")
+				}
 				if len(svc.HostsPatterns) == 0 || svc.HostsPatterns[0] != "api.github.com" {
 					t.Errorf("Expected HostsPatterns %v, got %v", []string{"api.github.com"}, svc.HostsPatterns)
 				}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -4499,6 +4499,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 // fakeSecretServiceImpl is a test implementation of the SecretService interface
 type fakeSecretServiceImpl struct {
 	name           string
+	description    string
 	hostsPatterns  []string
 	path           string
 	envVars        []string
@@ -4507,6 +4508,7 @@ type fakeSecretServiceImpl struct {
 }
 
 func (f *fakeSecretServiceImpl) Name() string            { return f.name }
+func (f *fakeSecretServiceImpl) Description() string     { return f.description }
 func (f *fakeSecretServiceImpl) HostsPatterns() []string { return f.hostsPatterns }
 func (f *fakeSecretServiceImpl) Path() string            { return f.path }
 func (f *fakeSecretServiceImpl) EnvVars() []string       { return f.envVars }

--- a/pkg/onecli/mapper_test.go
+++ b/pkg/onecli/mapper_test.go
@@ -35,6 +35,7 @@ func registryWithGitHub(t *testing.T) secretservice.Registry {
 		[]string{"GH_TOKEN", "GITHUB_TOKEN"},
 		"Authorization",
 		"Bearer ${value}",
+		"",
 	)
 	if err := reg.Register(svc); err != nil {
 		t.Fatal(err)
@@ -93,6 +94,7 @@ func TestMapper_KnownType_MultiplePatterns(t *testing.T) {
 		nil,
 		"Authorization",
 		"Bearer ${value}",
+		"",
 	)
 	if err := reg.Register(svc); err != nil {
 		t.Fatal(err)
@@ -126,7 +128,7 @@ func TestMapper_KnownType_EmptyPatterns(t *testing.T) {
 	t.Parallel()
 
 	reg := secretservice.NewRegistry()
-	svc := secretservice.NewSecretService("empty", nil, "", nil, "X-Token", "${value}")
+	svc := secretservice.NewSecretService("empty", nil, "", nil, "X-Token", "${value}", "")
 	if err := reg.Register(svc); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/secretservice/registry_test.go
+++ b/pkg/secretservice/registry_test.go
@@ -26,6 +26,7 @@ import (
 // fakeSecretService is a test implementation of the SecretService interface
 type fakeSecretService struct {
 	name           string
+	description    string
 	hostsPatterns  []string
 	path           string
 	envVars        []string
@@ -34,6 +35,7 @@ type fakeSecretService struct {
 }
 
 func (f *fakeSecretService) Name() string            { return f.name }
+func (f *fakeSecretService) Description() string     { return f.description }
 func (f *fakeSecretService) HostsPatterns() []string { return f.hostsPatterns }
 func (f *fakeSecretService) Path() string            { return f.path }
 func (f *fakeSecretService) EnvVars() []string       { return f.envVars }

--- a/pkg/secretservice/secretservice.go
+++ b/pkg/secretservice/secretservice.go
@@ -27,6 +27,10 @@ type SecretService interface {
 	// Name returns the identifier of the secret service.
 	Name() string
 
+	// Description returns a human-readable description of the secret service.
+	// Returns an empty string if not set.
+	Description() string
+
 	// HostsPatterns returns the list of regular expression patterns for matching hosts.
 	// Returns nil if not set.
 	HostsPatterns() []string
@@ -51,6 +55,7 @@ type SecretService interface {
 // service is the concrete implementation of SecretService.
 type service struct {
 	name           string
+	description    string
 	hostsPatterns  []string
 	path           string
 	envVars        []string
@@ -62,9 +67,10 @@ type service struct {
 var _ SecretService = (*service)(nil)
 
 // NewSecretService creates a new SecretService implementation with the given parameters.
-func NewSecretService(name string, hostsPatterns []string, path string, envVars []string, headerName, headerTemplate string) SecretService {
+func NewSecretService(name string, hostsPatterns []string, path string, envVars []string, headerName, headerTemplate, description string) SecretService {
 	return &service{
 		name:           name,
+		description:    description,
 		hostsPatterns:  hostsPatterns,
 		path:           path,
 		envVars:        envVars,
@@ -76,6 +82,11 @@ func NewSecretService(name string, hostsPatterns []string, path string, envVars 
 // Name returns the identifier of the secret service.
 func (s *service) Name() string {
 	return s.name
+}
+
+// Description returns a human-readable description of the secret service.
+func (s *service) Description() string {
+	return s.description
 }
 
 // HostsPatterns returns the list of regular expression patterns for matching hosts.

--- a/pkg/secretservice/secretservice_test.go
+++ b/pkg/secretservice/secretservice_test.go
@@ -1,0 +1,91 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package secretservice
+
+import (
+	"testing"
+)
+
+func TestNewSecretService(t *testing.T) {
+	t.Parallel()
+
+	svc := NewSecretService(
+		"github",
+		[]string{"api.github.com"},
+		"/path",
+		[]string{"GH_TOKEN", "GITHUB_TOKEN"},
+		"Authorization",
+		"Bearer ${value}",
+		"GitHub API token",
+	)
+
+	if svc == nil {
+		t.Fatal("NewSecretService() returned nil")
+	}
+
+	if svc.Name() != "github" {
+		t.Errorf("Name() = %q, want %q", svc.Name(), "github")
+	}
+	if svc.Description() != "GitHub API token" {
+		t.Errorf("Description() = %q, want %q", svc.Description(), "GitHub API token")
+	}
+	if len(svc.HostsPatterns()) != 1 || svc.HostsPatterns()[0] != "api.github.com" {
+		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"api.github.com"})
+	}
+	if svc.Path() != "/path" {
+		t.Errorf("Path() = %q, want %q", svc.Path(), "/path")
+	}
+	if len(svc.EnvVars()) != 2 || svc.EnvVars()[0] != "GH_TOKEN" || svc.EnvVars()[1] != "GITHUB_TOKEN" {
+		t.Errorf("EnvVars() = %v, want %v", svc.EnvVars(), []string{"GH_TOKEN", "GITHUB_TOKEN"})
+	}
+	if svc.HeaderName() != "Authorization" {
+		t.Errorf("HeaderName() = %q, want %q", svc.HeaderName(), "Authorization")
+	}
+	if svc.HeaderTemplate() != "Bearer ${value}" {
+		t.Errorf("HeaderTemplate() = %q, want %q", svc.HeaderTemplate(), "Bearer ${value}")
+	}
+}
+
+func TestNewSecretService_OptionalFieldsEmpty(t *testing.T) {
+	t.Parallel()
+
+	svc := NewSecretService("minimal", nil, "", nil, "X-Token", "", "")
+
+	if svc.Name() != "minimal" {
+		t.Errorf("Name() = %q, want %q", svc.Name(), "minimal")
+	}
+	if svc.Description() != "" {
+		t.Errorf("Description() = %q, want empty string", svc.Description())
+	}
+	if svc.HostsPatterns() != nil {
+		t.Errorf("HostsPatterns() = %v, want nil", svc.HostsPatterns())
+	}
+	if svc.Path() != "" {
+		t.Errorf("Path() = %q, want empty string", svc.Path())
+	}
+	if svc.EnvVars() != nil {
+		t.Errorf("EnvVars() = %v, want nil", svc.EnvVars())
+	}
+	if svc.HeaderName() != "X-Token" {
+		t.Errorf("HeaderName() = %q, want %q", svc.HeaderName(), "X-Token")
+	}
+	if svc.HeaderTemplate() != "" {
+		t.Errorf("HeaderTemplate() = %q, want empty string", svc.HeaderTemplate())
+	}
+}

--- a/pkg/secretservicesetup/register.go
+++ b/pkg/secretservicesetup/register.go
@@ -42,6 +42,7 @@ var secretServicesJSON []byte
 // secretServiceDefinition represents a secret service entry in the embedded JSON file.
 type secretServiceDefinition struct {
 	Name           string   `json:"name"`
+	Description    string   `json:"description"`
 	HostsPatterns  []string `json:"hostsPatterns"`
 	Path           string   `json:"path"`
 	HeaderName     string   `json:"headerName"`
@@ -81,6 +82,7 @@ func loadSecretServices() ([]secretServiceFactory, error) {
 				d.EnvVars,
 				d.HeaderName,
 				d.HeaderTemplate,
+				d.Description,
 			)
 		})
 	}

--- a/pkg/secretservicesetup/register_test.go
+++ b/pkg/secretservicesetup/register_test.go
@@ -28,6 +28,7 @@ import (
 // fakeSecretService is a test implementation of the SecretService interface
 type fakeSecretService struct {
 	name           string
+	description    string
 	hostsPatterns  []string
 	path           string
 	envVars        []string
@@ -36,6 +37,7 @@ type fakeSecretService struct {
 }
 
 func (f *fakeSecretService) Name() string            { return f.name }
+func (f *fakeSecretService) Description() string     { return f.description }
 func (f *fakeSecretService) HostsPatterns() []string { return f.hostsPatterns }
 func (f *fakeSecretService) Path() string            { return f.path }
 func (f *fakeSecretService) EnvVars() []string       { return f.envVars }
@@ -196,6 +198,9 @@ func TestAvailableSecretServicesContainGitHub(t *testing.T) {
 	if svc.Name() != "github" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "github")
 	}
+	if svc.Description() == "" {
+		t.Error("Description() should not be empty")
+	}
 	if len(svc.HostsPatterns()) == 0 || svc.HostsPatterns()[0] != "api.github.com" {
 		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"api.github.com"})
 	}
@@ -236,6 +241,9 @@ func TestAvailableSecretServicesContainGemini(t *testing.T) {
 	if svc.Name() != "gemini" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "gemini")
 	}
+	if svc.Description() == "" {
+		t.Error("Description() should not be empty")
+	}
 	if len(svc.HostsPatterns()) == 0 || svc.HostsPatterns()[0] != "generativelanguage.googleapis.com" {
 		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"generativelanguage.googleapis.com"})
 	}
@@ -275,6 +283,9 @@ func TestAvailableSecretServicesContainAnthropic(t *testing.T) {
 
 	if svc.Name() != "anthropic" {
 		t.Errorf("Name() = %q, want %q", svc.Name(), "anthropic")
+	}
+	if svc.Description() == "" {
+		t.Error("Description() should not be empty")
 	}
 	if len(svc.HostsPatterns()) == 0 || svc.HostsPatterns()[0] != "api.anthropic.com" {
 		t.Errorf("HostsPatterns() = %v, want %v", svc.HostsPatterns(), []string{"api.anthropic.com"})

--- a/pkg/secretservicesetup/secretservices.json
+++ b/pkg/secretservicesetup/secretservices.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "github",
+    "description": "GitHub API token for accessing GitHub repositories and services",
     "hostsPatterns": ["api.github.com"],
     "headerName": "Authorization",
     "headerTemplate": "Bearer ${value}",
@@ -8,6 +9,7 @@
   },
   {
     "name": "gemini",
+    "description": "Google Gemini AI API key for accessing Gemini language models",
     "hostsPatterns": ["generativelanguage.googleapis.com"],
     "headerName": "x-goog-api-key",
     "headerTemplate": "${value}",
@@ -15,6 +17,7 @@
   },
   {
     "name": "anthropic",
+    "description": "Anthropic API key for accessing Claude AI models",
     "hostsPatterns": ["api.anthropic.com"],
     "headerName": "x-api-key",
     "envVars": ["ANTHROPIC_API_KEY"]


### PR DESCRIPTION
The `SecretService` interface gains a `Description()` method and all built-in services (github, gemini, anthropic) now carry a human-readable description. The description is exposed via `kdn service list` (as a new DESCRIPTION table column) and `kdn service list -o json`.

Bumps `kdn-api/cli` and `kdn-api/workspace-configuration` to v0.8.0 which adds the `description` field to the `SecretService` API model.

Closes #366