### PR TITLE
feat(workspace): add timestamps and human-readable state to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,9 @@ $ kdn init /path/to/another-project --runtime podman --agent claude --model clau
   "paths": {
     "source": "/absolute/path/to/another-project",
     "configuration": "/absolute/path/to/another-project/.kaiden"
+  },
+  "timestamps": {
+    "created": 1752912000000
   }
 }
 ```
@@ -895,6 +898,10 @@ $ kdn workspace list -o json
       "paths": {
         "source": "/absolute/path/to/project",
         "configuration": "/absolute/path/to/project/.kaiden"
+      },
+      "timestamps": {
+        "created": 1752912000000,
+        "started": 1752912300000
       }
     },
     {
@@ -907,6 +914,9 @@ $ kdn workspace list -o json
       "paths": {
         "source": "/absolute/path/to/another-project",
         "configuration": "/absolute/path/to/another-project/.kaiden"
+      },
+      "timestamps": {
+        "created": 1752912000000
       }
     }
   ]
@@ -976,6 +986,9 @@ $ kdn workspace list -o json
       "paths": {
         "source": "/absolute/path/to/another-project",
         "configuration": "/absolute/path/to/another-project/.kaiden"
+      },
+      "timestamps": {
+        "created": 1752912000000
       }
     }
   ]
@@ -2975,11 +2988,13 @@ kdn workspace list
 Output:
 ```text
 NAME             SHORT ID      PROJECT                              SOURCES                              AGENT    MODEL                          STATE
-myproject        a1b2c3d4e5f6  /absolute/path/to/myproject          /absolute/path/to/myproject          claude   claude-sonnet-4-20250514       running
+myproject        a1b2c3d4e5f6  /absolute/path/to/myproject          /absolute/path/to/myproject          claude   claude-sonnet-4-20250514       running for 5min
 another-project  f6e5d4c3b2a1  /absolute/path/to/another-project    /absolute/path/to/another-project    goose                                   stopped
 ```
 
 The `AGENT` and `MODEL` columns are displayed separately. When no model is set, the `MODEL` column is empty.
+
+The `STATE` column shows a human-readable duration for running workspaces: `running for Xs` (under 1 minute), `running for Xmin` (under 1 hour), or `running for H:MMh` (1 hour or more). Stopped, errored, or unknown workspaces show their state name directly.
 
 **Use the short alias:**
 ```bash
@@ -3004,6 +3019,10 @@ Output:
       "paths": {
         "source": "/absolute/path/to/myproject",
         "configuration": "/absolute/path/to/myproject/.kaiden"
+      },
+      "timestamps": {
+        "created": 1752912000000,
+        "started": 1752912300000
       }
     },
     {
@@ -3015,6 +3034,9 @@ Output:
       "paths": {
         "source": "/absolute/path/to/another-project",
         "configuration": "/absolute/path/to/another-project/.kaiden"
+      },
+      "timestamps": {
+        "created": 1752912000000
       }
     }
   ]
@@ -3022,6 +3044,8 @@ Output:
 ```
 
 The `model` field is only present when a model was explicitly specified during `init` with the `--model` flag. When no model is set, the field is omitted from the JSON output.
+
+The `timestamps` object is always present. `created` is a Unix millisecond timestamp recording when the workspace was registered. `started` is a Unix millisecond timestamp recording when the workspace was last started; it is omitted when the workspace is not running.
 
 **List with short flag:**
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.1
 require (
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.8.0
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.8.0
+	github.com/openkaiden/kdn-api/cli/go v0.9.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.9.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/openkaiden/kdn-api/cli/go v0.8.0 h1:pOV2mFSGnUcxqvvgmaGVg2wo5rO5m8NGjkGloS+3Pbk=
-github.com/openkaiden/kdn-api/cli/go v0.8.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.8.0 h1:GYRftTPsJV3+o7XwafNnOL0hF52j+lfJ4IgdlxUMt4Q=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.8.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.9.0 h1:zXiPTgDtW3FBKHptdaFgU9jnNaRwXajMH4mKoKgfSQQ=
+github.com/openkaiden/kdn-api/cli/go v0.9.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.9.0 h1:fYqSzynKbNn/qo4RjCx/mEXzFtLwY145+sq48h4RDrQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.9.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=

--- a/pkg/cmd/conversion.go
+++ b/pkg/cmd/conversion.go
@@ -46,9 +46,16 @@ func instanceToWorkspace(instance instances.Instance) api.Workspace {
 			Configuration: instance.GetConfigDir(),
 			Source:        instance.GetSourceDir(),
 		},
+		Timestamps: api.WorkspaceTimestamps{
+			Created: instance.GetCreatedAt().UnixMilli(),
+		},
 	}
 	if model := instance.GetModel(); model != "" {
 		ws.Model = &model
+	}
+	if startedAt := instance.GetStartedAt(); !startedAt.IsZero() {
+		ms := startedAt.UnixMilli()
+		ws.Timestamps.Started = &ms
 	}
 	return ws
 }

--- a/pkg/cmd/conversion_test.go
+++ b/pkg/cmd/conversion_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/instances"
@@ -193,6 +194,66 @@ func TestInstanceToWorkspace(t *testing.T) {
 		}
 	})
 
+	t.Run("includes created timestamp from instance", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		createdAt := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+		instanceData := instances.InstanceData{
+			ID:        "ts-id",
+			Name:      "ts-workspace",
+			Paths:     instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			CreatedAt: createdAt,
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		expectedMs := createdAt.UnixMilli()
+		if result.Timestamps.Created != expectedMs {
+			t.Errorf("Expected Timestamps.Created %d, got %d", expectedMs, result.Timestamps.Created)
+		}
+		if result.Timestamps.Started != nil {
+			t.Errorf("Expected Timestamps.Started to be nil, got %d", *result.Timestamps.Started)
+		}
+	})
+
+	t.Run("includes started timestamp when set", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		createdAt := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+		startedAt := time.Date(2026, 1, 15, 10, 5, 0, 0, time.UTC)
+
+		instanceData := instances.InstanceData{
+			ID:        "ts-running-id",
+			Name:      "ts-running-workspace",
+			Paths:     instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			CreatedAt: createdAt,
+			StartedAt: startedAt,
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		expectedStartedMs := startedAt.UnixMilli()
+		if result.Timestamps.Started == nil {
+			t.Fatal("Expected Timestamps.Started to be set")
+		}
+		if *result.Timestamps.Started != expectedStartedMs {
+			t.Errorf("Expected Timestamps.Started %d, got %d", expectedStartedMs, *result.Timestamps.Started)
+		}
+	})
+
 	t.Run("includes all required fields", func(t *testing.T) {
 		t.Parallel()
 
@@ -243,6 +304,9 @@ func TestInstanceToWorkspace(t *testing.T) {
 		if _, exists := parsed["paths"]; !exists {
 			t.Error("Expected 'paths' field in JSON")
 		}
+		if _, exists := parsed["timestamps"]; !exists {
+			t.Error("Expected 'timestamps' field in JSON")
+		}
 
 		// Verify paths structure
 		paths, ok := parsed["paths"].(map[string]interface{})
@@ -255,6 +319,15 @@ func TestInstanceToWorkspace(t *testing.T) {
 		}
 		if _, exists := paths["configuration"]; !exists {
 			t.Error("Expected 'paths.configuration' field in JSON")
+		}
+
+		// Verify timestamps structure
+		timestamps, ok := parsed["timestamps"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected 'timestamps' to be an object")
+		}
+		if _, exists := timestamps["created"]; !exists {
+			t.Error("Expected 'timestamps.created' field in JSON")
 		}
 	})
 }

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	api "github.com/openkaiden/kdn-api/cli/go"
@@ -45,6 +46,30 @@ func truncateID(id string, n int) string {
 		return id
 	}
 	return id[:n]
+}
+
+// formatState returns a human-readable state string.
+// For running instances with a known start time it shows "running for X".
+func formatState(instance instances.Instance) string {
+	state := instance.GetRuntimeData().State
+	if state != api.WorkspaceStateRunning {
+		return string(state)
+	}
+	startedAt := instance.GetStartedAt()
+	if startedAt.IsZero() {
+		return string(state)
+	}
+	d := time.Since(startedAt)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("running for %ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("running for %dmin", int(d.Minutes()))
+	default:
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		return fmt.Sprintf("running for %d:%02dh", h, m)
+	}
 }
 
 // compactPath replaces the home directory prefix with ~/
@@ -156,7 +181,7 @@ func (w *workspaceListCmd) displayTable(cmd *cobra.Command, instancesList []inst
 		sources := compactPath(instance.GetSourceDir())
 		agent := instance.GetAgent()
 		model := displayModelID(instance.GetModel())
-		state := instance.GetRuntimeData().State
+		state := formatState(instance)
 
 		tbl.AddRow(name, shortID, project, sources, agent, model, state)
 	}

--- a/pkg/cmd/workspace_list_test.go
+++ b/pkg/cmd/workspace_list_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/cmd/testutil"
@@ -821,6 +822,237 @@ func TestWorkspaceListCmd_Model(t *testing.T) {
 
 		if workspacesList.Items[0].Model != nil {
 			t.Errorf("Expected Model to be nil in JSON output, got %q", *workspacesList.Items[0].Model)
+		}
+	})
+}
+
+func TestWorkspaceListCmd_Timestamps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("json output includes created timestamp", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kaiden"),
+			Name:      "ts-workspace",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		before := time.Now().UnixMilli()
+		_, err = manager.Add(context.Background(), instances.AddOptions{Instance: instance, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+		after := time.Now().UnixMilli()
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "list", "--storage", storageDir, "-o", "json"})
+
+		var output bytes.Buffer
+		rootCmd.SetOut(&output)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		var workspacesList api.WorkspacesList
+		if err := json.Unmarshal(output.Bytes(), &workspacesList); err != nil {
+			t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, output.String())
+		}
+
+		if len(workspacesList.Items) != 1 {
+			t.Fatalf("Expected 1 item, got %d", len(workspacesList.Items))
+		}
+
+		ws := workspacesList.Items[0]
+		if ws.Timestamps.Created < before || ws.Timestamps.Created > after {
+			t.Errorf("Expected Created timestamp between %d and %d, got %d", before, after, ws.Timestamps.Created)
+		}
+		if ws.Timestamps.Started != nil {
+			t.Errorf("Expected Started to be nil for stopped instance, got %d", *ws.Timestamps.Started)
+		}
+	})
+
+	t.Run("json output includes started timestamp when running", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kaiden"),
+			Name:      "running-workspace",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		added, err := manager.Add(context.Background(), instances.AddOptions{Instance: instance, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		before := time.Now().UnixMilli()
+		if err := manager.Start(context.Background(), added.GetID()); err != nil {
+			t.Fatalf("Failed to start instance: %v", err)
+		}
+		after := time.Now().UnixMilli()
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "list", "--storage", storageDir, "-o", "json"})
+
+		var output bytes.Buffer
+		rootCmd.SetOut(&output)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		var workspacesList api.WorkspacesList
+		if err := json.Unmarshal(output.Bytes(), &workspacesList); err != nil {
+			t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, output.String())
+		}
+
+		if len(workspacesList.Items) != 1 {
+			t.Fatalf("Expected 1 item, got %d", len(workspacesList.Items))
+		}
+
+		ws := workspacesList.Items[0]
+		if ws.Timestamps.Started == nil {
+			t.Fatal("Expected Started timestamp to be set for running instance")
+		}
+		if *ws.Timestamps.Started < before || *ws.Timestamps.Started > after {
+			t.Errorf("Expected Started timestamp between %d and %d, got %d", before, after, *ws.Timestamps.Started)
+		}
+	})
+}
+
+func TestFormatState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns stopped for stopped instance", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:    "id1",
+			Name:  "ws",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateStopped,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		if got := formatState(inst); got != "stopped" {
+			t.Errorf("Expected 'stopped', got %q", got)
+		}
+	})
+
+	t.Run("returns running for running instance with no start time", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:    "id2",
+			Name:  "ws",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateRunning,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		if got := formatState(inst); got != "running" {
+			t.Errorf("Expected 'running', got %q", got)
+		}
+	})
+
+	t.Run("returns running for Xs when started less than a minute ago", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:        "id3",
+			Name:      "ws",
+			Paths:     instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			StartedAt: time.Now().Add(-30 * time.Second),
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateRunning,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		got := formatState(inst)
+		if !strings.HasPrefix(got, "running for ") || !strings.HasSuffix(got, "s") {
+			t.Errorf("Expected 'running for Xs', got %q", got)
+		}
+	})
+
+	t.Run("returns running for Xmin when started between 1 and 60 minutes ago", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:        "id4",
+			Name:      "ws",
+			Paths:     instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			StartedAt: time.Now().Add(-5 * time.Minute),
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateRunning,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		got := formatState(inst)
+		if got != "running for 5min" {
+			t.Errorf("Expected 'running for 5min', got %q", got)
+		}
+	})
+
+	t.Run("returns running for h:mmh when started over 1 hour ago", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:        "id5",
+			Name:      "ws",
+			Paths:     instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			StartedAt: time.Now().Add(-2*time.Hour - 15*time.Minute),
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateRunning,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		got := formatState(inst)
+		if got != "running for 2:15h" {
+			t.Errorf("Expected 'running for 2:15h', got %q", got)
 		}
 	})
 }

--- a/pkg/instances/instance.go
+++ b/pkg/instances/instance.go
@@ -19,6 +19,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"time"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 )
@@ -79,6 +80,10 @@ type InstanceData struct {
 	// Model is the model ID configured for the agent (e.g., "claude-sonnet-4-20250514").
 	// Empty string means no model was explicitly specified.
 	Model string `json:"model,omitempty"`
+	// CreatedAt is when the instance was first registered.
+	CreatedAt time.Time `json:"created_at"`
+	// StartedAt is when the instance was last started. Zero value means not started.
+	StartedAt time.Time `json:"started_at,omitempty"`
 }
 
 // Instance represents a workspace instance with source and configuration directories.
@@ -107,6 +112,10 @@ type Instance interface {
 	GetAgent() string
 	// GetModel returns the model ID for this instance (empty if not set)
 	GetModel() string
+	// GetCreatedAt returns when the instance was first registered
+	GetCreatedAt() time.Time
+	// GetStartedAt returns when the instance was last started; zero value means not started
+	GetStartedAt() time.Time
 	// Dump returns the serializable data of the instance
 	Dump() InstanceData
 }
@@ -131,6 +140,10 @@ type instance struct {
 	Agent string
 	// Model is the model ID configured for the agent (empty if not set)
 	Model string
+	// CreatedAt is when the instance was first registered
+	CreatedAt time.Time
+	// StartedAt is when the instance was last started; zero value means not started
+	StartedAt time.Time
 }
 
 // Compile-time check to ensure instance implements Instance interface
@@ -199,6 +212,16 @@ func (i *instance) GetModel() string {
 	return i.Model
 }
 
+// GetCreatedAt returns when the instance was first registered
+func (i *instance) GetCreatedAt() time.Time {
+	return i.CreatedAt
+}
+
+// GetStartedAt returns when the instance was last started; zero value means not started
+func (i *instance) GetStartedAt() time.Time {
+	return i.StartedAt
+}
+
 // Dump returns the serializable data of the instance
 func (i *instance) Dump() InstanceData {
 	return InstanceData{
@@ -208,10 +231,12 @@ func (i *instance) Dump() InstanceData {
 			Source:        i.SourceDir,
 			Configuration: i.ConfigDir,
 		},
-		Runtime: i.Runtime,
-		Project: i.Project,
-		Agent:   i.Agent,
-		Model:   i.Model,
+		Runtime:   i.Runtime,
+		Project:   i.Project,
+		Agent:     i.Agent,
+		Model:     i.Model,
+		CreatedAt: i.CreatedAt,
+		StartedAt: i.StartedAt,
 	}
 }
 
@@ -271,6 +296,13 @@ func NewInstanceFromData(data InstanceData) (Instance, error) {
 		return nil, ErrInvalidPath
 	}
 
+	createdAt := data.CreatedAt
+	if createdAt.IsZero() {
+		// Backward compatibility: instances persisted before timestamp support
+		// get the current time as a conservative fallback.
+		createdAt = time.Now()
+	}
+
 	return &instance{
 		ID:        data.ID,
 		Name:      data.Name,
@@ -280,6 +312,8 @@ func NewInstanceFromData(data InstanceData) (Instance, error) {
 		Project:   data.Project,
 		Agent:     data.Agent,
 		Model:     data.Model,
+		CreatedAt: createdAt,
+		StartedAt: data.StartedAt,
 	}, nil
 }
 

--- a/pkg/instances/instance.go
+++ b/pkg/instances/instance.go
@@ -296,13 +296,6 @@ func NewInstanceFromData(data InstanceData) (Instance, error) {
 		return nil, ErrInvalidPath
 	}
 
-	createdAt := data.CreatedAt
-	if createdAt.IsZero() {
-		// Backward compatibility: instances persisted before timestamp support
-		// get the current time as a conservative fallback.
-		createdAt = time.Now()
-	}
-
 	return &instance{
 		ID:        data.ID,
 		Name:      data.Name,
@@ -312,7 +305,7 @@ func NewInstanceFromData(data InstanceData) (Instance, error) {
 		Project:   data.Project,
 		Agent:     data.Agent,
 		Model:     data.Model,
-		CreatedAt: createdAt,
+		CreatedAt: data.CreatedAt,
 		StartedAt: data.StartedAt,
 	}, nil
 }

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
@@ -109,6 +110,7 @@ type manager struct {
 	secretServiceRegistry secretservice.Registry
 	secretStore           secret.Store
 	gitDetector           git.Detector
+	now                   func() time.Time
 }
 
 // Compile-time check to ensure manager implements Manager interface
@@ -124,12 +126,12 @@ func NewManager(storageDir string) (Manager, error) {
 	agentReg := agent.NewRegistry()
 	secretServiceReg := secretservice.NewRegistry()
 	secretStore := secret.NewStore(storageDir)
-	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, agentReg, secretServiceReg, secretStore, git.NewDetector())
+	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, agentReg, secretServiceReg, secretStore, git.NewDetector(), time.Now)
 }
 
 // newManagerWithFactory creates a new instance manager with a custom instance factory, generator, registry, and git detector.
 // This is unexported and primarily useful for testing with fake instances, generators, runtimes, and git detector.
-func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, agentReg agent.Registry, secretServiceReg secretservice.Registry, secretStore secret.Store, detector git.Detector) (Manager, error) {
+func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, agentReg agent.Registry, secretServiceReg secretservice.Registry, secretStore secret.Store, detector git.Detector, clock func() time.Time) (Manager, error) {
 	if storageDir == "" {
 		return nil, errors.New("storage directory cannot be empty")
 	}
@@ -154,6 +156,9 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 	if detector == nil {
 		return nil, errors.New("git detector cannot be nil")
 	}
+	if clock == nil {
+		return nil, errors.New("clock cannot be nil")
+	}
 
 	// Ensure storage directory exists
 	if err := os.MkdirAll(storageDir, 0755); err != nil {
@@ -171,6 +176,7 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 		secretServiceRegistry: secretServiceReg,
 		secretStore:           secretStore,
 		gitDetector:           detector,
+		now:                   clock,
 	}, nil
 }
 
@@ -363,9 +369,10 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 			State:      runtimeInfo.State,
 			Info:       runtimeInfo.Info,
 		},
-		Project: project,
-		Agent:   opts.Agent,
-		Model:   opts.Model,
+		Project:   project,
+		Agent:     opts.Agent,
+		Model:     opts.Model,
+		CreatedAt: m.now(),
 	}
 
 	instances = append(instances, instanceWithID)
@@ -431,6 +438,8 @@ func (m *manager) Start(ctx context.Context, id string) error {
 	maps.Copy(mergedInfo, runtimeData.Info)
 	maps.Copy(mergedInfo, runtimeInfo.Info)
 
+	startedAt := m.now()
+
 	// Update the instance with new runtime state
 	updatedInstance := &instance{
 		ID:        instanceToStart.GetID(),
@@ -443,9 +452,11 @@ func (m *manager) Start(ctx context.Context, id string) error {
 			State:      runtimeInfo.State,
 			Info:       mergedInfo,
 		},
-		Project: instanceToStart.GetProject(),
-		Agent:   instanceToStart.GetAgent(),
-		Model:   instanceToStart.GetModel(),
+		Project:   instanceToStart.GetProject(),
+		Agent:     instanceToStart.GetAgent(),
+		Model:     instanceToStart.GetModel(),
+		CreatedAt: instanceToStart.GetCreatedAt(),
+		StartedAt: startedAt,
 	}
 
 	instances[index] = updatedInstance
@@ -525,9 +536,11 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 			State:      runtimeInfo.State,
 			Info:       mergedInfo,
 		},
-		Project: instanceToStop.GetProject(),
-		Agent:   instanceToStop.GetAgent(),
-		Model:   instanceToStop.GetModel(),
+		Project:   instanceToStop.GetProject(),
+		Agent:     instanceToStop.GetAgent(),
+		Model:     instanceToStop.GetModel(),
+		CreatedAt: instanceToStop.GetCreatedAt(),
+		// StartedAt is intentionally zero on stop: the instance is no longer running
 	}
 
 	instances[index] = updatedInstance

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -166,7 +166,7 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 	}
 
 	storageFile := filepath.Join(storageDir, DefaultStorageFileName)
-	return &manager{
+	mgr := &manager{
 		storageFile:           storageFile,
 		storageDir:            storageDir,
 		factory:               factory,
@@ -177,7 +177,13 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 		secretStore:           secretStore,
 		gitDetector:           detector,
 		now:                   clock,
-	}, nil
+	}
+
+	if err := mgr.migrateTimestamps(); err != nil {
+		return nil, fmt.Errorf("failed to migrate instance timestamps: %w", err)
+	}
+
+	return mgr, nil
 }
 
 // Add registers a new instance with a runtime.
@@ -913,6 +919,36 @@ func (m *manager) mergeConfigurations(projectID string, workspaceConfig *workspa
 	}
 
 	return result, nil
+}
+
+// migrateTimestamps backfills CreatedAt for instances persisted before timestamp
+// support was added. It runs once at manager construction, computes the missing
+// timestamp using the injected clock, and writes the result back to disk so
+// subsequent loads see the authoritative value.
+func (m *manager) migrateTimestamps() error {
+	instances, err := m.loadInstances()
+	if err != nil {
+		return err
+	}
+
+	migrated := false
+	for i, inst := range instances {
+		if inst.GetCreatedAt().IsZero() {
+			data := inst.Dump()
+			data.CreatedAt = m.now()
+			updated, err := m.factory(data)
+			if err != nil {
+				return err
+			}
+			instances[i] = updated
+			migrated = true
+		}
+	}
+
+	if migrated {
+		return m.saveInstances(instances)
+	}
+	return nil
 }
 
 // loadInstances reads instances from the storage file

--- a/pkg/instances/manager_project_test.go
+++ b/pkg/instances/manager_project_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openkaiden/kdn/pkg/agent"
 	"github.com/openkaiden/kdn/pkg/git"
@@ -37,7 +38,7 @@ func TestManager_detectProject(t *testing.T) {
 		// Create fake git detector that returns ErrNotGitRepository
 		gitDetector := newFakeGitDetector()
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), sourceDir)
@@ -60,7 +61,7 @@ func TestManager_detectProject(t *testing.T) {
 			"", // at root, relative path is empty
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)
@@ -85,7 +86,7 @@ func TestManager_detectProject(t *testing.T) {
 			filepath.Join("pkg", "git"),
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), subDir)
@@ -109,7 +110,7 @@ func TestManager_detectProject(t *testing.T) {
 			"", // at root
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)
@@ -133,7 +134,7 @@ func TestManager_detectProject(t *testing.T) {
 			filepath.Join("pkg", "utils"),
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), subDir)
@@ -157,7 +158,7 @@ func TestManager_detectProject(t *testing.T) {
 			"",
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)
@@ -181,7 +182,7 @@ func TestManager_detectProject(t *testing.T) {
 			filepath.Join("pkg", "cmd"),
 		)
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 		mgr := m.(*manager)
 
 		result := mgr.detectProject(context.Background(), repoRoot)

--- a/pkg/instances/manager_terminal_test.go
+++ b/pkg/instances/manager_terminal_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openkaiden/kdn/pkg/agent"
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -83,7 +84,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -132,7 +133,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -160,7 +161,7 @@ func TestManager_Terminal(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistryWithTerminal(tmpDir, nil), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistryWithTerminal(tmpDir, nil), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		err := manager.Terminal(context.Background(), "nonexistent-id", []string{"bash"})
 		if !errors.Is(err, ErrInstanceNotFound) {
@@ -178,7 +179,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -223,7 +224,7 @@ func TestManager_Terminal(t *testing.T) {
 		regularFakeRT := fake.New()
 		_ = reg.Register(regularFakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -257,7 +258,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
@@ -46,6 +47,8 @@ type fakeInstance struct {
 	project    string
 	agent      string
 	model      string
+	createdAt  time.Time
+	startedAt  time.Time
 }
 
 // Compile-time check to ensure fakeInstance implements Instance interface
@@ -91,6 +94,14 @@ func (f *fakeInstance) GetModel() string {
 	return f.model
 }
 
+func (f *fakeInstance) GetCreatedAt() time.Time {
+	return f.createdAt
+}
+
+func (f *fakeInstance) GetStartedAt() time.Time {
+	return f.startedAt
+}
+
 func (f *fakeInstance) Dump() InstanceData {
 	return InstanceData{
 		ID:   f.id,
@@ -99,9 +110,11 @@ func (f *fakeInstance) Dump() InstanceData {
 			Source:        f.sourceDir,
 			Configuration: f.configDir,
 		},
-		Runtime: f.runtime,
-		Project: f.project,
-		Agent:   f.agent,
+		Runtime:   f.runtime,
+		Project:   f.project,
+		Agent:     f.agent,
+		CreatedAt: f.createdAt,
+		StartedAt: f.startedAt,
 	}
 }
 
@@ -116,6 +129,8 @@ type newFakeInstanceParams struct {
 	Project    string
 	Agent      string
 	Model      string
+	CreatedAt  time.Time
+	StartedAt  time.Time
 }
 
 // newFakeInstance creates a new fake instance for testing
@@ -130,6 +145,8 @@ func newFakeInstance(params newFakeInstanceParams) Instance {
 		project:    params.Project,
 		agent:      params.Agent,
 		model:      params.Model,
+		createdAt:  params.CreatedAt,
+		startedAt:  params.StartedAt,
 	}
 }
 
@@ -159,6 +176,8 @@ func fakeInstanceFactory(data InstanceData) (Instance, error) {
 		project:    data.Project,
 		agent:      data.Agent,
 		model:      data.Model,
+		createdAt:  data.CreatedAt,
+		startedAt:  data.StartedAt,
 	}, nil
 }
 
@@ -417,7 +436,7 @@ func TestNewManager(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() unexpected error = %v", err)
 		}
@@ -449,7 +468,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -479,7 +498,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		_, err := manager.Add(context.Background(), AddOptions{Instance: nil, RuntimeType: "fake"})
 		if err == nil {
@@ -501,7 +520,7 @@ func TestManager_Add(t *testing.T) {
 			"duplicate-id-0000000000000000000000000000000000000000000000000000000a",
 			"unique-id-1-0000000000000000000000000000000000000000000000000000000b",
 		})
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		// Create instances without IDs (empty ID)
@@ -552,7 +571,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -578,7 +597,7 @@ func TestManager_Add(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -615,7 +634,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instances, err := manager.List()
 		if err != nil {
@@ -631,7 +650,7 @@ func TestManager_List(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -661,7 +680,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		// Create empty storage file
 		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
@@ -684,7 +703,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -717,7 +736,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		_, err := manager.Get("nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -729,7 +748,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -765,7 +784,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		_, err := manager.Get("nonexistent-name")
 		if err != ErrInstanceNotFound {
@@ -777,7 +796,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		// Create first instance
@@ -821,7 +840,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -851,7 +870,7 @@ func TestManager_Delete(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		err := manager.Delete(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -864,7 +883,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		source1 := filepath.Join(instanceTmpDir, "source1")
@@ -907,7 +926,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -921,7 +940,7 @@ func TestManager_Delete(t *testing.T) {
 		manager1.Delete(ctx, generatedID)
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		_, err := manager2.Get(generatedID)
 		if err != ErrInstanceNotFound {
 			t.Errorf("Get() from new manager error = %v, want %v", err, ErrInstanceNotFound)
@@ -933,7 +952,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -975,7 +994,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1007,7 +1026,7 @@ func TestManager_Start(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		err := manager.Start(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -1037,7 +1056,7 @@ func TestManager_Start(t *testing.T) {
 				runtime:    RuntimeData{}, // Empty runtime
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1077,7 +1096,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1088,7 +1107,7 @@ func TestManager_Start(t *testing.T) {
 		manager1.Start(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "running" {
@@ -1101,7 +1120,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1126,7 +1145,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1165,7 +1184,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1199,7 +1218,7 @@ func TestManager_Stop(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		err := manager.Stop(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -1212,7 +1231,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1252,7 +1271,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1264,7 +1283,7 @@ func TestManager_Stop(t *testing.T) {
 		manager1.Stop(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "stopped" {
@@ -1277,7 +1296,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1308,7 +1327,7 @@ func TestManager_Stop(t *testing.T) {
 				RelativePath: "",
 			},
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1352,7 +1371,7 @@ func TestManager_Stop(t *testing.T) {
 				RelativePath: "",
 			},
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), gitDetector, time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1389,7 +1408,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1417,7 +1436,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1475,7 +1494,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1519,7 +1538,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1563,7 +1582,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inaccessibleSource := filepath.Join(instanceTmpDir, "nonexistent-source")
@@ -1612,7 +1631,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: accessible,
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		accessibleConfig := filepath.Join(instanceTmpDir, "accessible-config")
 
@@ -1655,7 +1674,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1679,7 +1698,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		removed, err := manager.Reconcile()
 		if err != nil {
@@ -1702,7 +1721,7 @@ func TestManager_Persistence(t *testing.T) {
 		instanceTmpDir := t.TempDir()
 
 		// Create first manager and add instance
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		expectedSource := filepath.Join(instanceTmpDir, "source")
 		expectedConfig := filepath.Join(instanceTmpDir, "config")
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1715,7 +1734,7 @@ func TestManager_Persistence(t *testing.T) {
 		generatedID := added.GetID()
 
 		// Create second manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		instances, err := manager2.List()
 		if err != nil {
 			t.Fatalf("List() from second manager unexpected error = %v", err)
@@ -1736,7 +1755,7 @@ func TestManager_Persistence(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -1788,7 +1807,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		var wg sync.WaitGroup
@@ -1821,7 +1840,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		// Add some instances first
@@ -1902,7 +1921,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		// Cast to concrete type to access unexported methods
 		mgr := m.(*manager)
@@ -1935,7 +1954,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -1960,7 +1979,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -1999,7 +2018,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2035,7 +2054,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2056,7 +2075,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2073,7 +2092,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2098,7 +2117,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2116,7 +2135,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2137,7 +2156,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2155,7 +2174,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2177,7 +2196,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2227,7 +2246,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2288,7 +2307,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2364,7 +2383,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2463,7 +2482,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2517,7 +2536,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		result, err := mgr.mergeConfigurations("github.com/user/repo", nil, "")
@@ -2545,7 +2564,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -2575,7 +2594,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -2615,7 +2634,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -4157,6 +4176,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(),
 			store,
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4200,6 +4220,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(), // empty registry — mapper.Map will fail
 			store,
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4241,6 +4262,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(),
 			store,
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4316,6 +4338,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(),
 			store,
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4370,6 +4393,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(),
 			newFakeSecretStore(),
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4406,6 +4430,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(),
 			newFakeSecretStore(),
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4455,6 +4480,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			secretservice.NewRegistry(),
 			store,
 			newFakeGitDetector(),
+			time.Now,
 		)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
@@ -4534,7 +4560,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
 			t.Fatalf("Register() error = %v", err)
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4573,7 +4599,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
 			t.Fatalf("Register() error = %v", err)
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4600,7 +4626,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4627,7 +4653,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		_, err := manager.GetDashboardURL(ctx, "nonexistent-id")
 		if !errors.Is(err, ErrInstanceNotFound) {
@@ -4649,7 +4675,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
 			t.Fatalf("Register() error = %v", err)
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4683,7 +4709,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		svc := &fakeSecretServiceImpl{name: "github", hostsPatterns: []string{"github.com"}, headerName: "Authorization"}
 
@@ -4697,7 +4723,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector())
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), time.Now)
 
 		svc1 := &fakeSecretServiceImpl{name: "github", headerName: "Authorization"}
 		svc2 := &fakeSecretServiceImpl{name: "github", headerName: "X-Token"}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -1800,6 +1800,112 @@ func TestManager_Persistence(t *testing.T) {
 	})
 }
 
+func TestManager_MigrateTimestamps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("backfills CreatedAt for legacy instances and persists to disk", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+
+		// Write instances.json with a zero CreatedAt to simulate pre-timestamp
+		// data. Using json.Marshal ensures paths are correctly escaped on all
+		// platforms (e.g. backslashes on Windows).
+		legacyData := []InstanceData{
+			{
+				ID:    "legacy-id-0000000000000000000000000000000000000000000000000000000000",
+				Name:  "legacy",
+				Paths: InstancePaths{Source: sourceDir, Configuration: configDir},
+				// CreatedAt intentionally zero: time.Time{}.IsZero() == true after
+				// JSON round-trip, so migrateTimestamps will treat it as legacy.
+			},
+		}
+		legacyJSON, err := json.Marshal(legacyData)
+		if err != nil {
+			t.Fatalf("Failed to marshal legacy data: %v", err)
+		}
+		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
+		if err := os.WriteFile(storageFile, legacyJSON, 0644); err != nil {
+			t.Fatalf("Failed to write legacy storage file: %v", err)
+		}
+
+		fixedNow := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+		fixedClock := func() time.Time { return fixedNow }
+
+		// Creating the manager triggers migrateTimestamps
+		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), fixedClock)
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		instances, err := manager.List()
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if len(instances) != 1 {
+			t.Fatalf("Expected 1 instance, got %d", len(instances))
+		}
+		if !instances[0].GetCreatedAt().Equal(fixedNow) {
+			t.Errorf("GetCreatedAt() = %v, want %v", instances[0].GetCreatedAt(), fixedNow)
+		}
+
+		// Verify the backfilled timestamp was persisted to disk
+		raw, err := os.ReadFile(storageFile)
+		if err != nil {
+			t.Fatalf("Failed to read storage file: %v", err)
+		}
+		var persisted []InstanceData
+		if err := json.Unmarshal(raw, &persisted); err != nil {
+			t.Fatalf("Failed to unmarshal storage file: %v", err)
+		}
+		if persisted[0].CreatedAt.IsZero() {
+			t.Error("Expected CreatedAt to be persisted to disk, got zero value")
+		}
+		if !persisted[0].CreatedAt.Equal(fixedNow) {
+			t.Errorf("Persisted CreatedAt = %v, want %v", persisted[0].CreatedAt, fixedNow)
+		}
+	})
+
+	t.Run("does not modify instances that already have CreatedAt set", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+
+		// Add an instance through the manager (it will have CreatedAt set)
+		existingNow := time.Date(2026, 1, 10, 8, 0, 0, 0, time.UTC)
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), func() time.Time { return existingNow })
+
+		inst := newFakeInstance(newFakeInstanceParams{
+			SourceDir:  t.TempDir(),
+			ConfigDir:  t.TempDir(),
+			Accessible: true,
+		})
+		if _, err := manager1.Add(context.Background(), AddOptions{Instance: inst, RuntimeType: "fake"}); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		// Reload with a different clock — migration must not overwrite the existing timestamp
+		laterNow := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+		manager2, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeGitDetector(), func() time.Time { return laterNow })
+		if err != nil {
+			t.Fatalf("newManagerWithFactory() error = %v", err)
+		}
+
+		instances, err := manager2.List()
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if len(instances) != 1 {
+			t.Fatalf("Expected 1 instance, got %d", len(instances))
+		}
+		if !instances[0].GetCreatedAt().Equal(existingNow) {
+			t.Errorf("GetCreatedAt() = %v, want original %v (not later %v)", instances[0].GetCreatedAt(), existingNow, laterNow)
+		}
+	})
+}
+
 func TestManager_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Bump kdn-api modules to v0.9.0, which introduces WorkspaceTimestamps (created and started as Unix milliseconds) in the Workspace type.

- InstanceData gains CreatedAt/StartedAt (time.Time), persisted in instances.json; NewInstanceFromData falls back to time.Now() for backward compatibility with existing records.
- The manager clock is now injected (defaults to time.Now), enabling deterministic testing of timestamp behaviour.
- JSON output (workspace list -o json) includes a timestamps object on every workspace; started is omitted when the workspace is not running.
- The human-readable STATE column shows "running for Xs / Xmin / H:MMh" for running workspaces, and the plain state string otherwise.

Fixes #370 
