### PR TITLE
feat(cmd): add `ls` alias for `list` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2965,13 +2965,14 @@ kdn init /tmp/workspace --runtime podman --agent claude
 
 ### `workspace list` - List All Registered Workspaces
 
-Lists all workspaces that have been registered with kdn. Also available as the shorter alias `list`.
+Lists all workspaces that have been registered with kdn. Also available as the shorter aliases `list` and `ls`.
 
 #### Usage
 
 ```bash
 kdn workspace list [flags]
 kdn list [flags]
+kdn ls [flags]
 ```
 
 #### Flags
@@ -2996,9 +2997,10 @@ The `AGENT` and `MODEL` columns are displayed separately. When no model is set, 
 
 The `STATE` column shows a human-readable duration for running workspaces: `running for Xs` (under 1 minute), `running for Xmin` (under 1 hour), or `running for H:MMh` (1 hour or more). Stopped, errored, or unknown workspaces show their state name directly.
 
-**Use the short alias:**
+**Use the short aliases:**
 ```bash
 kdn list
+kdn ls
 ```
 
 **List workspaces in JSON format:**

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -29,6 +29,7 @@ func NewListCmd() *cobra.Command {
 	// Create an alias command that delegates to workspace list
 	cmd := &cobra.Command{
 		Use:     "list",
+		Aliases: []string{"ls"},
 		Short:   workspaceListCmd.Short + " (alias for 'workspace list')",
 		Long:    workspaceListCmd.Long,
 		Example: AdaptExampleForAlias(workspaceListCmd.Example, "workspace list", "list"),

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -35,6 +35,10 @@ func TestListCmd(t *testing.T) {
 		t.Errorf("Expected Use to be 'list', got '%s'", cmd.Use)
 	}
 
+	if len(cmd.Aliases) != 1 || cmd.Aliases[0] != "ls" {
+		t.Errorf("Expected Aliases to be [ls], got %v", cmd.Aliases)
+	}
+
 	// Verify it includes the original workspace list Short description
 	workspaceListCmd := NewWorkspaceListCmd()
 	if !strings.Contains(cmd.Short, workspaceListCmd.Short) {


### PR DESCRIPTION
Adds `ls` as a cobra alias for the `list` command so users can run `kdn ls` as a shorter alternative to `kdn list` or `kdn workspace list`.

Closes #306