### PR TITLE
fix(podman): delete workspace temp dirs on remove

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,8 @@ When a workspace has `network.mode = deny` with at least one host in `network.ho
 - `pkg/runtime/podman/pods/onecli-pod.yaml` — pod manifest with the approval-handler, network-guard, and OneCLI containers
 - `pkg/runtime/podman/system/path.go` / `path_windows.go` — `HostPathToMachinePath` / `MachinePathToHostPath` for translating host paths to Podman Machine (WSL2) paths on Windows; no-ops on Linux/macOS
 
+**Per-workspace temporary directories:** The Podman runtime writes files into subdirectories of `<storage-dir>/<dir>/<workspace-name>/` for each workspace it creates. These directories are cleaned up when the workspace is removed. The authoritative list is the `workspaceTempDirs` variable in `pkg/runtime/podman/remove.go`. **If you add a new per-workspace directory under `storageDir`, add its name to that slice** so `Remove()` cleans it up automatically.
+
 **For the full design, use:** `/working-with-onecli`
 
 ### Secret Service System

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -41,6 +41,9 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
 		if isNotFoundError(err) {
+			if podName, readErr := p.readPodName(id); readErr == nil {
+				p.cleanupWorkspaceTempDirs(podName)
+			}
 			p.cleanupPodFiles(id)
 			return nil
 		}
@@ -70,18 +73,25 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	}
 
 	p.cleanupPodFiles(id)
-	p.cleanupCerts(podName)
+	p.cleanupWorkspaceTempDirs(podName)
 
 	return nil
 }
 
-// cleanupCerts removes the CA certificate directory for a workspace.
-func (p *podmanRuntime) cleanupCerts(podName string) {
-	certsDir := filepath.Join(p.storageDir, "certs", podName)
-	if !strings.HasPrefix(filepath.Clean(certsDir), filepath.Join(p.storageDir, "certs")+string(filepath.Separator)) {
-		return
+// workspaceTempDirs lists the subdirectories under storageDir that hold
+// per-workspace temporary files and must be cleaned up on removal.
+var workspaceTempDirs = []string{"approval-handler", "certs"}
+
+// cleanupWorkspaceTempDirs removes per-workspace subdirectories from every
+// directory listed in workspaceTempDirs.
+func (p *podmanRuntime) cleanupWorkspaceTempDirs(podName string) {
+	for _, dir := range workspaceTempDirs {
+		dirPath := filepath.Join(p.storageDir, dir, podName)
+		if !strings.HasPrefix(filepath.Clean(dirPath), filepath.Join(p.storageDir, dir)+string(filepath.Separator)) {
+			continue
+		}
+		os.RemoveAll(dirPath)
 	}
-	os.RemoveAll(certsDir)
 }
 
 // isNotFoundError checks if an error indicates that a container was not found.

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -61,6 +62,12 @@ func TestRemove_Success(t *testing.T) {
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
 	podName := setupPodFiles(t, p, containerID, "my-project")
 
+	// Also create a certs directory to verify it is cleaned up
+	certsDir := filepath.Join(p.storageDir, "certs", podName)
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatalf("failed to create certs dir: %v", err)
+	}
+
 	err := p.Remove(context.Background(), containerID)
 	if err != nil {
 		t.Fatalf("Remove() failed: %v", err)
@@ -76,6 +83,14 @@ func TestRemove_Success(t *testing.T) {
 	// Verify pod files were cleaned up
 	if _, err := os.Stat(p.podDir(containerID)); !os.IsNotExist(err) {
 		t.Error("Expected pod directory to be cleaned up after Remove")
+	}
+
+	// Verify workspace temp dirs were cleaned up
+	for _, dir := range workspaceTempDirs {
+		path := filepath.Join(p.storageDir, dir, podName)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("Expected %s to be cleaned up after Remove", path)
+		}
 	}
 }
 
@@ -105,6 +120,41 @@ func TestRemove_IdempotentWhenContainerNotFound(t *testing.T) {
 
 	if len(fakeExec.RunCalls) > 0 {
 		t.Error("Run should not be called for non-existent container")
+	}
+}
+
+func TestRemove_IdempotentCleansUpTempDirsWhenContainerNotFound(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "inspect" {
+			return nil, fmt.Errorf("failed to inspect container: no such container")
+		}
+		return nil, fmt.Errorf("unexpected command: %v", args)
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	podName := setupPodFiles(t, p, containerID, "leftover-ws")
+
+	// Create certs dir to verify it is also cleaned up
+	certsDir := filepath.Join(p.storageDir, "certs", podName)
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatalf("failed to create certs dir: %v", err)
+	}
+
+	err := p.Remove(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Remove() should be idempotent for non-existent containers, got error: %v", err)
+	}
+
+	for _, dir := range workspaceTempDirs {
+		path := filepath.Join(p.storageDir, dir, podName)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("Expected %s to be cleaned up after Remove (container not found path)", path)
+		}
 	}
 }
 


### PR DESCRIPTION
approval-handler and certs directories under storageDir were not cleaned up when a workspace was removed, causing stale files to accumulate and interfere with re-creation of same-named workspaces.

Replaces the narrow cleanupCerts helper with cleanupWorkspaceTempDirs, which iterates over the workspaceTempDirs constant so new directories only need to be added in one place. Cleanup is also applied in the early-return (container-not-found) path. Documents the constant in AGENTS.md.

Fixes #372