### PR TITLE
fix(cmd): remove dashboard URL display from init command

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -276,10 +276,6 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(out, addedInstance.GetID())
 	}
 
-	if port, ok := addedInstance.GetRuntimeData().Info["onecli_web_port"]; ok {
-		fmt.Fprintf(out, "OneCLI dashboard: http://localhost:%s\n", port)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The init command was printing the OneCLI dashboard URL after workspace creation. This information is already available via the `kdn dashboard` command, and the init output should only display the workspace ID.

Fixes #381