### PR TITLE
feat(runtime): add openshell runtime for sandbox-based workspaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 **Key Components:**
 - **Runtime Interface** (`pkg/runtime/runtime.go`): Contract all runtimes must implement
 - **Registry** (`pkg/runtime/registry.go`): Manages runtime registration and discovery
-- **Runtime Implementations** (`pkg/runtime/<runtime-name>/`): Platform-specific packages (e.g., `fake`, `podman`)
+- **Runtime Implementations** (`pkg/runtime/<runtime-name>/`): Platform-specific packages (e.g., `fake`, `podman`, `openshell`)
 - **Centralized Registration** (`pkg/runtimesetup/register.go`): Automatically registers all available runtimes
 
 **Optional Interfaces:**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 kdn is a command-line interface for launching and managing AI agents in isolated, reproducible workspaces. It creates runtime-based environments (containers, VMs, or other backends) where agents run with your project source code mounted, automatically configured and ready to use — no manual onboarding or setup required.
 
-The architecture is built around pluggable runtimes. The first supported runtime is **Podman**, which creates container-based workspaces using a custom Fedora image. Additional runtimes (e.g., MicroVM, Kubernetes) can be added to support other execution environments.
+The architecture is built around pluggable runtimes. Supported runtimes include **Podman** (container-based workspaces using a custom Fedora image) and **OpenShell** (sandbox-based workspaces using the OpenShell Gateway with Podman or VM drivers). Additional runtimes (e.g., Kubernetes) can be added to support other execution environments.
 
 **Supported Agents**
 
@@ -17,7 +17,7 @@ The architecture is built around pluggable runtimes. The first supported runtime
 **Key Features**
 
 - Isolated workspaces per project, each running in its own runtime instance
-- Pluggable runtime system — Podman is the default, with support for adding other runtimes
+- Pluggable runtime system — Podman and OpenShell runtimes, with support for adding others
 - Automatic agent configuration (onboarding flags, trusted directories) on workspace creation
 - Multi-level configuration: workspace, global, project-specific, and agent-specific settings
 - Inject environment variables and mount directories into workspaces at multiple scopes
@@ -80,7 +80,17 @@ The underlying AI model that powers the agents. Examples include Claude (by Anth
 A standardized protocol for connecting AI agents to external data sources and tools. MCP servers provide agents with additional capabilities like database access, API integrations, or file system operations.
 
 ### Runtime
-The environment where workspaces run. kdn supports multiple runtimes (e.g., Podman containers), allowing workspaces to be hosted on different backends depending on your needs.
+The environment where workspaces run. kdn supports multiple runtimes:
+- **Podman** — container-based workspaces using a custom Fedora image
+- **OpenShell** — sandbox-based workspaces using the OpenShell Gateway, with `--openshell-driver podman` (default) or `--openshell-driver vm` drivers
+
+```bash
+# Register with openshell using VM driver
+kdn init --runtime openshell --agent claude --openshell-driver vm
+
+# Register with openshell and allow additional hosts
+kdn init --runtime openshell --agent claude --openshell-allow-hosts github.com,registry.npmjs.org
+```
 
 ### Service
 A secret service definition that describes how to inject credentials into workspace HTTP requests. Each service specifies a host pattern to match, the HTTP header to set, and which environment variables hold the credential value.

--- a/pkg/runtime/openshell/codesign_darwin.go
+++ b/pkg/runtime/openshell/codesign_darwin.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package openshell
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const entitlementsPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>`
+
+const codesignedSuffix = ".codesigned"
+
+// codesignBinary signs the binary with the hypervisor entitlement on macOS.
+// A marker file prevents re-signing on subsequent runs.
+func codesignBinary(binaryPath string) error {
+	markerPath := binaryPath + codesignedSuffix
+	if _, err := os.Stat(markerPath); err == nil {
+		return nil
+	}
+
+	tmpFile, err := os.CreateTemp("", "kdn-entitlements-*.plist")
+	if err != nil {
+		return fmt.Errorf("failed to create entitlements file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(entitlementsPlist); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write entitlements: %w", err)
+	}
+	tmpFile.Close()
+
+	cmd := exec.Command("codesign", "--entitlements", tmpFile.Name(), "--force", "-s", "-", binaryPath) //nolint:gosec
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("codesign failed: %s: %w", string(output), err)
+	}
+
+	return os.WriteFile(markerPath, nil, 0644)
+}

--- a/pkg/runtime/openshell/codesign_darwin_test.go
+++ b/pkg/runtime/openshell/codesign_darwin_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package openshell
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCodesignBinary_SignsBinary(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "test-binary")
+
+	src, err := os.Open("/usr/bin/true")
+	if err != nil {
+		t.Fatalf("failed to open /usr/bin/true: %v", err)
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(binaryPath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		t.Fatalf("failed to create test binary: %v", err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		t.Fatalf("failed to copy binary: %v", err)
+	}
+	dst.Close()
+
+	if err := codesignBinary(binaryPath); err != nil {
+		t.Fatalf("codesignBinary() error = %v", err)
+	}
+
+	markerPath := binaryPath + codesignedSuffix
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Errorf("marker file not created: %v", err)
+	}
+
+	cmd := exec.Command("codesign", "--verify", "--verbose", binaryPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Errorf("codesign verify failed: %s: %v", string(output), err)
+	}
+}
+
+func TestCodesignBinary_MarkerPreventsResign(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "test-binary")
+
+	if err := os.WriteFile(binaryPath, []byte("not a real binary"), 0755); err != nil {
+		t.Fatalf("failed to write fake binary: %v", err)
+	}
+
+	markerPath := binaryPath + codesignedSuffix
+	if err := os.WriteFile(markerPath, nil, 0644); err != nil {
+		t.Fatalf("failed to write marker: %v", err)
+	}
+
+	if err := codesignBinary(binaryPath); err != nil {
+		t.Errorf("codesignBinary() should skip signing when marker exists, got error = %v", err)
+	}
+}
+
+func TestCodesignBinary_NonexistentBinary(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "nonexistent")
+
+	if err := codesignBinary(binaryPath); err == nil {
+		t.Error("codesignBinary() should fail for nonexistent binary")
+	}
+
+	markerPath := binaryPath + codesignedSuffix
+	if _, err := os.Stat(markerPath); err == nil {
+		t.Error("marker file should not exist after failed codesign")
+	}
+}

--- a/pkg/runtime/openshell/codesign_other.go
+++ b/pkg/runtime/openshell/codesign_other.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin
+
+package openshell
+
+func codesignBinary(_ string) error {
+	return nil
+}

--- a/pkg/runtime/openshell/codesign_other_test.go
+++ b/pkg/runtime/openshell/codesign_other_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin
+
+package openshell
+
+import "testing"
+
+func TestCodesignBinary_Noop(t *testing.T) {
+	t.Parallel()
+
+	if err := codesignBinary("/nonexistent/path"); err != nil {
+		t.Errorf("codesignBinary() should be no-op on non-darwin, got error = %v", err)
+	}
+}

--- a/pkg/runtime/openshell/config.go
+++ b/pkg/runtime/openshell/config.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const (
+	configFile       = "config.json"
+	gatewayStateFile = "gateway-state.json"
+
+	// DriverPodman uses Podman as the sandbox container driver.
+	DriverPodman = "podman"
+
+	// DriverVM uses a VM as the sandbox driver.
+	DriverVM = "vm"
+
+	// defaultDriver is the driver used when none is specified.
+	defaultDriver = DriverPodman
+)
+
+type gatewayConfig struct {
+	Driver string `json:"driver"`
+}
+
+// loadConfig reads the gateway configuration from storage.
+// Returns default config if the file does not exist.
+func loadConfig(storageDir string) gatewayConfig {
+	data, err := os.ReadFile(filepath.Join(storageDir, configFile))
+	if err != nil {
+		return gatewayConfig{Driver: defaultDriver}
+	}
+
+	var cfg gatewayConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return gatewayConfig{Driver: defaultDriver}
+	}
+
+	if cfg.Driver == "" {
+		cfg.Driver = defaultDriver
+	}
+	return cfg
+}
+
+// saveConfig writes the gateway configuration to storage.
+func saveConfig(storageDir string, cfg gatewayConfig) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(storageDir, configFile), data, 0644)
+}
+
+type gatewayState struct {
+	PID    int    `json:"pid"`
+	Driver string `json:"driver"`
+}
+
+func loadGatewayState(storageDir string) (gatewayState, error) {
+	data, err := os.ReadFile(filepath.Join(storageDir, gatewayStateFile))
+	if err != nil {
+		return gatewayState{}, err
+	}
+
+	var state gatewayState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return gatewayState{}, err
+	}
+	return state, nil
+}
+
+func saveGatewayState(storageDir string, state gatewayState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(storageDir, gatewayStateFile), data, 0644)
+}
+
+func removeGatewayState(storageDir string) {
+	os.Remove(filepath.Join(storageDir, gatewayStateFile))
+	os.Remove(filepath.Join(storageDir, gatewayPIDFile))
+}

--- a/pkg/runtime/openshell/config_test.go
+++ b/pkg/runtime/openshell/config_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_DefaultsWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadConfig(t.TempDir())
+
+	if cfg.Driver != DriverPodman {
+		t.Errorf("Expected default driver %q, got %q", DriverPodman, cfg.Driver)
+	}
+}
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	cfg := gatewayConfig{Driver: DriverVM}
+	if err := saveConfig(dir, cfg); err != nil {
+		t.Fatalf("saveConfig() failed: %v", err)
+	}
+
+	loaded := loadConfig(dir)
+	if loaded.Driver != DriverVM {
+		t.Errorf("Expected driver %q, got %q", DriverVM, loaded.Driver)
+	}
+}
+
+func TestLoadConfig_DefaultsWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Save config with empty driver
+	cfg := gatewayConfig{Driver: ""}
+	if err := saveConfig(dir, cfg); err != nil {
+		t.Fatalf("saveConfig() failed: %v", err)
+	}
+
+	loaded := loadConfig(dir)
+	if loaded.Driver != DriverPodman {
+		t.Errorf("Expected default driver %q for empty config, got %q", DriverPodman, loaded.Driver)
+	}
+}
+
+func TestLoadConfig_DefaultsWhenCorruptJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, configFile), []byte("not json{"), 0644); err != nil {
+		t.Fatalf("Failed to write corrupt config: %v", err)
+	}
+
+	cfg := loadConfig(dir)
+	if cfg.Driver != DriverPodman {
+		t.Errorf("Expected default driver for corrupt JSON, got %q", cfg.Driver)
+	}
+}
+
+func TestSaveConfig_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	for _, driver := range []string{DriverPodman, DriverVM} {
+		cfg := gatewayConfig{Driver: driver}
+		if err := saveConfig(dir, cfg); err != nil {
+			t.Fatalf("saveConfig(%q) failed: %v", driver, err)
+		}
+		loaded := loadConfig(dir)
+		if loaded.Driver != driver {
+			t.Errorf("Round trip: expected %q, got %q", driver, loaded.Driver)
+		}
+	}
+}
+
+func TestSaveConfig_ErrorOnUnwritableDir(t *testing.T) {
+	t.Parallel()
+
+	err := saveConfig("/nonexistent/path/that/does/not/exist", gatewayConfig{Driver: DriverPodman})
+	if err == nil {
+		t.Error("Expected error when directory does not exist")
+	}
+}

--- a/pkg/runtime/openshell/create.go
+++ b/pkg/runtime/openshell/create.go
@@ -1,0 +1,325 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/steplogger"
+)
+
+// Create creates a new OpenShell sandbox.
+func (r *openshellRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+	step := steplogger.FromContext(ctx)
+	defer step.Complete()
+
+	if err := validateCreateParams(params); err != nil {
+		return runtime.RuntimeInfo{}, err
+	}
+
+	driver := params.RuntimeOptions["openshell-driver"]
+	var allowHosts []string
+	if v := params.RuntimeOptions["openshell-allow-hosts"]; v != "" {
+		allowHosts = strings.Split(v, ",")
+	}
+
+	// Update driver in memory so ensureGatewayRunning uses the requested driver.
+	// Config is persisted only after the gateway starts successfully.
+	if driver != "" {
+		r.config.Driver = driver
+	}
+
+	// Ensure the gateway is running (may fail on driver conflict)
+	if err := r.ensureGatewayRunning(ctx); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to ensure gateway is running: %w", err)
+	}
+
+	if driver != "" {
+		if err := saveConfig(r.storageDir, r.config); err != nil {
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to save driver config: %w", err)
+		}
+	}
+
+	name := sandboxName(params.Name)
+	l := logger.FromContext(ctx)
+
+	// Collect ports from workspace config and agent defaults
+	ports := collectPorts(params)
+
+	// Create the sandbox
+	step.Start(fmt.Sprintf("Creating sandbox: %s", name), "Sandbox created")
+	if err := r.createSandbox(ctx, name, params.Agent, l); err != nil {
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to create sandbox: %w", err)
+	}
+
+	// Upload sources
+	step.Start("Uploading workspace sources", "Sources uploaded")
+	if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+		"sandbox", "upload", name, params.SourcePath, containerWorkspaceSources,
+	); err != nil {
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to upload sources: %w", err)
+	}
+
+	// Upload agent settings
+	if len(params.AgentSettings) > 0 {
+		step.Start("Uploading agent settings", "Agent settings uploaded")
+		if err := r.uploadAgentSettings(ctx, name, params.AgentSettings); err != nil {
+			step.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to upload agent settings: %w", err)
+		}
+	}
+
+	// Set environment variables
+	if err := r.writeEnvFile(ctx, name, params); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to write env file: %w", err)
+	}
+
+	// Persist sandbox metadata for Start() to re-read network config
+	if err := r.writeSandboxData(name, sandboxData{
+		SourcePath: params.SourcePath,
+		ProjectID:  params.ProjectID,
+		Agent:      params.Agent,
+		AllowHosts: allowHosts,
+		Ports:      ports,
+	}); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to persist sandbox data: %w", err)
+	}
+
+	// Configure network policy
+	step.Start("Configuring network policy", "Network policy configured")
+	if err := r.applyNetworkPolicy(ctx, name, params.WorkspaceConfig, allowHosts); err != nil {
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure network policy: %w", err)
+	}
+
+	// Mark as stopped — the manager will call Start separately
+	if err := r.states.Set(name, api.WorkspaceStateStopped); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to set initial state: %w", err)
+	}
+
+	info := map[string]string{
+		"sandbox_name": name,
+		"source_path":  params.SourcePath,
+		"agent":        params.Agent,
+	}
+	if len(ports) > 0 {
+		forwards := buildForwards(ports)
+		if forwardsJSON, err := json.Marshal(forwards); err == nil {
+			info["forwards"] = string(forwardsJSON)
+		}
+	}
+
+	return runtime.RuntimeInfo{
+		ID:    name,
+		State: api.WorkspaceStateStopped,
+		Info:  info,
+	}, nil
+}
+
+func validateCreateParams(params runtime.CreateParams) error {
+	if params.Name == "" {
+		return fmt.Errorf("%w: name is required", runtime.ErrInvalidParams)
+	}
+	if params.SourcePath == "" {
+		return fmt.Errorf("%w: source path is required", runtime.ErrInvalidParams)
+	}
+	if params.Agent == "" {
+		return fmt.Errorf("%w: agent is required", runtime.ErrInvalidParams)
+	}
+	return nil
+}
+
+const (
+	sandboxReadinessTimeout  = 2 * time.Minute
+	sandboxReadinessInterval = 3 * time.Second
+)
+
+// createSandbox creates a new sandbox and waits for it to become ready.
+// The create command may fail if the pod is still initializing when it tries
+// to CONNECT. In that case, poll with exec until the sandbox becomes reachable.
+func sandboxImage(agent string) (string, error) {
+	switch agent {
+	case "claude", "opencode", "codex", "copilot":
+		return "base", nil
+	case "gemini", "ollama":
+		return agent, nil
+	case "openclaw":
+		return "quay.io/openkaiden/openshell-openclaw:2026.5.4", nil
+	default:
+		return "", fmt.Errorf("%w: unsupported agent %q", runtime.ErrInvalidParams, agent)
+	}
+}
+
+func (r *openshellRuntime) createSandbox(ctx context.Context, name string, agent string, l logger.Logger) error {
+	args := []string{"sandbox", "create", "--name", name}
+	if r.config.Driver != DriverVM {
+		image, err := sandboxImage(agent)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--from", image)
+	}
+	args = append(args, "--no-tty", "--no-bootstrap", "--", "true")
+	err := r.executor.Run(ctx, l.Stdout(), l.Stderr(), args...)
+	if err == nil {
+		return nil
+	}
+
+	// Sandbox was created but SSH tunnel not ready yet — poll with exec
+	deadline := time.Now().Add(sandboxReadinessTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sandboxReadinessInterval):
+		}
+		if execErr := r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+			"sandbox", "exec", "--name", name, "--no-tty", "--", "true",
+		); execErr == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("sandbox did not become ready: %w", err)
+}
+
+// uploadAgentSettings writes agent settings files into the sandbox using sandbox upload.
+func (r *openshellRuntime) uploadAgentSettings(ctx context.Context, name string, settings map[string][]byte) error {
+	l := logger.FromContext(ctx)
+
+	for relPath, content := range settings {
+		tmpFile, err := os.CreateTemp("", "kdn-agent-setting-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp file for %s: %w", relPath, err)
+		}
+		tmpPath := tmpFile.Name()
+
+		if _, err := tmpFile.Write(content); err != nil {
+			tmpFile.Close()
+			os.Remove(tmpPath)
+			return fmt.Errorf("failed to write temp file for %s: %w", relPath, err)
+		}
+		tmpFile.Close()
+
+		destPath := path.Join(containerHome, relPath)
+		if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+			"sandbox", "upload", name, tmpPath, destPath,
+		); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("failed to upload %s: %w", relPath, err)
+		}
+		os.Remove(tmpPath)
+	}
+
+	return nil
+}
+
+// writeEnvFile writes environment variables to a file inside the sandbox using sandbox upload.
+func (r *openshellRuntime) writeEnvFile(ctx context.Context, name string, params runtime.CreateParams) error {
+	var envLines []string
+
+	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Environment != nil {
+		for _, env := range *params.WorkspaceConfig.Environment {
+			if env.Value != nil && *env.Value != "" {
+				envLines = append(envLines, fmt.Sprintf("export %s=%q", env.Name, *env.Value))
+			}
+		}
+	}
+
+	for k, v := range params.SecretEnvVars {
+		envLines = append(envLines, fmt.Sprintf("export %s=%q", k, v))
+	}
+
+	if len(envLines) == 0 {
+		return nil
+	}
+
+	tmpFile, err := os.CreateTemp("", "kdn-env-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	content := strings.Join(envLines, "\n") + "\n"
+	if _, err := tmpFile.WriteString(content); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write env file: %w", err)
+	}
+	tmpFile.Close()
+
+	destPath := path.Join(containerHome, ".kdn-env")
+	l := logger.FromContext(ctx)
+	return r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+		"sandbox", "upload", name, tmpPath, destPath,
+	)
+}
+
+const openclawDefaultPort = 18789
+
+// agentDefaultPorts returns ports that should be automatically forwarded for a given agent.
+var agentDefaultPorts = map[string][]int{
+	"openclaw": {openclawDefaultPort},
+}
+
+// collectPorts returns the deduplicated list of ports to forward, combining
+// workspace config ports with agent-specific defaults.
+func collectPorts(params runtime.CreateParams) []int {
+	seen := make(map[int]bool)
+	var ports []int
+
+	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Ports != nil {
+		for _, p := range *params.WorkspaceConfig.Ports {
+			if !seen[p] {
+				seen[p] = true
+				ports = append(ports, p)
+			}
+		}
+	}
+
+	for _, p := range agentDefaultPorts[params.Agent] {
+		if !seen[p] {
+			seen[p] = true
+			ports = append(ports, p)
+		}
+	}
+
+	return ports
+}
+
+// buildForwards creates WorkspaceForward entries for the given ports.
+// OpenShell uses the same port number on host and container sides.
+func buildForwards(ports []int) []api.WorkspaceForward {
+	forwards := make([]api.WorkspaceForward, len(ports))
+	for i, port := range ports {
+		forwards[i] = api.WorkspaceForward{
+			Bind:   "127.0.0.1",
+			Port:   port,
+			Target: port,
+		}
+	}
+	return forwards
+}

--- a/pkg/runtime/openshell/create_test.go
+++ b/pkg/runtime/openshell/create_test.go
@@ -1,0 +1,1042 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+type noopLogger struct{}
+
+func (noopLogger) Stdout() io.Writer { return io.Discard }
+func (noopLogger) Stderr() io.Writer { return io.Discard }
+
+func TestCreate_ValidatesParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params runtime.CreateParams
+	}{
+		{
+			name:   "missing name",
+			params: runtime.CreateParams{SourcePath: "/src", Agent: "claude"},
+		},
+		{
+			name:   "missing source path",
+			params: runtime.CreateParams{Name: "test", Agent: "claude"},
+		},
+		{
+			name:   "missing agent",
+			params: runtime.CreateParams{Name: "test", SourcePath: "/src"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeExec := exec.NewFake()
+			rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+			_, err := rt.Create(context.Background(), tt.params)
+			if err == nil {
+				t.Error("Expected validation error")
+			}
+		})
+	}
+}
+
+func TestCreate_Success(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	storageDir := t.TempDir()
+	_ = newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-my-project\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	params := runtime.CreateParams{
+		Name:       "my-project",
+		SourcePath: "/home/user/code",
+		Agent:      "claude",
+	}
+
+	// Since we can't easily mock the gateway check (it uses os/exec directly),
+	// we test the validation and command construction separately.
+	err := validateCreateParams(params)
+	if err != nil {
+		t.Fatalf("validateCreateParams() failed: %v", err)
+	}
+}
+
+func TestCreate_ReturnsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Verify that Create returns stopped state to match the manager's flow
+	info := runtime.RuntimeInfo{
+		ID:    "kdn-test",
+		State: api.WorkspaceStateStopped,
+		Info:  map[string]string{"sandbox_name": "kdn-test"},
+	}
+
+	if info.State != api.WorkspaceStateStopped {
+		t.Errorf("Expected state %q, got %q", api.WorkspaceStateStopped, info.State)
+	}
+}
+
+func TestCreateSandbox_PodmanIncludesFromBase(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = DriverPodman
+
+	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+
+	if len(fakeExec.RunCalls) < 1 {
+		t.Fatal("Expected at least 1 Run call")
+	}
+
+	call := fakeExec.RunCalls[0]
+	hasFrom := false
+	for i, arg := range call {
+		if arg == "--from" && i+1 < len(call) && call[i+1] == "base" {
+			hasFrom = true
+			break
+		}
+	}
+	if !hasFrom {
+		t.Errorf("Expected --from base in podman create args: %v", call)
+	}
+}
+
+func TestCreateSandbox_PodmanUsesAgentImage(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = DriverPodman
+
+	_ = rt.createSandbox(context.Background(), "kdn-test", "gemini", noopLogger{})
+
+	if len(fakeExec.RunCalls) < 1 {
+		t.Fatal("Expected at least 1 Run call")
+	}
+
+	call := fakeExec.RunCalls[0]
+	hasFrom := false
+	for i, arg := range call {
+		if arg == "--from" && i+1 < len(call) && call[i+1] == "gemini" {
+			hasFrom = true
+			break
+		}
+	}
+	if !hasFrom {
+		t.Errorf("Expected --from gemini in podman create args: %v", call)
+	}
+}
+
+func TestCreateSandbox_PodmanRejectsUnknownAgent(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = DriverPodman
+
+	err := rt.createSandbox(context.Background(), "kdn-test", "unknown-agent", noopLogger{})
+	if err == nil {
+		t.Error("Expected error for unsupported agent")
+	}
+}
+
+func TestSandboxImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		agent   string
+		want    string
+		wantErr bool
+	}{
+		{agent: "claude", want: "base"},
+		{agent: "opencode", want: "base"},
+		{agent: "codex", want: "base"},
+		{agent: "copilot", want: "base"},
+		{agent: "gemini", want: "gemini"},
+		{agent: "ollama", want: "ollama"},
+		{agent: "openclaw", want: "quay.io/openkaiden/openshell-openclaw:2026.5.4"},
+		{agent: "unknown", wantErr: true},
+		{agent: "foo", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.agent, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := sandboxImage(tt.agent)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("sandboxImage(%q) expected error, got %q", tt.agent, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("sandboxImage(%q) unexpected error: %v", tt.agent, err)
+			}
+			if got != tt.want {
+				t.Errorf("sandboxImage(%q) = %q, want %q", tt.agent, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateSandbox_VMOmitsFromBase(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = DriverVM
+
+	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+
+	if len(fakeExec.RunCalls) < 1 {
+		t.Fatal("Expected at least 1 Run call")
+	}
+
+	call := fakeExec.RunCalls[0]
+	for _, arg := range call {
+		if arg == "--from" {
+			t.Errorf("VM driver should not include --from in create args: %v", call)
+			break
+		}
+	}
+}
+
+func TestUploadAgentSettings_UsesSandboxUpload(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	settings := map[string][]byte{
+		".claude.json": []byte("{\n  \"key\": \"value\"\n}\n"),
+	}
+
+	err := rt.uploadAgentSettings(context.Background(), "kdn-test", settings)
+	if err != nil {
+		t.Fatalf("uploadAgentSettings() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+
+	call := fakeExec.RunCalls[0]
+
+	if len(call) < 4 {
+		t.Fatalf("Expected at least 4 args, got %d", len(call))
+	}
+	if call[0] != "sandbox" || call[1] != "upload" {
+		t.Errorf("Expected sandbox upload command, got %v", call[:2])
+	}
+	if call[2] != "kdn-test" {
+		t.Errorf("Expected sandbox name 'kdn-test', got %q", call[2])
+	}
+	expectedDest := "/sandbox/.claude.json"
+	if call[4] != expectedDest {
+		t.Errorf("Expected destination %q, got %q", expectedDest, call[4])
+	}
+}
+
+func TestWriteEnvFile_UsesSandboxUpload(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "test",
+		SourcePath: "/src",
+		Agent:      "claude",
+		SecretEnvVars: map[string]string{
+			"API_KEY": "secret123",
+		},
+	}
+
+	err := rt.writeEnvFile(context.Background(), "kdn-test", params)
+	if err != nil {
+		t.Fatalf("writeEnvFile() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+
+	call := fakeExec.RunCalls[0]
+
+	if call[0] != "sandbox" || call[1] != "upload" {
+		t.Errorf("Expected sandbox upload command, got %v", call[:2])
+	}
+	expectedEnvDest := "/sandbox/.kdn-env"
+	if call[4] != expectedEnvDest {
+		t.Errorf("Expected destination %q, got %q", expectedEnvDest, call[4])
+	}
+}
+
+func TestWriteEnvFile_WorkspaceConfigEnvVars(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	envValue := "bar"
+	envVars := []workspace.EnvironmentVariable{
+		{Name: "FOO", Value: &envValue},
+	}
+
+	params := runtime.CreateParams{
+		Name:       "test",
+		SourcePath: "/src",
+		Agent:      "claude",
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Environment: &envVars,
+		},
+	}
+
+	err := rt.writeEnvFile(context.Background(), "kdn-test", params)
+	if err != nil {
+		t.Fatalf("writeEnvFile() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestWriteEnvFile_SkipsEmptyValues(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	emptyValue := ""
+	envVars := []workspace.EnvironmentVariable{
+		{Name: "EMPTY", Value: &emptyValue},
+	}
+
+	params := runtime.CreateParams{
+		Name:       "test",
+		SourcePath: "/src",
+		Agent:      "claude",
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Environment: &envVars,
+		},
+	}
+
+	err := rt.writeEnvFile(context.Background(), "kdn-test", params)
+	if err != nil {
+		t.Fatalf("writeEnvFile() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 0 {
+		t.Errorf("Expected no Run calls when all env values are empty, got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestCreate_FullFlow_Success(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-my-project\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	params := runtime.CreateParams{
+		Name:       "my-project",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+	}
+
+	info, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateStopped {
+		t.Errorf("Expected stopped state, got %q", info.State)
+	}
+	if info.ID != "kdn-my-project" {
+		t.Errorf("Expected ID 'kdn-my-project', got %q", info.ID)
+	}
+	if info.Info["agent"] != "claude" {
+		t.Errorf("Expected agent 'claude', got %q", info.Info["agent"])
+	}
+}
+
+func TestCreate_FullFlow_WithAgentSettings(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-with-settings\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "with-settings",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+		AgentSettings: map[string][]byte{
+			".claude.json": []byte(`{"key": "value"}`),
+		},
+	}
+
+	info, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	if info.ID != "kdn-with-settings" {
+		t.Errorf("Expected ID 'kdn-with-settings', got %q", info.ID)
+	}
+}
+
+func TestCreate_FullFlow_WithEnvVars(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-env-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "env-test",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+		SecretEnvVars: map[string]string{
+			"API_KEY": "secret123",
+		},
+	}
+
+	info, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	if info.ID != "kdn-env-test" {
+		t.Errorf("Expected ID 'kdn-env-test', got %q", info.ID)
+	}
+}
+
+func TestCreate_FullFlow_PersistsDriverConfig(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-driver-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	params := runtime.CreateParams{
+		Name:       "driver-test",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+		RuntimeOptions: map[string]string{
+			"openshell-driver": DriverVM,
+		},
+	}
+
+	_, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Verify config was persisted
+	cfg := loadConfig(storageDir)
+	if cfg.Driver != DriverVM {
+		t.Errorf("Expected persisted driver %q, got %q", DriverVM, cfg.Driver)
+	}
+}
+
+func TestCreate_FullFlow_CreateSandboxError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "sandbox" && (args[1] == "create" || args[1] == "exec") {
+			return fmt.Errorf("create failed")
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	// Use a short-lived context so the retry loop in createSandbox exits quickly
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	params := runtime.CreateParams{
+		Name:       "fail-test",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+	}
+
+	_, err := rt.Create(ctx, params)
+	if err == nil {
+		t.Error("Expected error when sandbox creation fails")
+	}
+}
+
+func TestCreate_FullFlow_UploadSourcesError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "upload" {
+			return fmt.Errorf("upload failed")
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "upload-fail",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+	}
+
+	_, err := rt.Create(context.Background(), params)
+	if err == nil {
+		t.Error("Expected error when source upload fails")
+	}
+}
+
+func TestCreateSandbox_ReadinessTimeout(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		return fmt.Errorf("not ready yet")
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := rt.createSandbox(ctx, "kdn-test", "claude", noopLogger{})
+	if err == nil {
+		t.Error("Expected error when context is cancelled")
+	}
+}
+
+func TestCreateSandbox_RetriesUntilReady(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		callCount++
+		if callCount == 1 {
+			return fmt.Errorf("ssh not ready")
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	err := rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+	if err != nil {
+		t.Fatalf("createSandbox should succeed after retry: %v", err)
+	}
+	if callCount < 2 {
+		t.Errorf("Expected at least 2 calls (create + exec retry), got %d", callCount)
+	}
+}
+
+func TestCreateSandbox_SucceedsFirstTry(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+	if err != nil {
+		t.Fatalf("createSandbox should succeed on first try: %v", err)
+	}
+	if len(fakeExec.RunCalls) != 1 {
+		t.Errorf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestUploadAgentSettings_MultipleFiles(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	settings := map[string][]byte{
+		".claude.json":    []byte(`{"key": "value"}`),
+		"subdir/file.txt": []byte("nested file"),
+	}
+
+	err := rt.uploadAgentSettings(context.Background(), "kdn-test", settings)
+	if err != nil {
+		t.Fatalf("uploadAgentSettings() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 2 {
+		t.Fatalf("Expected 2 Run calls (one per file), got %d", len(fakeExec.RunCalls))
+	}
+
+	expectedDests := map[string]bool{
+		"/sandbox/.claude.json":    false,
+		"/sandbox/subdir/file.txt": false,
+	}
+	for _, call := range fakeExec.RunCalls {
+		if len(call) >= 5 {
+			expectedDests[call[4]] = true
+		}
+	}
+	for dest, found := range expectedDests {
+		if !found {
+			t.Errorf("Expected destination %q not found in upload calls", dest)
+		}
+	}
+}
+
+func TestUploadAgentSettings_Error(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		return fmt.Errorf("upload failed")
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	settings := map[string][]byte{
+		".claude.json": []byte(`{}`),
+	}
+
+	err := rt.uploadAgentSettings(context.Background(), "kdn-test", settings)
+	if err == nil {
+		t.Error("Expected error when upload fails")
+	}
+}
+
+func TestWriteEnvFile_EmptyNoCall(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "test",
+		SourcePath: "/src",
+		Agent:      "claude",
+	}
+
+	err := rt.writeEnvFile(context.Background(), "kdn-test", params)
+	if err != nil {
+		t.Fatalf("writeEnvFile() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 0 {
+		t.Errorf("Expected no Run calls for empty env, got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestWriteEnvFile_UploadError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		return fmt.Errorf("upload failed")
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "test",
+		SourcePath: "/src",
+		Agent:      "claude",
+		SecretEnvVars: map[string]string{
+			"KEY": "value",
+		},
+	}
+
+	err := rt.writeEnvFile(context.Background(), "kdn-test", params)
+	if err == nil {
+		t.Error("Expected error when upload fails")
+	}
+}
+
+func TestWriteEnvFile_NilEnvValue(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	envVars := []workspace.EnvironmentVariable{
+		{Name: "NO_VALUE", Value: nil},
+	}
+
+	params := runtime.CreateParams{
+		Name:       "test",
+		SourcePath: "/src",
+		Agent:      "claude",
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Environment: &envVars,
+		},
+	}
+
+	err := rt.writeEnvFile(context.Background(), "kdn-test", params)
+	if err != nil {
+		t.Fatalf("writeEnvFile() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 0 {
+		t.Errorf("Expected no Run calls for nil env value, got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestCreate_FullFlow_AgentSettingsUploadError(t *testing.T) {
+	t.Parallel()
+
+	uploadCount := 0
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "upload" {
+			uploadCount++
+			if uploadCount == 2 {
+				return fmt.Errorf("settings upload failed")
+			}
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	params := runtime.CreateParams{
+		Name:       "settings-fail",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+		AgentSettings: map[string][]byte{
+			".config": []byte("data"),
+		},
+	}
+
+	_, err := rt.Create(context.Background(), params)
+	if err == nil {
+		t.Error("Expected error when agent settings upload fails")
+	}
+}
+
+func TestCreate_FullFlow_DriverConflict_ConfigNotPersisted(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+
+	// Save initial config as podman
+	_ = saveConfig(storageDir, gatewayConfig{Driver: DriverPodman})
+	// Gateway running with podman and has active sandboxes
+	_ = saveGatewayState(storageDir, gatewayState{PID: 99999, Driver: DriverPodman})
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-existing\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	params := runtime.CreateParams{
+		Name:       "new-project",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+		RuntimeOptions: map[string]string{
+			"openshell-driver": DriverVM,
+		},
+	}
+
+	_, err := rt.Create(context.Background(), params)
+	if err == nil {
+		t.Fatal("Expected error for driver conflict")
+	}
+	if !strings.Contains(err.Error(), "cannot switch") {
+		t.Errorf("Expected driver conflict error, got: %v", err)
+	}
+
+	// Config should NOT have been overwritten to VM
+	cfg := loadConfig(storageDir)
+	if cfg.Driver != DriverPodman {
+		t.Errorf("Expected config to remain %q after conflict, got %q", DriverPodman, cfg.Driver)
+	}
+}
+
+func TestCollectPorts_FromWorkspaceConfig(t *testing.T) {
+	t.Parallel()
+
+	ports := []int{8080, 3000}
+	params := runtime.CreateParams{
+		Agent: "claude",
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Ports: &ports,
+		},
+	}
+
+	result := collectPorts(params)
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 ports, got %d", len(result))
+	}
+	if result[0] != 8080 || result[1] != 3000 {
+		t.Errorf("Expected [8080, 3000], got %v", result)
+	}
+}
+
+func TestCollectPorts_OpenclawAutoInjects(t *testing.T) {
+	t.Parallel()
+
+	params := runtime.CreateParams{
+		Agent: "openclaw",
+	}
+
+	result := collectPorts(params)
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 port for openclaw, got %d", len(result))
+	}
+	if result[0] != openclawDefaultPort {
+		t.Errorf("Expected port %d, got %d", openclawDefaultPort, result[0])
+	}
+}
+
+func TestCollectPorts_OpenclawDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	ports := []int{openclawDefaultPort, 3000}
+	params := runtime.CreateParams{
+		Agent: "openclaw",
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Ports: &ports,
+		},
+	}
+
+	result := collectPorts(params)
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 ports (deduplicated), got %d", len(result))
+	}
+	if result[0] != openclawDefaultPort || result[1] != 3000 {
+		t.Errorf("Expected [%d, 3000], got %v", openclawDefaultPort, result)
+	}
+}
+
+func TestCollectPorts_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	params := runtime.CreateParams{
+		Agent: "claude",
+	}
+
+	result := collectPorts(params)
+	if len(result) != 0 {
+		t.Errorf("Expected no ports for claude without config, got %v", result)
+	}
+}
+
+func TestBuildForwards(t *testing.T) {
+	t.Parallel()
+
+	forwards := buildForwards([]int{8080, 3000})
+	if len(forwards) != 2 {
+		t.Fatalf("Expected 2 forwards, got %d", len(forwards))
+	}
+	if forwards[0].Bind != "127.0.0.1" || forwards[0].Port != 8080 || forwards[0].Target != 8080 {
+		t.Errorf("Unexpected forward[0]: %+v", forwards[0])
+	}
+	if forwards[1].Bind != "127.0.0.1" || forwards[1].Port != 3000 || forwards[1].Target != 3000 {
+		t.Errorf("Unexpected forward[1]: %+v", forwards[1])
+	}
+}
+
+func TestCreate_FullFlow_WithPorts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	ports := []int{8080}
+	params := runtime.CreateParams{
+		Name:       "port-test",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+		WorkspaceConfig: &workspace.WorkspaceConfiguration{
+			Ports: &ports,
+		},
+	}
+
+	info, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	forwardsJSON, ok := info.Info["forwards"]
+	if !ok {
+		t.Fatal("Expected 'forwards' key in RuntimeInfo.Info")
+	}
+
+	var forwards []api.WorkspaceForward
+	if err := json.Unmarshal([]byte(forwardsJSON), &forwards); err != nil {
+		t.Fatalf("Failed to unmarshal forwards: %v", err)
+	}
+	if len(forwards) != 1 {
+		t.Fatalf("Expected 1 forward, got %d", len(forwards))
+	}
+	if forwards[0].Port != 8080 || forwards[0].Target != 8080 {
+		t.Errorf("Unexpected forward: %+v", forwards[0])
+	}
+}
+
+func TestCreate_FullFlow_OpenclawAutoPort(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	params := runtime.CreateParams{
+		Name:       "openclaw-test",
+		SourcePath: t.TempDir(),
+		Agent:      "openclaw",
+	}
+
+	info, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	forwardsJSON, ok := info.Info["forwards"]
+	if !ok {
+		t.Fatal("Expected 'forwards' key in RuntimeInfo.Info for openclaw")
+	}
+
+	var forwards []api.WorkspaceForward
+	if err := json.Unmarshal([]byte(forwardsJSON), &forwards); err != nil {
+		t.Fatalf("Failed to unmarshal forwards: %v", err)
+	}
+	if len(forwards) != 1 {
+		t.Fatalf("Expected 1 forward for openclaw, got %d", len(forwards))
+	}
+	if forwards[0].Port != openclawDefaultPort || forwards[0].Target != openclawDefaultPort {
+		t.Errorf("Expected port %d, got: %+v", openclawDefaultPort, forwards[0])
+	}
+}
+
+func TestCreate_FullFlow_NoPorts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	params := runtime.CreateParams{
+		Name:       "no-ports",
+		SourcePath: t.TempDir(),
+		Agent:      "claude",
+	}
+
+	info, err := rt.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if _, ok := info.Info["forwards"]; ok {
+		t.Error("Expected no 'forwards' key in RuntimeInfo.Info when no ports configured")
+	}
+}

--- a/pkg/runtime/openshell/download.go
+++ b/pkg/runtime/openshell/download.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+)
+
+const (
+	openshellGatewayRelease  = "dev"
+	openshellRelease         = "dev"
+	openshellDriverVMRelease = "vm-dev"
+	githubRepo               = "NVIDIA/OpenShell"
+)
+
+// platformAsset returns the asset name for the current platform.
+func platformAsset(binary string) (string, error) {
+	os := goruntime.GOOS
+	arch := goruntime.GOARCH
+
+	switch binary {
+	case "openshell-gateway":
+		switch {
+		case os == "darwin" && arch == "arm64":
+			return "openshell-gateway-aarch64-apple-darwin.tar.gz", nil
+		case os == "linux" && arch == "arm64":
+			return "openshell-gateway-aarch64-unknown-linux-gnu.tar.gz", nil
+		case os == "linux" && arch == "amd64":
+			return "openshell-gateway-x86_64-unknown-linux-gnu.tar.gz", nil
+		}
+	case "openshell":
+		switch {
+		case os == "darwin" && arch == "arm64":
+			return "openshell-aarch64-apple-darwin.tar.gz", nil
+		case os == "linux" && arch == "arm64":
+			return "openshell-aarch64-unknown-linux-musl.tar.gz", nil
+		case os == "linux" && arch == "amd64":
+			return "openshell-x86_64-unknown-linux-musl.tar.gz", nil
+		}
+	case "openshell-driver-vm":
+		switch {
+		case os == "darwin" && arch == "arm64":
+			return "openshell-driver-vm-aarch64-apple-darwin.tar.gz", nil
+		case os == "linux" && arch == "arm64":
+			return "openshell-driver-vm-aarch64-unknown-linux-gnu.tar.gz", nil
+		case os == "linux" && arch == "amd64":
+			return "openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz", nil
+		}
+	}
+
+	return "", fmt.Errorf("unsupported platform %s/%s for binary %s", os, arch, binary)
+}
+
+// downloadURL returns the GitHub release download URL for an asset.
+func downloadURL(tag, asset string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, asset)
+}
+
+// ensureBinary downloads a binary if it doesn't exist in the bin directory.
+func ensureBinary(binDir, binary, releaseTag string) (string, error) {
+	binaryPath := filepath.Join(binDir, binary)
+
+	if _, err := os.Stat(binaryPath); err == nil {
+		return binaryPath, nil
+	}
+
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
+	asset, err := platformAsset(binary)
+	if err != nil {
+		return "", err
+	}
+
+	url := downloadURL(releaseTag, asset)
+	if err := downloadAndExtract(url, binDir, binary); err != nil {
+		return "", fmt.Errorf("failed to download %s: %w", binary, err)
+	}
+
+	return binaryPath, nil
+}
+
+// downloadAndExtract downloads a tar.gz from the URL and extracts the named binary.
+func downloadAndExtract(url, destDir, binaryName string) error {
+	resp, err := http.Get(url) //nolint:gosec,noctx
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with status %d for %s", resp.StatusCode, url)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar entry: %w", err)
+		}
+
+		// Extract only the target binary (may be nested in a directory)
+		name := filepath.Base(header.Name)
+		if header.Typeflag != tar.TypeReg || !strings.HasPrefix(name, binaryName) {
+			continue
+		}
+		if name != binaryName {
+			continue
+		}
+
+		destPath := filepath.Join(destDir, binaryName)
+		out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+		if err != nil {
+			return fmt.Errorf("failed to create file %s: %w", destPath, err)
+		}
+
+		if _, err := io.Copy(out, tr); err != nil { //nolint:gosec
+			out.Close()
+			return fmt.Errorf("failed to write file %s: %w", destPath, err)
+		}
+		out.Close()
+		return nil
+	}
+
+	return fmt.Errorf("binary %s not found in archive", binaryName)
+}

--- a/pkg/runtime/openshell/download_test.go
+++ b/pkg/runtime/openshell/download_test.go
@@ -1,0 +1,536 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPlatformAsset_Gateway(t *testing.T) {
+	t.Parallel()
+
+	asset, err := platformAsset("openshell-gateway")
+
+	// On supported platforms (darwin/arm64, linux/arm64, linux/amd64) this should succeed
+	if err != nil {
+		t.Skipf("Platform not supported for openshell-gateway: %v", err)
+	}
+
+	if !strings.HasPrefix(asset, "openshell-gateway-") {
+		t.Errorf("Expected asset name to start with 'openshell-gateway-', got %q", asset)
+	}
+	if !strings.HasSuffix(asset, ".tar.gz") {
+		t.Errorf("Expected asset name to end with '.tar.gz', got %q", asset)
+	}
+}
+
+func TestPlatformAsset_Openshell(t *testing.T) {
+	t.Parallel()
+
+	asset, err := platformAsset("openshell")
+	if err != nil {
+		t.Skipf("Platform not supported for openshell: %v", err)
+	}
+
+	if !strings.HasPrefix(asset, "openshell-") {
+		t.Errorf("Expected asset name to start with 'openshell-', got %q", asset)
+	}
+	if !strings.HasSuffix(asset, ".tar.gz") {
+		t.Errorf("Expected asset name to end with '.tar.gz', got %q", asset)
+	}
+}
+
+func TestPlatformAsset_VMDriver(t *testing.T) {
+	t.Parallel()
+
+	asset, err := platformAsset("openshell-driver-vm")
+	if err != nil {
+		t.Skipf("Platform not supported for openshell-driver-vm: %v", err)
+	}
+
+	if !strings.HasPrefix(asset, "openshell-driver-vm-") {
+		t.Errorf("Expected asset name to start with 'openshell-driver-vm-', got %q", asset)
+	}
+	if !strings.HasSuffix(asset, ".tar.gz") {
+		t.Errorf("Expected asset name to end with '.tar.gz', got %q", asset)
+	}
+}
+
+func TestPlatformAsset_UnknownBinary(t *testing.T) {
+	t.Parallel()
+
+	_, err := platformAsset("nonexistent-binary")
+	if err == nil {
+		t.Error("Expected error for unknown binary name")
+	}
+	if !strings.Contains(err.Error(), "unsupported platform") {
+		t.Errorf("Expected 'unsupported platform' error, got: %v", err)
+	}
+}
+
+func TestDownloadURL(t *testing.T) {
+	t.Parallel()
+
+	url := downloadURL("v1.0.0", "openshell-gateway-x86_64.tar.gz")
+
+	expected := "https://github.com/NVIDIA/OpenShell/releases/download/v1.0.0/openshell-gateway-x86_64.tar.gz"
+	if url != expected {
+		t.Errorf("Expected URL %q, got %q", expected, url)
+	}
+}
+
+func TestEnsureBinary_SkipsExisting(t *testing.T) {
+	t.Parallel()
+
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "openshell-gateway")
+
+	if err := os.WriteFile(binaryPath, []byte("fake binary"), 0755); err != nil {
+		t.Fatalf("Failed to create fake binary: %v", err)
+	}
+
+	path, err := ensureBinary(binDir, "openshell-gateway", "dev")
+	if err != nil {
+		t.Fatalf("ensureBinary() should succeed for existing binary: %v", err)
+	}
+	if path != binaryPath {
+		t.Errorf("Expected path %q, got %q", binaryPath, path)
+	}
+}
+
+func createTarGz(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for name, content := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0755,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatalf("Failed to write tar header: %v", err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("Failed to write tar content: %v", err)
+		}
+	}
+
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}
+
+func TestDownloadAndExtract_Success(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("#!/bin/sh\necho hello\n")
+	archive := createTarGz(t, map[string][]byte{
+		"my-binary": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "my-binary")
+	if err != nil {
+		t.Fatalf("downloadAndExtract() failed: %v", err)
+	}
+
+	extracted, err := os.ReadFile(filepath.Join(destDir, "my-binary"))
+	if err != nil {
+		t.Fatalf("Failed to read extracted binary: %v", err)
+	}
+	if !bytes.Equal(extracted, binaryContent) {
+		t.Errorf("Extracted content mismatch: got %q, want %q", extracted, binaryContent)
+	}
+}
+
+func TestDownloadAndExtract_NestedBinary(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("nested binary")
+	archive := createTarGz(t, map[string][]byte{
+		"subdir/my-binary": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "my-binary")
+	if err != nil {
+		t.Fatalf("downloadAndExtract() failed: %v", err)
+	}
+
+	extracted, err := os.ReadFile(filepath.Join(destDir, "my-binary"))
+	if err != nil {
+		t.Fatalf("Failed to read extracted binary: %v", err)
+	}
+	if !bytes.Equal(extracted, binaryContent) {
+		t.Errorf("Extracted content mismatch")
+	}
+}
+
+func TestDownloadAndExtract_BinaryNotInArchive(t *testing.T) {
+	t.Parallel()
+
+	archive := createTarGz(t, map[string][]byte{
+		"other-binary": []byte("not the one"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "my-binary")
+	if err == nil {
+		t.Error("Expected error when binary not found in archive")
+	}
+	if !strings.Contains(err.Error(), "not found in archive") {
+		t.Errorf("Expected 'not found in archive' error, got: %v", err)
+	}
+}
+
+func TestDownloadAndExtract_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "my-binary")
+	if err == nil {
+		t.Error("Expected error for HTTP 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("Expected status code in error, got: %v", err)
+	}
+}
+
+func TestDownloadAndExtract_InvalidGzip(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not a gzip file"))
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "my-binary")
+	if err == nil {
+		t.Error("Expected error for invalid gzip")
+	}
+}
+
+func TestDownloadAndExtract_ConnectionError(t *testing.T) {
+	t.Parallel()
+
+	err := downloadAndExtract("http://127.0.0.1:1/unreachable.tar.gz", t.TempDir(), "my-binary")
+	if err == nil {
+		t.Error("Expected error for connection failure")
+	}
+}
+
+func TestEnsureBinary_Downloads(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("#!/bin/sh\necho hello\n")
+	archive := createTarGz(t, map[string][]byte{
+		"test-binary": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	binDir := t.TempDir()
+
+	// Temporarily override downloadURL by calling downloadAndExtract directly
+	// since ensureBinary constructs a GitHub URL we can't intercept.
+	// Instead, test the download path by calling downloadAndExtract + verifying ensureBinary finds the result.
+	err := downloadAndExtract(server.URL+"/test.tar.gz", binDir, "test-binary")
+	if err != nil {
+		t.Fatalf("downloadAndExtract() failed: %v", err)
+	}
+
+	// Now ensureBinary should find it
+	path, err := ensureBinary(binDir, "test-binary", "unused")
+	if err != nil {
+		t.Fatalf("ensureBinary() failed after download: %v", err)
+	}
+	if filepath.Base(path) != "test-binary" {
+		t.Errorf("Expected binary name 'test-binary', got %q", filepath.Base(path))
+	}
+}
+
+func TestEnsureBinary_CreatesDir(t *testing.T) {
+	t.Parallel()
+
+	parentDir := t.TempDir()
+	binDir := filepath.Join(parentDir, "bin", "nested")
+
+	binaryContent := []byte("binary")
+	archive := createTarGz(t, map[string][]byte{
+		"openshell-gateway": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	// Pre-create the binary so ensureBinary doesn't try to download from GitHub
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("Failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "openshell-gateway"), binaryContent, 0755); err != nil {
+		t.Fatalf("Failed to write binary: %v", err)
+	}
+
+	path, err := ensureBinary(binDir, "openshell-gateway", "dev")
+	if err != nil {
+		t.Fatalf("ensureBinary() failed: %v", err)
+	}
+
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("Binary not found at %q: %v", path, statErr)
+	}
+}
+
+func TestDownloadAndExtract_SkipsPrefixMatchNonExact(t *testing.T) {
+	t.Parallel()
+
+	archive := createTarGz(t, map[string][]byte{
+		"my-binary-extra": []byte("wrong binary"),
+		"my-binary":       []byte("right binary"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "my-binary")
+	if err != nil {
+		t.Fatalf("downloadAndExtract() failed: %v", err)
+	}
+
+	extracted, err := os.ReadFile(filepath.Join(destDir, "my-binary"))
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	if string(extracted) != "right binary" {
+		t.Errorf("Expected 'right binary', got %q", extracted)
+	}
+}
+
+func TestDownloadURL_VariousInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tag      string
+		asset    string
+		expected string
+	}{
+		{"v1.0.0", "openshell-gateway-x86_64.tar.gz",
+			"https://github.com/NVIDIA/OpenShell/releases/download/v1.0.0/openshell-gateway-x86_64.tar.gz"},
+		{"dev", "openshell-aarch64-apple-darwin.tar.gz",
+			"https://github.com/NVIDIA/OpenShell/releases/download/dev/openshell-aarch64-apple-darwin.tar.gz"},
+	}
+
+	for _, tt := range tests {
+		url := downloadURL(tt.tag, tt.asset)
+		if url != tt.expected {
+			t.Errorf("downloadURL(%q, %q) = %q, want %q", tt.tag, tt.asset, url, tt.expected)
+		}
+	}
+}
+
+func TestPlatformAsset_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	_, err := platformAsset("nonexistent")
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "unsupported platform") {
+		t.Errorf("Expected 'unsupported platform' in error, got: %v", err)
+	}
+	if !strings.Contains(errMsg, "nonexistent") {
+		t.Errorf("Expected binary name in error, got: %v", err)
+	}
+}
+
+func TestEnsureBinary_UnsupportedPlatformBinary(t *testing.T) {
+	t.Parallel()
+
+	binDir := t.TempDir()
+	_, err := ensureBinary(binDir, "nonexistent-binary", "v1.0.0")
+	if err == nil {
+		t.Error("Expected error for unsupported platform binary")
+	}
+	if !strings.Contains(err.Error(), "unsupported platform") {
+		t.Errorf("Expected 'unsupported platform' error, got: %v", err)
+	}
+}
+
+func TestDownloadAndExtract_EmptyArchive(t *testing.T) {
+	t.Parallel()
+
+	archive := createTarGz(t, map[string][]byte{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	err := downloadAndExtract(server.URL+"/empty.tar.gz", t.TempDir(), "my-binary")
+	if err == nil {
+		t.Error("Expected error for empty archive")
+	}
+	if !strings.Contains(err.Error(), "not found in archive") {
+		t.Errorf("Expected 'not found in archive' error, got: %v", err)
+	}
+}
+
+func TestDownloadAndExtract_InvalidDestDir(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("binary")
+	archive := createTarGz(t, map[string][]byte{
+		"my-binary": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	err := downloadAndExtract(server.URL+"/test.tar.gz", "/nonexistent/path/to/nowhere", "my-binary")
+	if err == nil {
+		t.Error("Expected error for invalid destination directory")
+	}
+}
+
+func TestEnsureBinary_VerifiesFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions are not enforced on Windows")
+	}
+
+	binaryContent := []byte("binary content")
+	archive := createTarGz(t, map[string][]byte{
+		"test-perm-binary": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	if err := downloadAndExtract(server.URL+"/test.tar.gz", destDir, "test-perm-binary"); err != nil {
+		t.Fatalf("downloadAndExtract failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(destDir, "test-perm-binary"))
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+
+	mode := info.Mode().Perm()
+	if mode&0100 == 0 {
+		t.Errorf("Expected executable permission, got %o", mode)
+	}
+}
+
+func TestDownloadAndExtract_LargeFile(t *testing.T) {
+	t.Parallel()
+
+	largeContent := bytes.Repeat([]byte("x"), 1024*1024)
+	archive := createTarGz(t, map[string][]byte{
+		"large-binary": largeContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/large.tar.gz", destDir, "large-binary")
+	if err != nil {
+		t.Fatalf("downloadAndExtract() failed: %v", err)
+	}
+
+	extracted, err := os.ReadFile(filepath.Join(destDir, "large-binary"))
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	if len(extracted) != len(largeContent) {
+		t.Errorf("Size mismatch: got %d, want %d", len(extracted), len(largeContent))
+	}
+}
+
+func TestDownloadAndExtract_ServerPath(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("binary data")
+	archive := createTarGz(t, map[string][]byte{
+		"my-binary": binaryContent,
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/releases/download/v1.0.0/my-binary.tar.gz"
+		if r.URL.Path != expectedPath {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, "not found: %s", r.URL.Path)
+			return
+		}
+		w.Write(archive)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := downloadAndExtract(server.URL+"/releases/download/v1.0.0/my-binary.tar.gz", destDir, "my-binary")
+	if err != nil {
+		t.Fatalf("downloadAndExtract() failed: %v", err)
+	}
+}

--- a/pkg/runtime/openshell/exec/exec.go
+++ b/pkg/runtime/openshell/exec/exec.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package exec provides an abstraction for executing openshell commands.
+package exec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Executor provides an interface for executing openshell commands.
+type Executor interface {
+	// BinaryPath returns the path to the openshell binary.
+	BinaryPath() string
+
+	// Run executes an openshell command, writing stdout and stderr to the provided writers.
+	Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error
+
+	// Output executes an openshell command and returns its standard output.
+	Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error)
+
+	// RunInteractive executes an openshell command with stdin/stdout/stderr connected to the terminal.
+	RunInteractive(ctx context.Context, args ...string) error
+}
+
+// executor is the default implementation of Executor.
+type executor struct {
+	binaryPath string
+}
+
+// Ensure executor implements Executor at compile time.
+var _ Executor = (*executor)(nil)
+
+// New creates a new Executor instance that runs the given binary.
+func New(binaryPath string) Executor {
+	return &executor{binaryPath: binaryPath}
+}
+
+// BinaryPath returns the path to the openshell binary.
+func (e *executor) BinaryPath() string {
+	return e.binaryPath
+}
+
+// Run executes an openshell command, writing stdout and stderr to the provided writers.
+// When both stdout and stderr are nil, no pipes are created — safe for commands
+// that daemonize (e.g. forward start --background).
+func (e *executor) Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
+	if stderr != nil {
+		fmt.Fprintf(stderr, "$ %s %s\n", e.binaryPath, strings.Join(args, " "))
+	}
+	var stderrBuf bytes.Buffer
+	cmd := exec.CommandContext(ctx, e.binaryPath, args...)
+	if stdout != nil {
+		cmd.Stdout = stdout
+	}
+	if stderr != nil {
+		cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
+	}
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderrBuf.String()); msg != "" {
+			return fmt.Errorf("%w\nopenshell stderr:\n%s", err, msg)
+		}
+		return err
+	}
+	return nil
+}
+
+// Output executes an openshell command and returns its standard output.
+func (e *executor) Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error) {
+	fmt.Fprintf(stderr, "$ %s %s\n", e.binaryPath, strings.Join(args, " "))
+	var stderrBuf bytes.Buffer
+	cmd := exec.CommandContext(ctx, e.binaryPath, args...)
+	cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderrBuf.String()); msg != "" {
+			return out, fmt.Errorf("%w\nopenshell stderr:\n%s", err, msg)
+		}
+		return out, err
+	}
+	return out, nil
+}
+
+// RunInteractive executes an openshell command with stdin/stdout/stderr connected to the terminal.
+func (e *executor) RunInteractive(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, e.binaryPath, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/pkg/runtime/openshell/exec/exec_test.go
+++ b/pkg/runtime/openshell/exec/exec_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func echoCommand() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", "echo", "hello"}
+	}
+	return "echo", []string{"hello"}
+}
+
+func falseCommand() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", "exit", "1"}
+	}
+	return "false", nil
+}
+
+func stderrFailScript(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(dir, "fail.bat")
+		if err := os.WriteFile(script, []byte("@echo off\r\necho error message 1>&2\r\nexit /b 1\r\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		return script
+	}
+	script := filepath.Join(dir, "fail.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 'error message' >&2\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	e := New("/usr/bin/openshell")
+	if e.BinaryPath() != "/usr/bin/openshell" {
+		t.Errorf("BinaryPath() = %q, want %q", e.BinaryPath(), "/usr/bin/openshell")
+	}
+}
+
+func TestExecutor_Run_Success(t *testing.T) {
+	t.Parallel()
+
+	bin, args := echoCommand()
+	e := New(bin)
+	var stdout, stderr bytes.Buffer
+	err := e.Run(context.Background(), &stdout, &stderr, args...)
+	if err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "hello") {
+		t.Errorf("Expected stdout to contain 'hello', got %q", stdout.String())
+	}
+}
+
+func TestExecutor_Run_Failure(t *testing.T) {
+	t.Parallel()
+
+	bin, args := falseCommand()
+	e := New(bin)
+	var stdout, stderr bytes.Buffer
+	err := e.Run(context.Background(), &stdout, &stderr, args...)
+	if err == nil {
+		t.Error("Expected error from failing command")
+	}
+}
+
+func TestExecutor_Run_NonexistentBinary(t *testing.T) {
+	t.Parallel()
+
+	e := New("/nonexistent/binary/path")
+	var stdout, stderr bytes.Buffer
+	err := e.Run(context.Background(), &stdout, &stderr)
+	if err == nil {
+		t.Error("Expected error for nonexistent binary")
+	}
+}
+
+func TestExecutor_Output_Success(t *testing.T) {
+	t.Parallel()
+
+	bin, args := echoCommand()
+	e := New(bin)
+	var stderr bytes.Buffer
+	out, err := e.Output(context.Background(), &stderr, args...)
+	if err != nil {
+		t.Fatalf("Output() failed: %v", err)
+	}
+	if !strings.Contains(string(out), "hello") {
+		t.Errorf("Expected 'hello', got %q", out)
+	}
+}
+
+func TestExecutor_Output_Failure(t *testing.T) {
+	t.Parallel()
+
+	bin, args := falseCommand()
+	e := New(bin)
+	var stderr bytes.Buffer
+	_, err := e.Output(context.Background(), &stderr, args...)
+	if err == nil {
+		t.Error("Expected error from failing command")
+	}
+}
+
+func TestExecutor_Output_NonexistentBinary(t *testing.T) {
+	t.Parallel()
+
+	e := New("/nonexistent/binary/path")
+	var stderr bytes.Buffer
+	_, err := e.Output(context.Background(), &stderr)
+	if err == nil {
+		t.Error("Expected error for nonexistent binary")
+	}
+}
+
+func TestExecutor_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	bin, _ := echoCommand()
+	e := New(bin)
+	var stdout, stderr bytes.Buffer
+	err := e.Run(ctx, &stdout, &stderr, "test")
+	if err == nil {
+		t.Error("Expected error for cancelled context")
+	}
+}
+
+func TestFakeExecutor_BinaryPath(t *testing.T) {
+	t.Parallel()
+
+	f := NewFake()
+	if f.BinaryPath() != "/fake/openshell" {
+		t.Errorf("BinaryPath() = %q, want '/fake/openshell'", f.BinaryPath())
+	}
+}
+
+func TestFakeExecutor_Run_Default(t *testing.T) {
+	t.Parallel()
+
+	f := NewFake()
+	err := f.Run(context.Background(), nil, nil, "test", "args")
+	if err != nil {
+		t.Fatalf("Run() should succeed by default: %v", err)
+	}
+
+	if len(f.RunCalls) != 1 {
+		t.Fatalf("Expected 1 RunCall, got %d", len(f.RunCalls))
+	}
+	if f.RunCalls[0][0] != "test" || f.RunCalls[0][1] != "args" {
+		t.Errorf("Expected args [test args], got %v", f.RunCalls[0])
+	}
+}
+
+func TestFakeExecutor_Output_Default(t *testing.T) {
+	t.Parallel()
+
+	f := NewFake()
+	out, err := f.Output(context.Background(), nil, "sandbox", "list")
+	if err != nil {
+		t.Fatalf("Output() should succeed by default: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("Expected empty output, got %q", out)
+	}
+
+	if len(f.OutputCalls) != 1 {
+		t.Fatalf("Expected 1 OutputCall, got %d", len(f.OutputCalls))
+	}
+}
+
+func TestFakeExecutor_RunInteractive_Default(t *testing.T) {
+	t.Parallel()
+
+	f := NewFake()
+	err := f.RunInteractive(context.Background(), "sandbox", "connect")
+	if err != nil {
+		t.Fatalf("RunInteractive() should succeed by default: %v", err)
+	}
+
+	if len(f.RunInteractiveCalls) != 1 {
+		t.Fatalf("Expected 1 RunInteractiveCall, got %d", len(f.RunInteractiveCalls))
+	}
+}
+
+func TestFakeExecutor_CustomFuncs(t *testing.T) {
+	t.Parallel()
+
+	f := NewFake()
+	f.RunFunc = func(_ context.Context, args ...string) error {
+		return nil
+	}
+	f.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("custom output"), nil
+	}
+	f.RunInteractiveFunc = func(_ context.Context, args ...string) error {
+		return nil
+	}
+
+	_ = f.Run(context.Background(), nil, nil, "test")
+	out, _ := f.Output(context.Background(), nil, "test")
+	_ = f.RunInteractive(context.Background(), "test")
+
+	if string(out) != "custom output" {
+		t.Errorf("Expected 'custom output', got %q", out)
+	}
+}
+
+func TestFakeExecutor_TracksCalls(t *testing.T) {
+	t.Parallel()
+
+	f := NewFake()
+	_ = f.Run(context.Background(), nil, nil, "cmd1")
+	_ = f.Run(context.Background(), nil, nil, "cmd2")
+	_, _ = f.Output(context.Background(), nil, "cmd3")
+	_ = f.RunInteractive(context.Background(), "cmd4")
+
+	if len(f.RunCalls) != 2 {
+		t.Errorf("Expected 2 RunCalls, got %d", len(f.RunCalls))
+	}
+	if len(f.OutputCalls) != 1 {
+		t.Errorf("Expected 1 OutputCall, got %d", len(f.OutputCalls))
+	}
+	if len(f.RunInteractiveCalls) != 1 {
+		t.Errorf("Expected 1 RunInteractiveCall, got %d", len(f.RunInteractiveCalls))
+	}
+}
+
+func TestExecutor_Run_StderrInError(t *testing.T) {
+	t.Parallel()
+
+	script := stderrFailScript(t)
+	e := New(script)
+	var stdout, stderr bytes.Buffer
+	err := e.Run(context.Background(), &stdout, &stderr)
+	if err == nil {
+		t.Fatal("Expected error from failing script")
+	}
+	if !strings.Contains(err.Error(), "error message") {
+		t.Errorf("Expected stderr in error message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "openshell stderr:") {
+		t.Errorf("Expected 'openshell stderr:' prefix in error, got: %v", err)
+	}
+}
+
+func TestExecutor_Output_StderrInError(t *testing.T) {
+	t.Parallel()
+
+	script := stderrFailScript(t)
+	e := New(script)
+	var stderr bytes.Buffer
+	_, err := e.Output(context.Background(), &stderr)
+	if err == nil {
+		t.Fatal("Expected error from failing script")
+	}
+	if !strings.Contains(err.Error(), "error message") {
+		t.Errorf("Expected stderr in error message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "openshell stderr:") {
+		t.Errorf("Expected 'openshell stderr:' prefix in error, got: %v", err)
+	}
+}

--- a/pkg/runtime/openshell/exec/fake.go
+++ b/pkg/runtime/openshell/exec/fake.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"io"
+)
+
+// FakeExecutor is a fake implementation of Executor for testing.
+type FakeExecutor struct {
+	// RunFunc is called when Run is invoked. If nil, Run returns nil.
+	RunFunc func(ctx context.Context, args ...string) error
+
+	// OutputFunc is called when Output is invoked. If nil, Output returns empty bytes.
+	OutputFunc func(ctx context.Context, args ...string) ([]byte, error)
+
+	// RunInteractiveFunc is called when RunInteractive is invoked. If nil, RunInteractive returns nil.
+	RunInteractiveFunc func(ctx context.Context, args ...string) error
+
+	// RunCalls tracks all calls to Run with their arguments.
+	RunCalls [][]string
+
+	// OutputCalls tracks all calls to Output with their arguments.
+	OutputCalls [][]string
+
+	// RunInteractiveCalls tracks all calls to RunInteractive with their arguments.
+	RunInteractiveCalls [][]string
+}
+
+// BinaryPath is the path returned by BinaryPath(). Set in tests if needed.
+func (f *FakeExecutor) BinaryPath() string {
+	return "/fake/openshell"
+}
+
+// Ensure FakeExecutor implements Executor at compile time.
+var _ Executor = (*FakeExecutor)(nil)
+
+// NewFake creates a new FakeExecutor.
+func NewFake() *FakeExecutor {
+	return &FakeExecutor{
+		RunCalls:            make([][]string, 0),
+		OutputCalls:         make([][]string, 0),
+		RunInteractiveCalls: make([][]string, 0),
+	}
+}
+
+// Run executes the RunFunc if set, otherwise returns nil.
+func (f *FakeExecutor) Run(ctx context.Context, stdout, stderr io.Writer, args ...string) error {
+	f.RunCalls = append(f.RunCalls, args)
+	if f.RunFunc != nil {
+		return f.RunFunc(ctx, args...)
+	}
+	return nil
+}
+
+// Output executes the OutputFunc if set, otherwise returns empty bytes.
+func (f *FakeExecutor) Output(ctx context.Context, stderr io.Writer, args ...string) ([]byte, error) {
+	f.OutputCalls = append(f.OutputCalls, args)
+	if f.OutputFunc != nil {
+		return f.OutputFunc(ctx, args...)
+	}
+	return []byte{}, nil
+}
+
+// RunInteractive executes the RunInteractiveFunc if set, otherwise returns nil.
+func (f *FakeExecutor) RunInteractive(ctx context.Context, args ...string) error {
+	f.RunInteractiveCalls = append(f.RunInteractiveCalls, args)
+	if f.RunInteractiveFunc != nil {
+		return f.RunInteractiveFunc(ctx, args...)
+	}
+	return nil
+}

--- a/pkg/runtime/openshell/gateway.go
+++ b/pkg/runtime/openshell/gateway.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/openkaiden/kdn/pkg/steplogger"
+)
+
+const (
+	gatewayPIDFile           = "gateway.pid"
+	gatewayLogFile           = "gateway.log"
+	gatewayReadinessTimeout  = 5 * time.Minute
+	gatewayReadinessInterval = 3 * time.Second
+	gatewayPort              = "8080"
+	gatewayURL               = "http://127.0.0.1:" + gatewayPort
+	supervisorImage          = "quay.io/fbenoit/openshell-supervisor:2026-04-29"
+)
+
+// isGatewayReady checks whether the OpenShell gateway is reachable by
+// attempting to list sandboxes. This validates the full stack: gateway running
+// and responding to sandbox operations.
+func (r *openshellRuntime) isGatewayReady(ctx context.Context) bool {
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := r.executor.Output(checkCtx, io.Discard, "sandbox", "list", "--names")
+	return err == nil
+}
+
+// stopGateway terminates the running gateway process and cleans up state files.
+func (r *openshellRuntime) stopGateway(ctx context.Context) error {
+	state, err := loadGatewayState(r.storageDir)
+	if err != nil || state.PID <= 0 {
+		removeGatewayState(r.storageDir)
+		return nil
+	}
+
+	process, err := os.FindProcess(state.PID)
+	if err != nil {
+		removeGatewayState(r.storageDir)
+		return nil
+	}
+
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		removeGatewayState(r.storageDir)
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = process.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = process.Kill()
+	}
+
+	removeGatewayState(r.storageDir)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !r.isGatewayReady(ctx) {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return nil
+}
+
+// hasActiveSandboxes returns true if there are kdn-managed sandboxes on the running gateway.
+func (r *openshellRuntime) hasActiveSandboxes(ctx context.Context) bool {
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	output, err := r.executor.Output(checkCtx, io.Discard, "sandbox", "list", "--names")
+	if err != nil {
+		return false
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), sandboxNamePrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureGatewayRunning starts the OpenShell Gateway if it is not already running,
+// then waits for the gateway to become ready.
+func (r *openshellRuntime) ensureGatewayRunning(ctx context.Context) error {
+	// Download binaries on first use (deferred from Initialize to avoid
+	// network calls during runtime registration).
+	if err := r.ensureBinaries(); err != nil {
+		return err
+	}
+
+	// Always ensure the gateway is registered with the CLI, even if it's
+	// already running (the CLI config may have been lost across restarts).
+	_ = r.ensureGatewayRegistered(ctx)
+
+	if r.isGatewayReady(ctx) {
+		running, loadErr := loadGatewayState(r.storageDir)
+		if loadErr == nil && running.Driver != "" && running.Driver != r.config.Driver {
+			if r.hasActiveSandboxes(ctx) {
+				return fmt.Errorf(
+					"cannot switch from %q to %q driver: the gateway is running with the %q driver "+
+						"and has active sandboxes\n"+
+						"Remove existing openshell workspaces first, then retry with '--openshell-driver %s'",
+					running.Driver, r.config.Driver,
+					running.Driver, r.config.Driver,
+				)
+			}
+			step := steplogger.FromContext(ctx)
+			step.Start(
+				fmt.Sprintf("Switching gateway driver from %s to %s", running.Driver, r.config.Driver),
+				"Gateway driver switched",
+			)
+			if err := r.stopGateway(ctx); err != nil {
+				step.Fail(err)
+				return fmt.Errorf("failed to stop gateway for driver switch: %w", err)
+			}
+		} else {
+			return nil
+		}
+	}
+
+	step := steplogger.FromContext(ctx)
+	step.Start("Starting OpenShell Gateway", "OpenShell Gateway started")
+
+	sshSecret, err := generateSSHSecret()
+	if err != nil {
+		step.Fail(err)
+		return err
+	}
+
+	// Redirect gateway output to a log file. The gateway is a long-running
+	// background process that outlives the kdn command, so piping to the
+	// command's stdout/stderr would leak output to the terminal.
+	logFile, err := os.OpenFile(
+		filepath.Join(r.storageDir, gatewayLogFile),
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644,
+	)
+	if err != nil {
+		step.Fail(err)
+		return fmt.Errorf("failed to create gateway log file: %w", err)
+	}
+
+	cmd, err := r.buildGatewayCommand(sshSecret)
+	if err != nil {
+		logFile.Close()
+		step.Fail(err)
+		return err
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		step.Fail(err)
+		return fmt.Errorf("failed to start openshell-gateway: %w", err)
+	}
+
+	// Monitor the process in the background so we can detect early exits.
+	processExited := make(chan error, 1)
+	go func() {
+		processExited <- cmd.Wait()
+		logFile.Close()
+	}()
+
+	_ = saveGatewayState(r.storageDir, gatewayState{
+		PID:    cmd.Process.Pid,
+		Driver: r.config.Driver,
+	})
+
+	// Register the gateway with the CLI before polling readiness.
+	// The readiness check uses "openshell sandbox list" which requires
+	// the gateway to be registered first.
+	if err := r.ensureGatewayRegistered(ctx); err != nil {
+		step.Fail(err)
+		return fmt.Errorf("failed to register gateway: %w", err)
+	}
+
+	// Wait for gateway readiness
+	deadline := time.Now().Add(gatewayReadinessTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case exitErr := <-processExited:
+			err := r.gatewayExitError(exitErr)
+			step.Fail(err)
+			return err
+		default:
+		}
+
+		if r.isGatewayReady(ctx) {
+			return nil
+		}
+
+		select {
+		case exitErr := <-processExited:
+			err := r.gatewayExitError(exitErr)
+			step.Fail(err)
+			return err
+		case <-ctx.Done():
+			step.Fail(ctx.Err())
+			return ctx.Err()
+		case <-time.After(gatewayReadinessInterval):
+		}
+	}
+
+	err = fmt.Errorf("openshell gateway did not become ready within %s", gatewayReadinessTimeout)
+	step.Fail(err)
+	return err
+}
+
+// buildGatewayCommand constructs the exec.Cmd for starting the gateway
+// based on the configured driver (podman or vm).
+func (r *openshellRuntime) buildGatewayCommand(sshSecret string) (*exec.Cmd, error) {
+	switch r.config.Driver {
+	case DriverVM:
+		if _, err := platformAsset("openshell-driver-vm"); err != nil {
+			return nil, fmt.Errorf("the vm driver is not supported on this platform")
+		}
+		return r.buildVMGatewayCommand(sshSecret), nil
+	case DriverPodman, "":
+		return r.buildPodmanGatewayCommand(sshSecret), nil
+	default:
+		return nil, fmt.Errorf("unsupported gateway driver: %s (supported: podman, vm)", r.config.Driver)
+	}
+}
+
+func (r *openshellRuntime) buildPodmanGatewayCommand(sshSecret string) *exec.Cmd {
+	dbPath := filepath.Join(r.storageDir, "openshell-podman.db")
+
+	cmd := exec.Command(r.gatewayBinaryPath, //nolint:gosec
+		"--drivers", "podman",
+		"--port", gatewayPort,
+		"--db-url", fmt.Sprintf("sqlite:%s", dbPath),
+		"--disable-tls",
+	)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage),
+		fmt.Sprintf("OPENSHELL_SSH_HANDSHAKE_SECRET=%s", sshSecret),
+	)
+	return cmd
+}
+
+func (r *openshellRuntime) buildVMGatewayCommand(sshSecret string) *exec.Cmd {
+	dbPath := filepath.Join(r.storageDir, "openshell-vm.db")
+	binDir := filepath.Join(r.storageDir, "bin")
+	vmStateDir := filepath.Join(r.storageDir, "vm-driver")
+
+	cmd := exec.Command(r.gatewayBinaryPath, //nolint:gosec
+		"--drivers", "vm",
+		"--port", gatewayPort,
+		"--db-url", fmt.Sprintf("sqlite:%s", dbPath),
+		"--driver-dir", binDir,
+		"--grpc-endpoint", gatewayURL,
+		"--ssh-handshake-secret", sshSecret,
+		"--disable-tls",
+	)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("OPENSHELL_VM_DRIVER_STATE_DIR=%s", vmStateDir),
+	)
+	return cmd
+}
+
+// gatewayExitError builds an error message when the gateway process exits unexpectedly,
+// including the last lines from the gateway log file for diagnostics.
+func (r *openshellRuntime) gatewayExitError(exitErr error) error {
+	logPath := filepath.Join(r.storageDir, gatewayLogFile)
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil || len(logData) == 0 {
+		return fmt.Errorf("openshell-gateway process exited unexpectedly: %w", exitErr)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	const maxLines = 20
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	tail := strings.Join(lines, "\n")
+	return fmt.Errorf("openshell-gateway process exited unexpectedly: %w\ngateway log:\n%s", exitErr, tail)
+}
+
+// ensureGatewayRegistered registers the gateway with the openshell CLI if not already registered.
+func (r *openshellRuntime) ensureGatewayRegistered(ctx context.Context) error {
+	// Discard stdout/stderr: the "already exists" error is expected and
+	// handled below, so we don't want it leaking to the user's terminal.
+	err := r.executor.Run(ctx, io.Discard, io.Discard,
+		"gateway", "add", gatewayURL, "--local",
+	)
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		return nil
+	}
+	return err
+}
+
+// generateSSHSecret generates a random 16-byte hex-encoded SSH handshake secret.
+func generateSSHSecret() (string, error) {
+	secretBytes := make([]byte, 16)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return "", fmt.Errorf("failed to generate SSH secret: %w", err)
+	}
+	return hex.EncodeToString(secretBytes), nil
+}

--- a/pkg/runtime/openshell/gateway_test.go
+++ b/pkg/runtime/openshell/gateway_test.go
@@ -1,0 +1,889 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestEnsureGatewayRegistered_AlreadyRegistered(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "gateway" && args[1] == "add" {
+			return fmt.Errorf("exit status 1\nopenshell stderr:\nGateway '127.0.0.1' already exists.")
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.ensureGatewayRegistered(context.Background())
+	if err != nil {
+		t.Fatalf("ensureGatewayRegistered() should succeed when gateway already exists: %v", err)
+	}
+}
+
+func TestEnsureGatewayRegistered_RegistersNew(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.ensureGatewayRegistered(context.Background())
+	if err != nil {
+		t.Fatalf("ensureGatewayRegistered() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+
+	call := fakeExec.RunCalls[0]
+	if len(call) < 4 {
+		t.Fatalf("Expected at least 4 args, got %d: %v", len(call), call)
+	}
+	if call[0] != "gateway" || call[1] != "add" {
+		t.Errorf("Expected 'gateway add', got %v", call[:2])
+	}
+	if call[2] != gatewayURL {
+		t.Errorf("Expected gateway URL %q, got %q", gatewayURL, call[2])
+	}
+	if call[3] != "--local" {
+		t.Errorf("Expected '--local' flag, got %q", call[3])
+	}
+}
+
+func TestBuildGatewayCommand_Podman(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = DriverPodman
+
+	cmd, err := rt.buildGatewayCommand("abc123")
+	if err != nil {
+		t.Fatalf("buildGatewayCommand() failed: %v", err)
+	}
+
+	args := cmd.Args
+	// Should contain --drivers podman
+	found := false
+	for i, arg := range args {
+		if arg == "--drivers" && i+1 < len(args) && args[i+1] == "podman" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected --drivers podman in args: %v", args)
+	}
+
+	// Should use file-based sqlite
+	foundDB := false
+	for i, arg := range args {
+		if arg == "--db-url" && i+1 < len(args) && strings.HasPrefix(args[i+1], "sqlite:") && strings.HasSuffix(args[i+1], "openshell-podman.db") {
+			foundDB = true
+			break
+		}
+	}
+	if !foundDB {
+		t.Errorf("Expected --db-url sqlite:<path>/openshell-podman.db in args: %v", args)
+	}
+
+	// Should have env vars set
+	hasEnv := false
+	for _, env := range cmd.Env {
+		if fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage) == env {
+			hasEnv = true
+			break
+		}
+	}
+	if !hasEnv {
+		t.Error("Expected OPENSHELL_SUPERVISOR_IMAGE env var for podman driver")
+	}
+}
+
+func TestBuildGatewayCommand_VM(t *testing.T) {
+	t.Parallel()
+
+	if _, err := platformAsset("openshell-driver-vm"); err != nil {
+		t.Skipf("VM driver not supported on this platform: %v", err)
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", storageDir)
+	rt.config.Driver = DriverVM
+
+	cmd, err := rt.buildGatewayCommand("abc123")
+	if err != nil {
+		t.Fatalf("buildGatewayCommand() failed: %v", err)
+	}
+
+	args := cmd.Args
+	// Should contain --drivers vm
+	found := false
+	for i, arg := range args {
+		if arg == "--drivers" && i+1 < len(args) && args[i+1] == "vm" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected --drivers vm in args: %v", args)
+	}
+
+	// Should contain --driver-dir
+	foundDriverDir := false
+	for i, arg := range args {
+		if arg == "--driver-dir" && i+1 < len(args) {
+			foundDriverDir = true
+			break
+		}
+	}
+	if !foundDriverDir {
+		t.Errorf("Expected --driver-dir in args: %v", args)
+	}
+
+	// Should contain --grpc-endpoint
+	foundGRPC := false
+	for i, arg := range args {
+		if arg == "--grpc-endpoint" && i+1 < len(args) && args[i+1] == gatewayURL {
+			foundGRPC = true
+			break
+		}
+	}
+	if !foundGRPC {
+		t.Errorf("Expected --grpc-endpoint %s in args: %v", gatewayURL, args)
+	}
+
+	// Should contain --ssh-handshake-secret as a flag (not env var)
+	foundSecret := false
+	for i, arg := range args {
+		if arg == "--ssh-handshake-secret" && i+1 < len(args) && args[i+1] == "abc123" {
+			foundSecret = true
+			break
+		}
+	}
+	if !foundSecret {
+		t.Errorf("Expected --ssh-handshake-secret abc123 in args: %v", args)
+	}
+
+	// Should NOT have OPENSHELL_SUPERVISOR_IMAGE env var
+	for _, env := range cmd.Env {
+		if fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage) == env {
+			t.Error("VM driver should not set OPENSHELL_SUPERVISOR_IMAGE env var")
+			break
+		}
+	}
+
+	// Should have OPENSHELL_VM_DRIVER_STATE_DIR env var pointing to storage
+	expectedStateDir := fmt.Sprintf("OPENSHELL_VM_DRIVER_STATE_DIR=%s", filepath.Join(storageDir, "vm-driver"))
+	hasStateDir := false
+	for _, env := range cmd.Env {
+		if env == expectedStateDir {
+			hasStateDir = true
+			break
+		}
+	}
+	if !hasStateDir {
+		t.Errorf("Expected OPENSHELL_VM_DRIVER_STATE_DIR env var, got env: %v", cmd.Env)
+	}
+}
+
+func TestBuildGatewayCommand_UnsupportedDriver(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = "invalid"
+
+	_, err := rt.buildGatewayCommand("abc123")
+	if err == nil {
+		t.Error("Expected error for unsupported driver")
+	}
+}
+
+func TestBuildGatewayCommand_DefaultDriverUsesPodman(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = ""
+
+	cmd, err := rt.buildGatewayCommand("abc123")
+	if err != nil {
+		t.Fatalf("buildGatewayCommand() failed: %v", err)
+	}
+
+	found := false
+	for i, arg := range cmd.Args {
+		if arg == "--drivers" && i+1 < len(cmd.Args) && cmd.Args[i+1] == "podman" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected --drivers podman for empty driver, got args: %v", cmd.Args)
+	}
+}
+
+func TestGatewayExitError_WithLog(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", storageDir)
+
+	logContent := "line1\nline2\nerror: failed to start\n"
+	if err := os.WriteFile(filepath.Join(storageDir, gatewayLogFile), []byte(logContent), 0644); err != nil {
+		t.Fatalf("Failed to write log file: %v", err)
+	}
+
+	err := rt.gatewayExitError(fmt.Errorf("exit status 1"))
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Errorf("Expected exit error in message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "error: failed to start") {
+		t.Errorf("Expected log content in message, got: %v", err)
+	}
+}
+
+func TestGatewayExitError_WithoutLog(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", storageDir)
+
+	err := rt.gatewayExitError(fmt.Errorf("exit status 1"))
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	if !strings.Contains(err.Error(), "exited unexpectedly") {
+		t.Errorf("Expected 'exited unexpectedly' in message, got: %v", err)
+	}
+}
+
+func TestGatewayExitError_TruncatesLongLog(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", storageDir)
+
+	var lines []string
+	for i := range 30 {
+		lines = append(lines, fmt.Sprintf("log line %d", i))
+	}
+	logContent := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(storageDir, gatewayLogFile), []byte(logContent), 0644); err != nil {
+		t.Fatalf("Failed to write log file: %v", err)
+	}
+
+	err := rt.gatewayExitError(fmt.Errorf("exit status 1"))
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	// Should contain last lines but not the first ones (truncated to 20)
+	if !strings.Contains(err.Error(), "log line 29") {
+		t.Errorf("Expected last log line in message, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "log line 0") {
+		t.Errorf("Expected first log lines to be truncated, got: %v", err)
+	}
+}
+
+func TestIsGatewayReady_True(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-test\n"), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if !rt.isGatewayReady(context.Background()) {
+		t.Error("Expected isGatewayReady to return true when executor succeeds")
+	}
+}
+
+func TestIsGatewayReady_False(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("connection refused")
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if rt.isGatewayReady(context.Background()) {
+		t.Error("Expected isGatewayReady to return false when executor fails")
+	}
+}
+
+func TestEnsureGatewayRunning_AlreadyReady(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-test\n"), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err != nil {
+		t.Fatalf("ensureGatewayRunning() should succeed when gateway is ready: %v", err)
+	}
+}
+
+func TestEnsureGatewayRunning_RegistersBeforeCheck(t *testing.T) {
+	t.Parallel()
+
+	var callOrder []string
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "gateway" && args[1] == "add" {
+			callOrder = append(callOrder, "register")
+		}
+		return nil
+	}
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			callOrder = append(callOrder, "ready-check")
+			return []byte("ready\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	err := rt.ensureGatewayRunning(context.Background())
+	if err != nil {
+		t.Fatalf("ensureGatewayRunning() failed: %v", err)
+	}
+
+	if len(callOrder) < 2 {
+		t.Fatalf("Expected at least 2 calls, got %d: %v", len(callOrder), callOrder)
+	}
+	if callOrder[0] != "register" {
+		t.Errorf("Expected register before ready-check, got order: %v", callOrder)
+	}
+}
+
+func TestEnsureGatewayRunning_StartsGatewayProcess(t *testing.T) {
+	t.Parallel()
+
+	if goruntime.GOOS == "windows" {
+		t.Skip("Shell scripts not available on Windows")
+	}
+
+	storageDir := t.TempDir()
+
+	gatewayScript := filepath.Join(storageDir, "fake-gateway")
+	if err := os.WriteFile(gatewayScript, []byte("#!/bin/sh\nexec sleep 30\n"), 0755); err != nil {
+		t.Fatalf("Failed to write gateway script: %v", err)
+	}
+
+	readyCalls := 0
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			readyCalls++
+			if readyCalls <= 1 {
+				return nil, fmt.Errorf("not ready")
+			}
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, gatewayScript, storageDir)
+
+	t.Cleanup(func() {
+		state, err := loadGatewayState(storageDir)
+		if err == nil && state.PID > 0 {
+			if p, err := os.FindProcess(state.PID); err == nil {
+				p.Kill()
+			}
+		}
+	})
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err != nil {
+		t.Fatalf("ensureGatewayRunning() should start gateway and detect readiness: %v", err)
+	}
+
+	// Verify gateway state was written
+	state, err := loadGatewayState(storageDir)
+	if err != nil {
+		t.Fatalf("Expected gateway state to be created: %v", err)
+	}
+	if state.PID <= 0 {
+		t.Errorf("Expected valid PID in state, got %d", state.PID)
+	}
+	if state.Driver != DriverPodman {
+		t.Errorf("Expected driver %q in state, got %q", DriverPodman, state.Driver)
+	}
+
+	// Verify log file was created
+	if _, err := os.Stat(filepath.Join(storageDir, gatewayLogFile)); err != nil {
+		t.Errorf("Expected log file to be created: %v", err)
+	}
+}
+
+func TestEnsureGatewayRunning_GatewayExitsEarly(t *testing.T) {
+	t.Parallel()
+
+	if goruntime.GOOS == "windows" {
+		t.Skip("Shell scripts not available on Windows")
+	}
+
+	storageDir := t.TempDir()
+
+	// Create a gateway that exits immediately with an error
+	gatewayScript := filepath.Join(storageDir, "fake-gateway")
+	if err := os.WriteFile(gatewayScript, []byte("#!/bin/sh\necho 'fatal error' >&2\nexit 1\n"), 0755); err != nil {
+		t.Fatalf("Failed to write gateway script: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return nil, fmt.Errorf("not ready")
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, gatewayScript, storageDir)
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err == nil {
+		t.Fatal("Expected error when gateway exits immediately")
+	}
+	if !strings.Contains(err.Error(), "exited unexpectedly") {
+		t.Errorf("Expected 'exited unexpectedly' error, got: %v", err)
+	}
+}
+
+func TestEnsureGatewayRunning_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	if goruntime.GOOS == "windows" {
+		t.Skip("Shell scripts not available on Windows")
+	}
+
+	storageDir := t.TempDir()
+
+	gatewayScript := filepath.Join(storageDir, "fake-gateway")
+	if err := os.WriteFile(gatewayScript, []byte("#!/bin/sh\nexec sleep 30\n"), 0755); err != nil {
+		t.Fatalf("Failed to write gateway script: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("not ready")
+	}
+
+	rt := newWithDeps(fakeExec, gatewayScript, storageDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	t.Cleanup(func() {
+		state, loadErr := loadGatewayState(storageDir)
+		if loadErr == nil && state.PID > 0 {
+			if p, findErr := os.FindProcess(state.PID); findErr == nil {
+				p.Kill()
+			}
+		}
+	})
+
+	err := rt.ensureGatewayRunning(ctx)
+	if err == nil {
+		t.Fatal("Expected error when context is cancelled")
+	}
+}
+
+func TestEnsureGatewayRunning_BuildCommandError(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("not ready")
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.config.Driver = "invalid-driver"
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err == nil {
+		t.Fatal("Expected error for invalid driver")
+	}
+	if !strings.Contains(err.Error(), "unsupported gateway driver") {
+		t.Errorf("Expected 'unsupported gateway driver' error, got: %v", err)
+	}
+}
+
+func TestHasActiveSandboxes_WithKdnSandboxes(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-myproject\nother-sandbox\n"), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if !rt.hasActiveSandboxes(context.Background()) {
+		t.Error("Expected hasActiveSandboxes to return true when kdn-prefixed sandboxes exist")
+	}
+}
+
+func TestHasActiveSandboxes_NoKdnSandboxes(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("other-sandbox\nunrelated\n"), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if rt.hasActiveSandboxes(context.Background()) {
+		t.Error("Expected hasActiveSandboxes to return false when no kdn-prefixed sandboxes exist")
+	}
+}
+
+func TestHasActiveSandboxes_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if rt.hasActiveSandboxes(context.Background()) {
+		t.Error("Expected hasActiveSandboxes to return false on empty list")
+	}
+}
+
+func TestHasActiveSandboxes_ExecutorError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("connection refused")
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if rt.hasActiveSandboxes(context.Background()) {
+		t.Error("Expected hasActiveSandboxes to return false on executor error")
+	}
+}
+
+func TestEnsureGatewayRunning_DriverConflict_WithActiveSandboxes(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+
+	// Write state indicating gateway is running with VM driver
+	_ = saveGatewayState(storageDir, gatewayState{PID: 99999, Driver: DriverVM})
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-myproject\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.config.Driver = DriverPodman
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err == nil {
+		t.Fatal("Expected error for driver conflict with active sandboxes")
+	}
+	if !strings.Contains(err.Error(), "cannot switch") {
+		t.Errorf("Expected 'cannot switch' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), DriverVM) || !strings.Contains(err.Error(), DriverPodman) {
+		t.Errorf("Expected both driver names in error, got: %v", err)
+	}
+}
+
+func TestEnsureGatewayRunning_DriverConflict_NoActiveSandboxes(t *testing.T) {
+	t.Parallel()
+
+	if goruntime.GOOS == "windows" {
+		t.Skip("Shell scripts not available on Windows")
+	}
+
+	storageDir := t.TempDir()
+
+	// Start a real sleep process to act as the old gateway
+	gatewayScript := filepath.Join(storageDir, "fake-gateway")
+	if err := os.WriteFile(gatewayScript, []byte("#!/bin/sh\nexec sleep 30\n"), 0755); err != nil {
+		t.Fatalf("Failed to write gateway script: %v", err)
+	}
+
+	readyCalls := 0
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			readyCalls++
+			if readyCalls <= 1 {
+				// First call: gateway is "ready" (old driver)
+				return []byte(""), nil
+			}
+			if readyCalls == 2 {
+				// Second call: hasActiveSandboxes check — no kdn sandboxes
+				return []byte(""), nil
+			}
+			if readyCalls <= 4 {
+				// After stop, gateway not ready yet
+				return nil, fmt.Errorf("not ready")
+			}
+			// Eventually ready with new driver
+			return []byte(""), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, gatewayScript, storageDir)
+	rt.config.Driver = DriverPodman
+
+	// Write state indicating gateway is running with VM driver, using a real PID
+	// We need a real process. Start one.
+	sleepCmd := exec.NewFake() //nolint:ineffassign,staticcheck
+	_ = sleepCmd
+	// Actually write the state with a fake PID that doesn't exist
+	_ = saveGatewayState(storageDir, gatewayState{PID: 99999, Driver: DriverVM})
+
+	t.Cleanup(func() {
+		state, loadErr := loadGatewayState(storageDir)
+		if loadErr == nil && state.PID > 0 {
+			if p, findErr := os.FindProcess(state.PID); findErr == nil {
+				p.Kill()
+			}
+		}
+	})
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err != nil {
+		t.Fatalf("Expected driver switch to succeed with no active sandboxes: %v", err)
+	}
+
+	// Verify gateway state was updated with new driver
+	state, err := loadGatewayState(storageDir)
+	if err != nil {
+		t.Fatalf("Expected gateway state after restart: %v", err)
+	}
+	if state.Driver != DriverPodman {
+		t.Errorf("Expected driver %q after switch, got %q", DriverPodman, state.Driver)
+	}
+}
+
+func TestEnsureGatewayRunning_SameDriver_NoConflict(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	_ = saveGatewayState(storageDir, gatewayState{PID: 99999, Driver: DriverPodman})
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-test\n"), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.config.Driver = DriverPodman
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error for same driver: %v", err)
+	}
+}
+
+func TestEnsureGatewayRunning_UnknownRunningDriver_NoConflict(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	// No gateway state file — backward compat with old installs
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-test\n"), nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.config.Driver = DriverVM
+
+	err := rt.ensureGatewayRunning(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error when gateway state is unknown: %v", err)
+	}
+}
+
+func TestStopGateway_NoStateFile(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", storageDir)
+
+	err := rt.stopGateway(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error when no state file exists: %v", err)
+	}
+}
+
+func TestStopGateway_DeadProcess(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	_ = saveGatewayState(storageDir, gatewayState{PID: 99999, Driver: DriverPodman})
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("not ready")
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	err := rt.stopGateway(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error for dead process: %v", err)
+	}
+
+	// Verify state files were cleaned up
+	if _, err := loadGatewayState(storageDir); err == nil {
+		t.Error("Expected gateway state file to be removed")
+	}
+}
+
+func TestGatewayState_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	state := gatewayState{PID: 12345, Driver: DriverVM}
+
+	if err := saveGatewayState(storageDir, state); err != nil {
+		t.Fatalf("saveGatewayState() failed: %v", err)
+	}
+
+	loaded, err := loadGatewayState(storageDir)
+	if err != nil {
+		t.Fatalf("loadGatewayState() failed: %v", err)
+	}
+	if loaded.PID != state.PID {
+		t.Errorf("Expected PID %d, got %d", state.PID, loaded.PID)
+	}
+	if loaded.Driver != state.Driver {
+		t.Errorf("Expected driver %q, got %q", state.Driver, loaded.Driver)
+	}
+}
+
+func TestGatewayState_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadGatewayState(t.TempDir())
+	if err == nil {
+		t.Error("Expected error when state file is missing")
+	}
+}
+
+func TestGatewayState_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(storageDir, gatewayStateFile), []byte("not json"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	_, err := loadGatewayState(storageDir)
+	if err == nil {
+		t.Error("Expected error for invalid JSON")
+	}
+}
+
+func TestRemoveGatewayState_CleansUpBothFiles(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+
+	// Create both state file and legacy PID file
+	_ = saveGatewayState(storageDir, gatewayState{PID: 123, Driver: DriverPodman})
+	_ = os.WriteFile(filepath.Join(storageDir, gatewayPIDFile), []byte("123"), 0644)
+
+	removeGatewayState(storageDir)
+
+	if _, err := os.Stat(filepath.Join(storageDir, gatewayStateFile)); err == nil {
+		t.Error("Expected gateway state file to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(storageDir, gatewayPIDFile)); err == nil {
+		t.Error("Expected legacy PID file to be removed")
+	}
+}
+
+func TestGatewayState_JSONFormat(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	_ = saveGatewayState(storageDir, gatewayState{PID: 42, Driver: DriverVM})
+
+	data, err := os.ReadFile(filepath.Join(storageDir, gatewayStateFile))
+	if err != nil {
+		t.Fatalf("Failed to read state file: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("State file is not valid JSON: %v", err)
+	}
+	if _, ok := raw["pid"]; !ok {
+		t.Error("Expected 'pid' field in state JSON")
+	}
+	if _, ok := raw["driver"]; !ok {
+		t.Error("Expected 'driver' field in state JSON")
+	}
+}
+
+func TestGenerateSSHSecret(t *testing.T) {
+	t.Parallel()
+
+	secret, err := generateSSHSecret()
+	if err != nil {
+		t.Fatalf("generateSSHSecret() failed: %v", err)
+	}
+
+	// 16 bytes = 32 hex characters
+	if len(secret) != 32 {
+		t.Errorf("Expected 32 hex characters, got %d: %q", len(secret), secret)
+	}
+
+	// Verify uniqueness (generate another)
+	secret2, err := generateSSHSecret()
+	if err != nil {
+		t.Fatalf("generateSSHSecret() failed: %v", err)
+	}
+	if secret == secret2 {
+		t.Error("Expected unique secrets, got identical values")
+	}
+}

--- a/pkg/runtime/openshell/info.go
+++ b/pkg/runtime/openshell/info.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime"
+)
+
+// Info retrieves information about an OpenShell sandbox.
+func (r *openshellRuntime) Info(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	if id == "" {
+		return runtime.RuntimeInfo{}, fmt.Errorf("%w: sandbox ID is required", runtime.ErrInvalidParams)
+	}
+
+	if err := r.ensureBinaries(); err != nil {
+		return runtime.RuntimeInfo{}, err
+	}
+
+	// Check local state override first
+	if state, ok := r.states.Get(id); ok {
+		return runtime.RuntimeInfo{
+			ID:    id,
+			State: state,
+			Info:  map[string]string{"sandbox_name": id},
+		}, nil
+	}
+
+	// Query actual sandbox state
+	state := r.querySandboxState(ctx, id)
+
+	return runtime.RuntimeInfo{
+		ID:    id,
+		State: state,
+		Info:  map[string]string{"sandbox_name": id},
+	}, nil
+}
+
+// querySandboxState checks whether a sandbox exists and is running.
+func (r *openshellRuntime) querySandboxState(ctx context.Context, id string) api.WorkspaceState {
+	l := logger.FromContext(ctx)
+	output, err := r.executor.Output(ctx, l.Stderr(), "sandbox", "list", "--names")
+	if err != nil {
+		return api.WorkspaceStateError
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if strings.TrimSpace(line) == id {
+			return api.WorkspaceStateRunning
+		}
+	}
+
+	return api.WorkspaceStateError
+}

--- a/pkg/runtime/openshell/info_test.go
+++ b/pkg/runtime/openshell/info_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestInfo_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_, err := rt.Info(context.Background(), "")
+	if err == nil {
+		t.Error("Expected error for empty ID")
+	}
+}
+
+func TestInfo_ReturnsOverrideState(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	info, err := rt.Info(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Info() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateStopped {
+		t.Errorf("Expected state %q, got %q", api.WorkspaceStateStopped, info.State)
+	}
+
+	// Executor should not be called when override exists
+	if len(fakeExec.OutputCalls) != 0 {
+		t.Error("Expected no executor calls when override exists")
+	}
+}
+
+func TestInfo_QueriesSandboxWhenNoOverride(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-test\nother-sandbox\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	info, err := rt.Info(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Info() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateRunning {
+		t.Errorf("Expected state %q, got %q", api.WorkspaceStateRunning, info.State)
+	}
+}
+
+func TestInfo_ReturnsErrorForMissingSandbox(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("other-sandbox\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	info, err := rt.Info(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Info() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateError {
+		t.Errorf("Expected state %q, got %q", api.WorkspaceStateError, info.State)
+	}
+}
+
+func TestInfo_ReturnsIDAndSandboxName(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-my-project\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	info, err := rt.Info(context.Background(), "kdn-my-project")
+	if err != nil {
+		t.Fatalf("Info() failed: %v", err)
+	}
+
+	if info.ID != "kdn-my-project" {
+		t.Errorf("Expected ID 'kdn-my-project', got %q", info.ID)
+	}
+	if info.Info["sandbox_name"] != "kdn-my-project" {
+		t.Errorf("Expected sandbox_name 'kdn-my-project', got %q", info.Info["sandbox_name"])
+	}
+}
+
+func TestInfo_ExecutorError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("connection refused")
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	info, err := rt.Info(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Info() should not return error (returns error state): %v", err)
+	}
+
+	if info.State != api.WorkspaceStateError {
+		t.Errorf("Expected error state when executor fails, got %q", info.State)
+	}
+}
+
+func TestQuerySandboxState_EmptyOutput(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	state := rt.querySandboxState(context.Background(), "kdn-test")
+	if state != api.WorkspaceStateError {
+		t.Errorf("Expected error state for empty output, got %q", state)
+	}
+}
+
+func TestQuerySandboxState_MultipleSandboxes(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-first\nkdn-second\nkdn-third\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if state := rt.querySandboxState(context.Background(), "kdn-second"); state != api.WorkspaceStateRunning {
+		t.Errorf("Expected running for kdn-second, got %q", state)
+	}
+	if state := rt.querySandboxState(context.Background(), "kdn-missing"); state != api.WorkspaceStateError {
+		t.Errorf("Expected error for kdn-missing, got %q", state)
+	}
+}

--- a/pkg/runtime/openshell/network.go
+++ b/pkg/runtime/openshell/network.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+const networkRuleName = "kdn-network"
+
+var networkEndpointPorts = []int{80, 443}
+
+// loadNetworkConfig reads the merged workspace configuration for a project by
+// combining workspace-level, project-level, and agent-level configs. It mirrors
+// the merge logic used at workspace creation time so that edits take effect on
+// the next Start() without recreating the workspace.
+func loadNetworkConfig(sourcePath, storageDir, projectID, agentName string) (*workspace.WorkspaceConfiguration, error) {
+	merger := config.NewMerger()
+
+	var merged *workspace.WorkspaceConfiguration
+
+	wsCfgLoader, err := config.NewConfig(filepath.Join(sourcePath, ".kaiden"))
+	if err != nil {
+		return nil, fmt.Errorf("initializing workspace config loader: %w", err)
+	}
+	if wc, loadErr := wsCfgLoader.Load(); loadErr == nil {
+		merged = wc
+	}
+
+	projectLoader, err := config.NewProjectConfigLoader(storageDir)
+	if err != nil {
+		return nil, fmt.Errorf("initializing project config loader: %w", err)
+	}
+	if pc, loadErr := projectLoader.Load(projectID); loadErr == nil {
+		merged = merger.Merge(merged, pc)
+	}
+
+	if agentName != "" {
+		agentLoader, err := config.NewAgentConfigLoader(storageDir)
+		if err != nil {
+			return nil, fmt.Errorf("initializing agent config loader: %w", err)
+		}
+		if ac, loadErr := agentLoader.Load(agentName); loadErr == nil {
+			merged = merger.Merge(merged, ac)
+		}
+	}
+
+	return merged, nil
+}
+
+// collectSecretHosts returns the host patterns contributed by the secrets
+// listed in wsCfg. For known secret types, patterns come from the secret
+// service registry; for "other" secrets, they come from the stored metadata.
+func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.Store, registry secretservice.Registry) ([]string, error) {
+	if wsCfg == nil || wsCfg.Secrets == nil || len(*wsCfg.Secrets) == 0 {
+		return nil, nil
+	}
+	if store == nil || registry == nil {
+		return nil, nil
+	}
+
+	items, err := store.List()
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+
+	byName := make(map[string]secret.ListItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	seen := make(map[string]bool)
+	var hosts []string
+	for _, name := range *wsCfg.Secrets {
+		item, ok := byName[name]
+		if !ok {
+			continue
+		}
+		var itemHosts []string
+		if item.Type == secret.TypeOther {
+			itemHosts = item.Hosts
+		} else {
+			svc, svcErr := registry.Get(item.Type)
+			if svcErr != nil {
+				continue
+			}
+			itemHosts = svc.HostsPatterns()
+		}
+		for _, h := range itemHosts {
+			if !seen[h] {
+				seen[h] = true
+				hosts = append(hosts, h)
+			}
+		}
+	}
+	return hosts, nil
+}
+
+// mergeHosts returns a deduplicated list of all hosts from a and b,
+// preserving order (a first, then new entries from b).
+func mergeHosts(a, b []string) []string {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	result := make([]string, 0, len(a)+len(b))
+	for _, h := range a {
+		if !seen[h] {
+			seen[h] = true
+			result = append(result, h)
+		}
+	}
+	for _, h := range b {
+		if !seen[h] {
+			seen[h] = true
+			result = append(result, h)
+		}
+	}
+	return result
+}
+
+// collectAllRegistryHosts returns the host patterns from every registered
+// secret service. Used in allow mode where all known services should be
+// reachable regardless of which secrets are configured in the workspace.
+func collectAllRegistryHosts(registry secretservice.Registry) []string {
+	if registry == nil {
+		return nil
+	}
+
+	names := registry.List()
+	if len(names) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var hosts []string
+	for _, name := range names {
+		svc, err := registry.Get(name)
+		if err != nil {
+			continue
+		}
+		for _, h := range svc.HostsPatterns() {
+			if !seen[h] {
+				seen[h] = true
+				hosts = append(hosts, h)
+			}
+		}
+	}
+	return hosts
+}
+
+// applyNetworkPolicy determines the network mode and applies the appropriate
+// policy to the sandbox. Called from both Create and Start.
+//
+// OpenShell sandboxes enforce deny-by-default networking and do not support
+// unrestricted "allow all" policies (wildcard hosts like "**" are rejected).
+// When no deny-mode hosts are configured, the sandbox keeps its default
+// deny-all behavior. Only explicit host patterns are added as rules.
+//
+// In allow mode, hosts are derived from the secret service registry and
+// the allowHosts parameter (from --openshell-allow-hosts).
+// In deny mode, hosts come from workspace config network.hosts and
+// configured secret host patterns.
+func (r *openshellRuntime) applyNetworkPolicy(ctx context.Context, sandboxName string, wsCfg *workspace.WorkspaceConfiguration, allowHosts []string) error {
+	l := logger.FromContext(ctx)
+
+	isDenyMode := wsCfg != nil &&
+		wsCfg.Network != nil &&
+		wsCfg.Network.Mode != nil &&
+		*wsCfg.Network.Mode == workspace.Deny
+
+	if !isDenyMode {
+		registryHosts := collectAllRegistryHosts(r.secretServiceRegistry)
+		hosts := mergeHosts(registryHosts, allowHosts)
+		fmt.Fprintf(l.Stderr(), "Network policy (allow mode): %v\n", hosts)
+		return r.configureNetworkPolicy(ctx, sandboxName, hosts)
+	}
+
+	var explicitHosts []string
+	if wsCfg.Network.Hosts != nil {
+		explicitHosts = *wsCfg.Network.Hosts
+	}
+
+	secretHosts, err := collectSecretHosts(wsCfg, r.secretStore, r.secretServiceRegistry)
+	if err != nil {
+		return fmt.Errorf("collecting secret hosts: %w", err)
+	}
+	allHosts := mergeHosts(explicitHosts, secretHosts)
+	fmt.Fprintf(l.Stderr(), "Network policy (deny mode): %v\n", allHosts)
+
+	return r.configureNetworkPolicy(ctx, sandboxName, allHosts)
+}
+
+// configureNetworkPolicy applies network rules to the sandbox via the
+// openshell policy update CLI. It always removes any existing kdn-managed
+// rule first, then adds endpoints for each host on standard ports.
+func (r *openshellRuntime) configureNetworkPolicy(ctx context.Context, sandboxName string, hosts []string) error {
+	l := logger.FromContext(ctx)
+
+	// Remove existing kdn-managed rule (ignore errors — rule may not exist)
+	_ = r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+		"policy", "update", sandboxName, "--remove-rule", networkRuleName,
+	)
+
+	if len(hosts) == 0 {
+		return nil
+	}
+
+	args := []string{"policy", "update", sandboxName}
+	for _, host := range hosts {
+		for _, port := range networkEndpointPorts {
+			args = append(args, "--add-endpoint", fmt.Sprintf("%s:%d:full", host, port))
+		}
+	}
+	args = append(args, "--binary", "/**", "--wait")
+
+	if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(), args...); err != nil {
+		if strings.Contains(err.Error(), "sandbox has no spec") {
+			fmt.Fprintf(l.Stderr(), "Network policy not supported for this sandbox, skipping\n")
+			return nil
+		}
+		return fmt.Errorf("updating network policy: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/runtime/openshell/network_test.go
+++ b/pkg/runtime/openshell/network_test.go
@@ -1,0 +1,581 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+func TestApplyNetworkPolicy_NilConfig_NoRegistry(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	err := rt.applyNetworkPolicy(context.Background(), "kdn-test", nil, nil)
+	if err != nil {
+		t.Fatalf("applyNetworkPolicy() failed: %v", err)
+	}
+
+	// No registry and no allow hosts means no endpoints added
+	for _, call := range fakeExec.RunCalls {
+		for _, arg := range call {
+			if arg == "--add-endpoint" {
+				t.Errorf("Expected no --add-endpoint calls without registry, got: %v", call)
+			}
+		}
+	}
+}
+
+func TestApplyNetworkPolicy_AllowMode_WithRegistry(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"anthropic": &fakeSecretService{hosts: []string{"api.anthropic.com"}},
+			"github":    &fakeSecretService{hosts: []string{"api.github.com"}},
+		},
+	}
+
+	mode := workspace.Allow
+	cfg := &workspace.WorkspaceConfiguration{
+		Network: &workspace.NetworkConfiguration{
+			Mode: &mode,
+		},
+	}
+
+	err := rt.applyNetworkPolicy(context.Background(), "kdn-test", cfg, nil)
+	if err != nil {
+		t.Fatalf("applyNetworkPolicy() failed: %v", err)
+	}
+
+	assertPolicyUpdateContains(t, fakeExec.RunCalls, "api.anthropic.com:443:full", "api.github.com:443:full")
+}
+
+func TestApplyNetworkPolicy_AllowMode_WithAllowHosts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"anthropic": &fakeSecretService{hosts: []string{"api.anthropic.com"}},
+		},
+	}
+
+	err := rt.applyNetworkPolicy(context.Background(), "kdn-test", nil, []string{"github.com", "registry.npmjs.org"})
+	if err != nil {
+		t.Fatalf("applyNetworkPolicy() failed: %v", err)
+	}
+
+	assertPolicyUpdateContains(t, fakeExec.RunCalls, "api.anthropic.com:443:full", "github.com:443:full", "registry.npmjs.org:443:full")
+}
+
+func TestApplyNetworkPolicy_DenyWithHosts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	mode := workspace.Deny
+	hosts := []string{"api.github.com", "*.example.com"}
+	cfg := &workspace.WorkspaceConfiguration{
+		Network: &workspace.NetworkConfiguration{
+			Mode:  &mode,
+			Hosts: &hosts,
+		},
+	}
+
+	err := rt.applyNetworkPolicy(context.Background(), "kdn-test", cfg, nil)
+	if err != nil {
+		t.Fatalf("applyNetworkPolicy() failed: %v", err)
+	}
+
+	assertPolicyUpdateContains(t, fakeExec.RunCalls, "api.github.com:80:full", "api.github.com:443:full", "*.example.com:80:full", "*.example.com:443:full")
+	assertPolicyUpdateNotContains(t, fakeExec.RunCalls, "**:80:full")
+}
+
+func TestApplyNetworkPolicy_DenyNoHosts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	mode := workspace.Deny
+	cfg := &workspace.WorkspaceConfiguration{
+		Network: &workspace.NetworkConfiguration{
+			Mode: &mode,
+		},
+	}
+
+	err := rt.applyNetworkPolicy(context.Background(), "kdn-test", cfg, nil)
+	if err != nil {
+		t.Fatalf("applyNetworkPolicy() failed: %v", err)
+	}
+
+	// Should only have the remove-rule call, no add-endpoint
+	for _, call := range fakeExec.RunCalls {
+		for _, arg := range call {
+			if arg == "--add-endpoint" {
+				t.Errorf("Expected no --add-endpoint calls for deny with no hosts, got: %v", call)
+			}
+		}
+	}
+}
+
+func TestConfigureNetworkPolicy_RemovesExistingRule(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	err := rt.configureNetworkPolicy(context.Background(), "kdn-test", []string{"example.com"})
+	if err != nil {
+		t.Fatalf("configureNetworkPolicy() failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) < 2 {
+		t.Fatalf("Expected at least 2 Run calls, got %d", len(fakeExec.RunCalls))
+	}
+
+	// First call should be remove-rule
+	removeCall := fakeExec.RunCalls[0]
+	if !slices.Contains(removeCall, "--remove-rule") || !slices.Contains(removeCall, networkRuleName) {
+		t.Errorf("First call should remove existing rule, got: %v", removeCall)
+	}
+}
+
+func TestConfigureNetworkPolicy_EmptyHosts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	err := rt.configureNetworkPolicy(context.Background(), "kdn-test", nil)
+	if err != nil {
+		t.Fatalf("configureNetworkPolicy() failed: %v", err)
+	}
+
+	// Should only have the remove-rule call
+	if len(fakeExec.RunCalls) != 1 {
+		t.Errorf("Expected 1 Run call (remove-rule only), got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestConfigureNetworkPolicy_PolicyUpdateError(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		callCount++
+		if callCount == 2 {
+			return fmt.Errorf("policy update failed")
+		}
+		return nil
+	}
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	err := rt.configureNetworkPolicy(context.Background(), "kdn-test", []string{"example.com"})
+	if err == nil {
+		t.Error("Expected error when policy update fails")
+	}
+}
+
+func TestConfigureNetworkPolicy_IncludesBinaryAndWait(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	err := rt.configureNetworkPolicy(context.Background(), "kdn-test", []string{"example.com"})
+	if err != nil {
+		t.Fatalf("configureNetworkPolicy() failed: %v", err)
+	}
+
+	// Find the policy update call (second call, after remove-rule)
+	if len(fakeExec.RunCalls) < 2 {
+		t.Fatalf("Expected at least 2 Run calls, got %d", len(fakeExec.RunCalls))
+	}
+
+	updateCall := fakeExec.RunCalls[1]
+	if !slices.Contains(updateCall, "--binary") || !slices.Contains(updateCall, "/**") {
+		t.Errorf("Expected --binary /** in update call, got: %v", updateCall)
+	}
+	if !slices.Contains(updateCall, "--wait") {
+		t.Errorf("Expected --wait in update call, got: %v", updateCall)
+	}
+}
+
+func TestMergeHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{
+			name: "nil inputs",
+			want: nil,
+		},
+		{
+			name: "a only",
+			a:    []string{"a.com", "b.com"},
+			want: []string{"a.com", "b.com"},
+		},
+		{
+			name: "b only",
+			b:    []string{"c.com"},
+			want: []string{"c.com"},
+		},
+		{
+			name: "merge with dedup",
+			a:    []string{"a.com", "b.com"},
+			b:    []string{"b.com", "c.com"},
+			want: []string{"a.com", "b.com", "c.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeHosts(tt.a, tt.b)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mergeHosts() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mergeHosts()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCollectSecretHosts_NilInputs(t *testing.T) {
+	t.Parallel()
+
+	got, err := collectSecretHosts(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("collectSecretHosts() failed: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Expected nil, got %v", got)
+	}
+}
+
+func TestCollectSecretHosts_NoSecrets(t *testing.T) {
+	t.Parallel()
+
+	cfg := &workspace.WorkspaceConfiguration{}
+	got, err := collectSecretHosts(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("collectSecretHosts() failed: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Expected nil, got %v", got)
+	}
+}
+
+func TestCollectSecretHosts_NilStoreWithSecrets(t *testing.T) {
+	t.Parallel()
+
+	secrets := []string{"my-secret"}
+	cfg := &workspace.WorkspaceConfiguration{
+		Secrets: &secrets,
+	}
+
+	got, err := collectSecretHosts(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("collectSecretHosts() failed: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Expected nil, got %v", got)
+	}
+}
+
+func TestCollectSecretHosts_StoreListError(t *testing.T) {
+	t.Parallel()
+
+	secrets := []string{"my-secret"}
+	cfg := &workspace.WorkspaceConfiguration{
+		Secrets: &secrets,
+	}
+
+	store := &fakeSecretStore{err: fmt.Errorf("store unavailable")}
+	registry := &fakeSecretServiceRegistry{}
+
+	_, err := collectSecretHosts(cfg, store, registry)
+	if err == nil {
+		t.Error("Expected error when store.List() fails")
+	}
+}
+
+func TestCollectSecretHosts_KnownType(t *testing.T) {
+	t.Parallel()
+
+	secrets := []string{"my-github"}
+	cfg := &workspace.WorkspaceConfiguration{
+		Secrets: &secrets,
+	}
+
+	store := &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "my-github", Type: "github"},
+		},
+	}
+
+	registry := &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"github": &fakeSecretService{hosts: []string{"api.github.com", "github.com"}},
+		},
+	}
+
+	got, err := collectSecretHosts(cfg, store, registry)
+	if err != nil {
+		t.Fatalf("collectSecretHosts() failed: %v", err)
+	}
+
+	want := []string{"api.github.com", "github.com"}
+	if len(got) != len(want) {
+		t.Fatalf("collectSecretHosts() = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("collectSecretHosts()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestCollectSecretHosts_OtherType(t *testing.T) {
+	t.Parallel()
+
+	secrets := []string{"custom-api"}
+	cfg := &workspace.WorkspaceConfiguration{
+		Secrets: &secrets,
+	}
+
+	store := &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "custom-api", Type: secret.TypeOther, Hosts: []string{"custom.api.com"}},
+		},
+	}
+
+	registry := &fakeSecretServiceRegistry{}
+
+	got, err := collectSecretHosts(cfg, store, registry)
+	if err != nil {
+		t.Fatalf("collectSecretHosts() failed: %v", err)
+	}
+
+	if len(got) != 1 || got[0] != "custom.api.com" {
+		t.Errorf("collectSecretHosts() = %v, want [custom.api.com]", got)
+	}
+}
+
+func TestCollectAllRegistryHosts_NilRegistry(t *testing.T) {
+	t.Parallel()
+
+	got := collectAllRegistryHosts(nil)
+	if got != nil {
+		t.Errorf("Expected nil, got %v", got)
+	}
+}
+
+func TestCollectAllRegistryHosts_EmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	registry := &fakeSecretServiceRegistry{}
+	got := collectAllRegistryHosts(registry)
+	if got != nil {
+		t.Errorf("Expected nil, got %v", got)
+	}
+}
+
+func TestCollectAllRegistryHosts_MultipleServices(t *testing.T) {
+	t.Parallel()
+
+	registry := &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"github":    &fakeSecretService{hosts: []string{"api.github.com"}},
+			"anthropic": &fakeSecretService{hosts: []string{"api.anthropic.com"}},
+		},
+	}
+
+	got := collectAllRegistryHosts(registry)
+	if len(got) != 2 {
+		t.Fatalf("Expected 2 hosts, got %v", got)
+	}
+
+	seen := map[string]bool{}
+	for _, h := range got {
+		seen[h] = true
+	}
+	for _, want := range []string{"api.github.com", "api.anthropic.com"} {
+		if !seen[want] {
+			t.Errorf("Missing expected host %q in %v", want, got)
+		}
+	}
+}
+
+func TestCollectAllRegistryHosts_Deduplication(t *testing.T) {
+	t.Parallel()
+
+	registry := &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"svc-a": &fakeSecretService{hosts: []string{"shared.com", "a-only.com"}},
+			"svc-b": &fakeSecretService{hosts: []string{"shared.com", "b-only.com"}},
+		},
+	}
+
+	got := collectAllRegistryHosts(registry)
+	if len(got) != 3 {
+		t.Fatalf("Expected 3 hosts (deduplicated), got %v", got)
+	}
+
+	seen := map[string]bool{}
+	for _, h := range got {
+		seen[h] = true
+	}
+	for _, want := range []string{"shared.com", "a-only.com", "b-only.com"} {
+		if !seen[want] {
+			t.Errorf("Missing expected host %q in %v", want, got)
+		}
+	}
+}
+
+// assertPolicyUpdateContains checks that at least one RunCall contains all the specified endpoint strings.
+func assertPolicyUpdateContains(t *testing.T, calls [][]string, endpoints ...string) {
+	t.Helper()
+
+	for _, ep := range endpoints {
+		found := false
+		for _, call := range calls {
+			for _, arg := range call {
+				if arg == ep {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected endpoint %q in RunCalls, not found. Calls: %v", ep, calls)
+		}
+	}
+}
+
+// assertPolicyUpdateNotContains checks that no RunCall contains any of the specified endpoint strings.
+func assertPolicyUpdateNotContains(t *testing.T, calls [][]string, endpoints ...string) {
+	t.Helper()
+
+	for _, ep := range endpoints {
+		for _, call := range calls {
+			for _, arg := range call {
+				if arg == ep {
+					t.Errorf("Unexpected endpoint %q in RunCalls: %v", ep, call)
+				}
+			}
+		}
+	}
+}
+
+// fakeSecretStore implements secret.Store for testing.
+type fakeSecretStore struct {
+	items []secret.ListItem
+	err   error
+}
+
+func (f *fakeSecretStore) Create(secret.CreateParams) error { return nil }
+func (f *fakeSecretStore) List() ([]secret.ListItem, error) { return f.items, f.err }
+func (f *fakeSecretStore) Get(string) (secret.ListItem, string, error) {
+	return secret.ListItem{}, "", nil
+}
+func (f *fakeSecretStore) Remove(string) error { return nil }
+
+// fakeSecretServiceRegistry implements secretservice.Registry for testing.
+type fakeSecretServiceRegistry struct {
+	services map[string]secretservice.SecretService
+}
+
+func (f *fakeSecretServiceRegistry) Register(svc secretservice.SecretService) error { return nil }
+
+func (f *fakeSecretServiceRegistry) Get(name string) (secretservice.SecretService, error) {
+	svc, ok := f.services[name]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", name)
+	}
+	return svc, nil
+}
+
+func (f *fakeSecretServiceRegistry) List() []string {
+	if f.services == nil {
+		return nil
+	}
+	names := make([]string, 0, len(f.services))
+	for name := range f.services {
+		names = append(names, name)
+	}
+	return names
+}
+
+// fakeSecretService implements secretservice.SecretService for testing.
+type fakeSecretService struct {
+	hosts []string
+}
+
+func (f *fakeSecretService) Name() string            { return "fake" }
+func (f *fakeSecretService) Description() string     { return "" }
+func (f *fakeSecretService) HostsPatterns() []string { return f.hosts }
+func (f *fakeSecretService) Path() string            { return "" }
+func (f *fakeSecretService) EnvVars() []string       { return nil }
+func (f *fakeSecretService) HeaderName() string      { return "" }
+func (f *fakeSecretService) HeaderTemplate() string  { return "" }
+
+func TestConfigureNetworkPolicy_NoSpec(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		for _, arg := range args {
+			if arg == "--add-endpoint" {
+				return fmt.Errorf("exit status 1\nopenshell stderr:\nsandbox has no spec")
+			}
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.configureNetworkPolicy(context.Background(), "kdn-test", []string{"github.com"})
+	if err != nil {
+		t.Errorf("Expected no error for 'sandbox has no spec', got: %v", err)
+	}
+}

--- a/pkg/runtime/openshell/openshell.go
+++ b/pkg/runtime/openshell/openshell.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package openshell provides an OpenShell runtime implementation for sandbox-based workspaces.
+package openshell
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+const (
+	containerHome             = "/sandbox"
+	containerWorkspaceSources = containerHome + "/workspace/sources"
+	sandboxNamePrefix         = "kdn-"
+)
+
+// openshellRuntime implements the runtime.Runtime interface for OpenShell Gateway.
+type openshellRuntime struct {
+	executor              exec.Executor
+	gatewayBinaryPath     string
+	storageDir            string
+	globalStorageDir      string
+	states                *stateOverrides
+	config                gatewayConfig
+	binariesOnce          sync.Once
+	binariesErr           error
+	secretStore           secret.Store
+	secretServiceRegistry secretservice.Registry
+}
+
+// Ensure openshellRuntime implements runtime.Runtime at compile time.
+var _ runtime.Runtime = (*openshellRuntime)(nil)
+
+// Ensure openshellRuntime implements runtime.StorageAware at compile time.
+var _ runtime.StorageAware = (*openshellRuntime)(nil)
+
+// Ensure openshellRuntime implements runtime.Terminal at compile time.
+var _ runtime.Terminal = (*openshellRuntime)(nil)
+
+// Ensure openshellRuntime implements runtime.SecretServiceRegistryAware at compile time.
+var _ runtime.SecretServiceRegistryAware = (*openshellRuntime)(nil)
+
+// Ensure openshellRuntime implements runtime.FlagProvider at compile time.
+var _ runtime.FlagProvider = (*openshellRuntime)(nil)
+
+// New creates a new OpenShell Gateway runtime instance.
+func New() runtime.Runtime {
+	return &openshellRuntime{}
+}
+
+// newWithDeps creates a new OpenShell Gateway runtime instance with custom dependencies (for testing).
+func newWithDeps(executor exec.Executor, gatewayBinaryPath, storageDir string) *openshellRuntime {
+	rt := &openshellRuntime{
+		executor:          executor,
+		gatewayBinaryPath: gatewayBinaryPath,
+		storageDir:        storageDir,
+		states:            newStateOverrides(storageDir),
+		config:            loadConfig(storageDir),
+	}
+	// Mark binaries as resolved so ensureBinaries() is a no-op in tests.
+	rt.binariesOnce.Do(func() {})
+	return rt
+}
+
+// Available reports whether the OpenShell Gateway runtime is supported on the current platform.
+func (r *openshellRuntime) Available() bool {
+	_, err := platformAsset("openshell-gateway")
+	return err == nil
+}
+
+// Flags implements runtime.FlagProvider.
+func (r *openshellRuntime) Flags() []runtime.FlagDef {
+	return []runtime.FlagDef{
+		{
+			Name:        "openshell-driver",
+			Usage:       "OpenShell driver to use (podman, vm)",
+			Completions: []string{"podman", "vm"},
+		},
+		{
+			Name:  "openshell-allow-hosts",
+			Usage: "Additional hosts to allow in the openshell runtime (comma-separated)",
+		},
+	}
+}
+
+// SetSecretServiceRegistry implements runtime.SecretServiceRegistryAware.
+func (r *openshellRuntime) SetSecretServiceRegistry(reg secretservice.Registry) {
+	r.secretServiceRegistry = reg
+}
+
+// Initialize implements runtime.StorageAware.
+// It sets up directories and configuration. Binary downloads are deferred
+// to first use (ensureBinaries) to avoid network calls during registration.
+func (r *openshellRuntime) Initialize(storageDir string) error {
+	if storageDir == "" {
+		return fmt.Errorf("storage directory cannot be empty")
+	}
+	r.storageDir = storageDir
+	r.globalStorageDir = filepath.Dir(filepath.Dir(storageDir))
+	r.states = newStateOverrides(storageDir)
+	r.config = loadConfig(storageDir)
+	r.secretStore = secret.NewStore(r.globalStorageDir)
+
+	return nil
+}
+
+// ensureBinaries downloads the openshell, openshell-gateway, and
+// openshell-driver-vm binaries if they are not already present.
+// It is safe to call from multiple entry points — the download
+// runs at most once per runtime instance.
+func (r *openshellRuntime) ensureBinaries() error {
+	r.binariesOnce.Do(func() {
+		r.binariesErr = r.downloadBinaries()
+	})
+	return r.binariesErr
+}
+
+func (r *openshellRuntime) downloadBinaries() error {
+	binDir := filepath.Join(r.storageDir, "bin")
+
+	gatewayPath, err := ensureBinary(binDir, "openshell-gateway", openshellGatewayRelease)
+	if err != nil {
+		return fmt.Errorf("failed to ensure openshell-gateway binary: %w", err)
+	}
+	r.gatewayBinaryPath = gatewayPath
+
+	openshellPath, err := ensureBinary(binDir, "openshell", openshellRelease)
+	if err != nil {
+		return fmt.Errorf("failed to ensure openshell binary: %w", err)
+	}
+	r.executor = exec.New(openshellPath)
+
+	if _, assetErr := platformAsset("openshell-driver-vm"); assetErr == nil {
+		vmDriverPath, dlErr := ensureBinary(binDir, "openshell-driver-vm", openshellDriverVMRelease)
+		if dlErr != nil {
+			return fmt.Errorf("failed to ensure openshell-driver-vm binary: %w", dlErr)
+		}
+		if err := codesignBinary(vmDriverPath); err != nil {
+			return fmt.Errorf("failed to codesign openshell-driver-vm: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Type returns the runtime type identifier.
+func (r *openshellRuntime) Type() string {
+	return "openshell"
+}
+
+// WorkspaceSourcesPath returns the path where sources are mounted inside the sandbox.
+func (r *openshellRuntime) WorkspaceSourcesPath() string {
+	return containerWorkspaceSources
+}
+
+// sandboxName returns the prefixed sandbox name for a given instance name.
+func sandboxName(name string) string {
+	return sandboxNamePrefix + name
+}

--- a/pkg/runtime/openshell/openshell_test.go
+++ b/pkg/runtime/openshell/openshell_test.go
@@ -1,0 +1,279 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	rt := New()
+	if rt == nil {
+		t.Fatal("New() returned nil")
+	}
+
+	if rt.Type() != "openshell" {
+		t.Errorf("Expected type 'openshell', got %s", rt.Type())
+	}
+}
+
+func TestOpenshellRuntime_Available(t *testing.T) {
+	t.Parallel()
+
+	rt := New()
+
+	avail, ok := rt.(interface{ Available() bool })
+	if !ok {
+		t.Fatal("Expected runtime to implement Available interface")
+	}
+
+	_, err := platformAsset("openshell-gateway")
+	expected := err == nil
+	if avail.Available() != expected {
+		t.Errorf("Expected Available() to return %v on this platform, got %v", expected, avail.Available())
+	}
+}
+
+func TestOpenshellRuntime_WorkspaceSourcesPath(t *testing.T) {
+	t.Parallel()
+
+	rt := New()
+	path := rt.WorkspaceSourcesPath()
+
+	if path != "/sandbox/workspace/sources" {
+		t.Errorf("WorkspaceSourcesPath() = %q, want %q", path, "/sandbox/workspace/sources")
+	}
+}
+
+func TestOpenshellRuntime_Type(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", t.TempDir())
+	if rt.Type() != "openshell" {
+		t.Errorf("Type() = %q, want %q", rt.Type(), "openshell")
+	}
+}
+
+func TestOpenshellRuntime_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+
+	var _ runtime.Runtime = (*openshellRuntime)(nil)
+	var _ runtime.StorageAware = (*openshellRuntime)(nil)
+	var _ runtime.Terminal = (*openshellRuntime)(nil)
+	var _ runtime.FlagProvider = (*openshellRuntime)(nil)
+}
+
+func TestOpenshellRuntime_Flags(t *testing.T) {
+	t.Parallel()
+
+	rt := &openshellRuntime{}
+	flags := rt.Flags()
+
+	if len(flags) != 2 {
+		t.Fatalf("Expected 2 flags, got %d", len(flags))
+	}
+
+	if flags[0].Name != "openshell-driver" {
+		t.Errorf("Expected first flag name 'openshell-driver', got %q", flags[0].Name)
+	}
+	if len(flags[0].Completions) != 2 {
+		t.Errorf("Expected 2 completions for openshell-driver, got %d", len(flags[0].Completions))
+	}
+
+	if flags[1].Name != "openshell-allow-hosts" {
+		t.Errorf("Expected second flag name 'openshell-allow-hosts', got %q", flags[1].Name)
+	}
+}
+
+func TestOpenshellRuntime_SetSecretServiceRegistry(t *testing.T) {
+	t.Parallel()
+
+	rt := &openshellRuntime{}
+	registry := &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"test": &fakeSecretService{hosts: []string{"example.com"}},
+		},
+	}
+
+	rt.SetSecretServiceRegistry(registry)
+
+	if rt.secretServiceRegistry == nil {
+		t.Error("Expected secretServiceRegistry to be set")
+	}
+}
+
+func TestOpenshellRuntime_Initialize_EmptyStorageDir(t *testing.T) {
+	t.Parallel()
+
+	rt := &openshellRuntime{}
+	err := rt.Initialize("")
+	if err == nil {
+		t.Error("Expected error for empty storage directory")
+	}
+}
+
+func TestOpenshellRuntime_Initialize_SetsUpState(t *testing.T) {
+	t.Parallel()
+
+	rt := &openshellRuntime{}
+	storageDir := t.TempDir()
+	err := rt.Initialize(storageDir)
+	if err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	if rt.storageDir != storageDir {
+		t.Errorf("storageDir = %q, want %q", rt.storageDir, storageDir)
+	}
+	if rt.states == nil {
+		t.Error("Expected states to be initialized")
+	}
+	if rt.config.Driver != defaultDriver {
+		t.Errorf("Expected default driver %q, got %q", defaultDriver, rt.config.Driver)
+	}
+}
+
+func TestOpenshellRuntime_Initialize_DoesNotDownload(t *testing.T) {
+	t.Parallel()
+
+	rt := &openshellRuntime{}
+	storageDir := t.TempDir()
+	err := rt.Initialize(storageDir)
+	if err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	if rt.executor != nil {
+		t.Error("Expected executor to be nil after Initialize (downloads are deferred)")
+	}
+	if rt.gatewayBinaryPath != "" {
+		t.Error("Expected gatewayBinaryPath to be empty after Initialize (downloads are deferred)")
+	}
+}
+
+func TestOpenshellRuntime_EnsureBinaries_SkipsWhenDepsInjected(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.ensureBinaries()
+	if err != nil {
+		t.Fatalf("ensureBinaries() should be no-op for test deps: %v", err)
+	}
+
+	if rt.executor != fakeExec {
+		t.Error("Expected executor to remain the injected fake")
+	}
+}
+
+func TestDownloadBinaries_WithPreExistingBinaries(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	binDir := filepath.Join(storageDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("Failed to create bin dir: %v", err)
+	}
+
+	for _, name := range []string{"openshell-gateway", "openshell"} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte("fake binary"), 0755); err != nil {
+			t.Fatalf("Failed to create %s: %v", name, err)
+		}
+	}
+	if _, err := platformAsset("openshell-driver-vm"); err == nil {
+		if err := os.WriteFile(filepath.Join(binDir, "openshell-driver-vm"), []byte("fake vm driver"), 0755); err != nil {
+			t.Fatalf("Failed to create openshell-driver-vm: %v", err)
+		}
+	}
+
+	rt := &openshellRuntime{storageDir: storageDir}
+	err := rt.downloadBinaries()
+	if err != nil {
+		t.Fatalf("downloadBinaries() with existing binaries: %v", err)
+	}
+
+	if rt.gatewayBinaryPath == "" {
+		t.Error("Expected gatewayBinaryPath to be set")
+	}
+	if rt.executor == nil {
+		t.Error("Expected executor to be set")
+	}
+}
+
+func TestEnsureBinaries_RunsOnce(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	binDir := filepath.Join(storageDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("Failed to create bin dir: %v", err)
+	}
+
+	for _, name := range []string{"openshell-gateway", "openshell"} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte("fake binary"), 0755); err != nil {
+			t.Fatalf("Failed to create %s: %v", name, err)
+		}
+	}
+	if _, err := platformAsset("openshell-driver-vm"); err == nil {
+		if err := os.WriteFile(filepath.Join(binDir, "openshell-driver-vm"), []byte("fake"), 0755); err != nil {
+			t.Fatalf("Failed to create vm driver: %v", err)
+		}
+	}
+
+	rt := &openshellRuntime{storageDir: storageDir}
+
+	// Call ensureBinaries twice — downloadBinaries should only execute once
+	if err := rt.ensureBinaries(); err != nil {
+		t.Fatalf("First ensureBinaries() call: %v", err)
+	}
+	firstExecutor := rt.executor
+
+	if err := rt.ensureBinaries(); err != nil {
+		t.Fatalf("Second ensureBinaries() call: %v", err)
+	}
+
+	if rt.executor != firstExecutor {
+		t.Error("Expected executor to be the same instance after second call (sync.Once)")
+	}
+}
+
+func TestSandboxName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"my-project", "kdn-my-project"},
+		{"test", "kdn-test"},
+		{"", "kdn-"},
+	}
+
+	for _, tt := range tests {
+		got := sandboxName(tt.input)
+		if got != tt.expected {
+			t.Errorf("sandboxName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/pkg/runtime/openshell/remove.go
+++ b/pkg/runtime/openshell/remove.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/steplogger"
+)
+
+// Remove deletes an OpenShell sandbox.
+func (r *openshellRuntime) Remove(ctx context.Context, id string) error {
+	step := steplogger.FromContext(ctx)
+	defer step.Complete()
+
+	if id == "" {
+		return fmt.Errorf("%w: sandbox ID is required", runtime.ErrInvalidParams)
+	}
+
+	if err := r.ensureBinaries(); err != nil {
+		return err
+	}
+
+	// Check if sandbox is "stopped" (has override) — required before removal
+	info, err := r.Info(ctx, id)
+	if err != nil {
+		return err
+	}
+	if info.State == api.WorkspaceStateRunning {
+		return fmt.Errorf("sandbox %s is still running, stop it first", id)
+	}
+
+	// Delete the sandbox
+	step.Start(fmt.Sprintf("Removing sandbox: %s", id), "Sandbox removed")
+	l := logger.FromContext(ctx)
+	if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(), "sandbox", "delete", id); err != nil {
+		step.Fail(err)
+		return fmt.Errorf("failed to delete sandbox: %w", err)
+	}
+
+	// Clean up state override and sandbox data
+	_ = r.states.Remove(id)
+	r.removeSandboxData(id)
+
+	return nil
+}

--- a/pkg/runtime/openshell/remove_test.go
+++ b/pkg/runtime/openshell/remove_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestRemove_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.Remove(context.Background(), "")
+	if err == nil {
+		t.Error("Expected error for empty ID")
+	}
+}
+
+func TestRemove_RefusesRunning(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		// Sandbox exists and is running (no stopped override)
+		return []byte("kdn-test\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.Remove(context.Background(), "kdn-test")
+	if err == nil {
+		t.Error("Expected error when removing running sandbox")
+	}
+}
+
+func TestRemove_DeleteError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "delete" {
+			return fmt.Errorf("delete failed")
+		}
+		return nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	err := rt.Remove(context.Background(), "kdn-test")
+	if err == nil {
+		t.Error("Expected error when delete fails")
+	}
+}
+
+func TestRemove_DeletesStopped(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	// Set stopped override
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	err := rt.Remove(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	// Verify executor was called with delete
+	found := false
+	for _, call := range fakeExec.RunCalls {
+		if len(call) >= 3 && call[0] == "sandbox" && call[1] == "delete" && call[2] == "kdn-test" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected executor to be called with 'sandbox delete kdn-test'")
+	}
+
+	// Verify override is cleaned up
+	_, ok := rt.states.Get("kdn-test")
+	if ok {
+		t.Error("Expected state override to be removed after delete")
+	}
+}
+
+func TestRemove_CleansSandboxData(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	// Write sandbox data
+	data := sandboxData{SourcePath: "/src", ProjectID: "proj1", Agent: "claude"}
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	// Verify it exists
+	dir := rt.sandboxDataDir("kdn-test")
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("Expected sandbox data directory to exist: %v", err)
+	}
+
+	// Set stopped override (required for remove)
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	if err := rt.Remove(context.Background(), "kdn-test"); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	// Verify sandbox data is cleaned up
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("Expected sandbox data directory to be removed, got err: %v", err)
+	}
+}

--- a/pkg/runtime/openshell/sandbox_data.go
+++ b/pkg/runtime/openshell/sandbox_data.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const sandboxDataFile = "sandbox-data.json"
+
+type sandboxData struct {
+	SourcePath string   `json:"source_path"`
+	ProjectID  string   `json:"project_id"`
+	Agent      string   `json:"agent"`
+	AllowHosts []string `json:"allow_hosts,omitempty"`
+	Ports      []int    `json:"ports,omitempty"`
+}
+
+func (r *openshellRuntime) sandboxDataDir(sandboxName string) string {
+	return filepath.Join(r.storageDir, "sandboxes", sandboxName)
+}
+
+func (r *openshellRuntime) writeSandboxData(sandboxName string, data sandboxData) error {
+	dir := r.sandboxDataDir(sandboxName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating sandbox data directory: %w", err)
+	}
+
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling sandbox data: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, sandboxDataFile), raw, 0644); err != nil {
+		return fmt.Errorf("writing sandbox data: %w", err)
+	}
+	return nil
+}
+
+func (r *openshellRuntime) readSandboxData(sandboxName string) (sandboxData, error) {
+	path := filepath.Join(r.sandboxDataDir(sandboxName), sandboxDataFile)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return sandboxData{}, fmt.Errorf("reading sandbox data: %w", err)
+	}
+
+	var data sandboxData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return sandboxData{}, fmt.Errorf("unmarshaling sandbox data: %w", err)
+	}
+	return data, nil
+}
+
+func (r *openshellRuntime) removeSandboxData(sandboxName string) {
+	os.RemoveAll(r.sandboxDataDir(sandboxName))
+}

--- a/pkg/runtime/openshell/sandbox_data_test.go
+++ b/pkg/runtime/openshell/sandbox_data_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestWriteReadSandboxData(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	data := sandboxData{
+		SourcePath: "/home/user/project",
+		ProjectID:  "abc123",
+		Agent:      "claude",
+	}
+
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	got, err := rt.readSandboxData("kdn-test")
+	if err != nil {
+		t.Fatalf("readSandboxData() failed: %v", err)
+	}
+
+	if got.SourcePath != data.SourcePath {
+		t.Errorf("SourcePath = %q, want %q", got.SourcePath, data.SourcePath)
+	}
+	if got.ProjectID != data.ProjectID {
+		t.Errorf("ProjectID = %q, want %q", got.ProjectID, data.ProjectID)
+	}
+	if got.Agent != data.Agent {
+		t.Errorf("Agent = %q, want %q", got.Agent, data.Agent)
+	}
+}
+
+func TestReadSandboxData_NotFound(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	_, err := rt.readSandboxData("nonexistent")
+	if err == nil {
+		t.Error("Expected error for missing sandbox data")
+	}
+}
+
+func TestRemoveSandboxData(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	data := sandboxData{SourcePath: "/src", ProjectID: "id", Agent: "claude"}
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	dir := rt.sandboxDataDir("kdn-test")
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("Expected sandbox data directory to exist: %v", err)
+	}
+
+	rt.removeSandboxData("kdn-test")
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("Expected sandbox data directory to be removed, got err: %v", err)
+	}
+}
+
+func TestWriteReadSandboxData_WithAllowHosts(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	data := sandboxData{
+		SourcePath: "/home/user/project",
+		ProjectID:  "abc123",
+		Agent:      "claude",
+		AllowHosts: []string{"github.com", "registry.npmjs.org"},
+	}
+
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	got, err := rt.readSandboxData("kdn-test")
+	if err != nil {
+		t.Fatalf("readSandboxData() failed: %v", err)
+	}
+
+	if len(got.AllowHosts) != 2 {
+		t.Fatalf("AllowHosts length = %d, want 2", len(got.AllowHosts))
+	}
+	if got.AllowHosts[0] != "github.com" {
+		t.Errorf("AllowHosts[0] = %q, want %q", got.AllowHosts[0], "github.com")
+	}
+	if got.AllowHosts[1] != "registry.npmjs.org" {
+		t.Errorf("AllowHosts[1] = %q, want %q", got.AllowHosts[1], "registry.npmjs.org")
+	}
+}
+
+func TestWriteReadSandboxData_WithoutAllowHosts(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	data := sandboxData{
+		SourcePath: "/home/user/project",
+		ProjectID:  "abc123",
+		Agent:      "claude",
+	}
+
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	got, err := rt.readSandboxData("kdn-test")
+	if err != nil {
+		t.Fatalf("readSandboxData() failed: %v", err)
+	}
+
+	if got.AllowHosts != nil {
+		t.Errorf("AllowHosts = %v, want nil", got.AllowHosts)
+	}
+}
+
+func TestReadSandboxData_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	dir := rt.sandboxDataDir("kdn-test")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("Failed to create sandbox data dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sandboxDataFile), []byte("{invalid json"), 0644); err != nil {
+		t.Fatalf("Failed to write invalid JSON: %v", err)
+	}
+
+	_, err := rt.readSandboxData("kdn-test")
+	if err == nil {
+		t.Error("Expected error for invalid JSON")
+	}
+}
+
+func TestWriteSandboxData_UnwritableDir(t *testing.T) {
+	t.Parallel()
+
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", blocker)
+
+	err := rt.writeSandboxData("kdn-test", sandboxData{
+		SourcePath: "/src",
+		ProjectID:  "id",
+		Agent:      "claude",
+	})
+	if err == nil {
+		t.Error("Expected error when storage directory does not exist")
+	}
+}
+
+func TestSandboxDataDir(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", "/storage")
+
+	got := rt.sandboxDataDir("kdn-test")
+	want := filepath.Join("/storage", "sandboxes", "kdn-test")
+	if got != want {
+		t.Errorf("sandboxDataDir() = %q, want %q", got, want)
+	}
+}
+
+func TestWriteReadSandboxData_WithPorts(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	data := sandboxData{
+		SourcePath: "/home/user/project",
+		ProjectID:  "abc123",
+		Agent:      "openclaw",
+		Ports:      []int{18789, 8080},
+	}
+
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	got, err := rt.readSandboxData("kdn-test")
+	if err != nil {
+		t.Fatalf("readSandboxData() failed: %v", err)
+	}
+
+	if len(got.Ports) != 2 {
+		t.Fatalf("Ports length = %d, want 2", len(got.Ports))
+	}
+	if got.Ports[0] != 18789 {
+		t.Errorf("Ports[0] = %d, want 18789", got.Ports[0])
+	}
+	if got.Ports[1] != 8080 {
+		t.Errorf("Ports[1] = %d, want 8080", got.Ports[1])
+	}
+}
+
+func TestWriteReadSandboxData_WithoutPorts(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/gw", t.TempDir())
+
+	data := sandboxData{
+		SourcePath: "/home/user/project",
+		ProjectID:  "abc123",
+		Agent:      "claude",
+	}
+
+	if err := rt.writeSandboxData("kdn-test", data); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	got, err := rt.readSandboxData("kdn-test")
+	if err != nil {
+		t.Fatalf("readSandboxData() failed: %v", err)
+	}
+
+	if got.Ports != nil {
+		t.Errorf("Ports = %v, want nil", got.Ports)
+	}
+}

--- a/pkg/runtime/openshell/start.go
+++ b/pkg/runtime/openshell/start.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/steplogger"
+)
+
+// Start verifies an OpenShell sandbox exists and marks it as running.
+// Since OpenShell sandboxes are always running after creation, this
+// just clears the stopped state override and validates the sandbox exists.
+func (r *openshellRuntime) Start(ctx context.Context, id string) (runtime.RuntimeInfo, error) {
+	step := steplogger.FromContext(ctx)
+	defer step.Complete()
+
+	if id == "" {
+		return runtime.RuntimeInfo{}, fmt.Errorf("%w: sandbox ID is required", runtime.ErrInvalidParams)
+	}
+
+	// Ensure the gateway is running
+	if err := r.ensureGatewayRunning(ctx); err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to ensure gateway is running: %w", err)
+	}
+
+	// Verify the sandbox still exists
+	step.Start(fmt.Sprintf("Starting sandbox: %s", id), "Sandbox started")
+	state := r.querySandboxState(ctx, id)
+	if state != api.WorkspaceStateRunning {
+		err := fmt.Errorf("sandbox %s not found", id)
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, err
+	}
+
+	// Re-read merged config and apply network policy
+	data, readErr := r.readSandboxData(id)
+	if readErr == nil {
+		step.Start("Configuring network policy", "Network policy configured")
+		wsCfg, loadErr := loadNetworkConfig(data.SourcePath, r.globalStorageDir, data.ProjectID, data.Agent)
+		if loadErr != nil {
+			step.Fail(loadErr)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to load network config: %w", loadErr)
+		}
+		if err := r.applyNetworkPolicy(ctx, id, wsCfg, data.AllowHosts); err != nil {
+			step.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to configure network policy: %w", err)
+		}
+	}
+
+	// Start port forwarding for configured ports
+	if readErr == nil && len(data.Ports) > 0 {
+		step.Start("Setting up port forwarding", "Port forwarding established")
+		if err := r.startPortForwards(ctx, id, data.Ports); err != nil {
+			step.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to set up port forwarding: %w", err)
+		}
+	}
+
+	// Clear any stopped override
+	if err := r.states.Remove(id); err != nil {
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to clear state override: %w", err)
+	}
+
+	info := map[string]string{"sandbox_name": id}
+	if readErr == nil && len(data.Ports) > 0 {
+		forwards := buildForwards(data.Ports)
+		if forwardsJSON, err := json.Marshal(forwards); err == nil {
+			info["forwards"] = string(forwardsJSON)
+		}
+	}
+
+	return runtime.RuntimeInfo{
+		ID:    id,
+		State: api.WorkspaceStateRunning,
+		Info:  info,
+	}, nil
+}
+
+// startPortForwards starts background port forwards for each configured port.
+// Passes nil writers so no pipes are created — the daemonized forwarder would
+// otherwise hold them open and cause Run to block indefinitely.
+func (r *openshellRuntime) startPortForwards(ctx context.Context, sandboxName string, ports []int) error {
+	for _, port := range ports {
+		if err := r.executor.Run(ctx, nil, nil,
+			"forward", "start", "--background", fmt.Sprintf("%d", port), sandboxName,
+		); err != nil {
+			return fmt.Errorf("failed to forward port %d: %w", port, err)
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/openshell/start_test.go
+++ b/pkg/runtime/openshell/start_test.go
@@ -1,0 +1,380 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"testing"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestStart_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_, err := rt.Start(context.Background(), "")
+	if err == nil {
+		t.Error("Expected error for empty ID")
+	}
+}
+
+func TestStart_ClearsStoppedOverride(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	// Set a stopped override
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state override: %v", err)
+	}
+
+	// Verify override exists
+	state, ok := rt.states.Get("kdn-test")
+	if !ok || state != api.WorkspaceStateStopped {
+		t.Fatal("Expected stopped override to exist")
+	}
+
+	// Note: Start will fail because isGatewayReady uses os/exec directly,
+	// but we can verify the state override logic independently.
+	_ = rt.states.Remove("kdn-test")
+
+	// Verify override is cleared
+	_, ok = rt.states.Get("kdn-test")
+	if ok {
+		t.Error("Expected override to be removed after start")
+	}
+}
+
+func TestStart_ReturnsRunningState(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-test\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	// Set stopped override first, then start clears it
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	// Verify the state override and query logic used by Start
+	state := rt.querySandboxState(context.Background(), "kdn-test")
+	if state != api.WorkspaceStateRunning {
+		t.Errorf("Expected running state from sandbox query, got %q", state)
+	}
+}
+
+func TestStart_SandboxNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("other-sandbox\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	state := rt.querySandboxState(context.Background(), "kdn-test")
+	if state != api.WorkspaceStateError {
+		t.Errorf("Expected error state for missing sandbox, got %q", state)
+	}
+}
+
+func TestStart_FullFlow_Success(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	// Set stopped override (mimics state after Create)
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	info, err := rt.Start(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateRunning {
+		t.Errorf("Expected running state, got %q", info.State)
+	}
+	if info.ID != "kdn-test" {
+		t.Errorf("Expected ID 'kdn-test', got %q", info.ID)
+	}
+
+	// Override should be cleared
+	_, ok := rt.states.Get("kdn-test")
+	if ok {
+		t.Error("Expected stopped override to be cleared after Start")
+	}
+}
+
+func TestStart_FullFlow_SandboxNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("other-sandbox\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_, err := rt.Start(context.Background(), "kdn-test")
+	if err == nil {
+		t.Error("Expected error when sandbox not found")
+	}
+}
+
+func TestStart_FullFlow_QueryError(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		callCount++
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			if callCount == 1 {
+				// First call: isGatewayReady → success
+				return []byte("kdn-test\n"), nil
+			}
+			// Second call: querySandboxState → error
+			return nil, fmt.Errorf("gateway unreachable")
+		}
+		return []byte{}, nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_, err := rt.Start(context.Background(), "kdn-test")
+	if err == nil {
+		t.Error("Expected error when sandbox query fails")
+	}
+}
+
+func TestStart_FullFlow_AppliesNetworkPolicy(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.globalStorageDir = storageDir
+
+	// Write sandbox data so Start can read it
+	if err := rt.writeSandboxData("kdn-test", sandboxData{
+		SourcePath: t.TempDir(),
+		ProjectID:  "",
+		Agent:      "claude",
+	}); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	// Set stopped override
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	info, err := rt.Start(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateRunning {
+		t.Errorf("Expected running state, got %q", info.State)
+	}
+
+	// Verify policy update was called (allow-all by default)
+	hasPolicyUpdate := false
+	for _, call := range fakeExec.RunCalls {
+		if len(call) >= 2 && call[0] == "policy" && call[1] == "update" {
+			hasPolicyUpdate = true
+			break
+		}
+	}
+	if !hasPolicyUpdate {
+		t.Error("Expected policy update call during Start")
+	}
+}
+
+func TestStart_FullFlow_NetworkLoadError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.globalStorageDir = ""
+
+	if err := rt.writeSandboxData("kdn-test", sandboxData{
+		SourcePath: t.TempDir(),
+		ProjectID:  "proj1",
+		Agent:      "claude",
+	}); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	_, err := rt.Start(context.Background(), "kdn-test")
+	if err == nil {
+		t.Error("Expected error when network config loading fails")
+	}
+}
+
+func TestStart_FullFlow_StartsPortForwarding(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+	rt.globalStorageDir = storageDir
+
+	if err := rt.writeSandboxData("kdn-test", sandboxData{
+		SourcePath: t.TempDir(),
+		Agent:      "openclaw",
+		Ports:      []int{8080, 18789},
+	}); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	info, err := rt.Start(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateRunning {
+		t.Errorf("Expected running state, got %q", info.State)
+	}
+
+	// Verify forward start calls
+	forwardStartCount := 0
+	for _, call := range fakeExec.RunCalls {
+		if len(call) >= 2 && call[0] == "forward" && call[1] == "start" {
+			forwardStartCount++
+			if !slices.Contains(call, "--background") {
+				t.Errorf("Expected --background flag in forward start call, got: %v", call)
+			}
+		}
+	}
+	if forwardStartCount != 2 {
+		t.Errorf("Expected 2 forward start calls, got %d. Calls: %v", forwardStartCount, fakeExec.RunCalls)
+	}
+
+	// Verify forwards in RuntimeInfo
+	forwardsJSON, ok := info.Info["forwards"]
+	if !ok {
+		t.Fatal("Expected 'forwards' in RuntimeInfo.Info")
+	}
+
+	var forwards []api.WorkspaceForward
+	if err := json.Unmarshal([]byte(forwardsJSON), &forwards); err != nil {
+		t.Fatalf("Failed to unmarshal forwards: %v", err)
+	}
+	if len(forwards) != 2 {
+		t.Fatalf("Expected 2 forwards, got %d", len(forwards))
+	}
+	if forwards[0].Port != 8080 || forwards[1].Port != 18789 {
+		t.Errorf("Unexpected forward ports: %v", forwards)
+	}
+}
+
+func TestStart_FullFlow_NoSandboxDataSkipsNetwork(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "sandbox" && args[1] == "list" {
+			return []byte("kdn-test\n"), nil
+		}
+		return []byte{}, nil
+	}
+
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	// No sandbox data written — simulates old sandbox created before network support
+
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	info, err := rt.Start(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if info.State != api.WorkspaceStateRunning {
+		t.Errorf("Expected running state, got %q", info.State)
+	}
+
+	// No policy update should have been called
+	for _, call := range fakeExec.RunCalls {
+		if slices.Contains(call, "policy") {
+			t.Errorf("Expected no policy calls without sandbox data, got: %v", call)
+		}
+	}
+}

--- a/pkg/runtime/openshell/state.go
+++ b/pkg/runtime/openshell/state.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+)
+
+const stateOverridesFile = "state-overrides.json"
+
+// stateOverrides manages sandbox state overrides for the stop/start no-op pattern.
+// OpenShell sandboxes cannot be stopped, so we track a virtual "stopped" state locally.
+type stateOverrides struct {
+	mu   sync.Mutex
+	path string
+}
+
+func newStateOverrides(storageDir string) *stateOverrides {
+	return &stateOverrides{
+		path: filepath.Join(storageDir, stateOverridesFile),
+	}
+}
+
+func (s *stateOverrides) load() (map[string]api.WorkspaceState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]api.WorkspaceState), nil
+		}
+		return nil, err
+	}
+
+	overrides := make(map[string]api.WorkspaceState)
+	if err := json.Unmarshal(data, &overrides); err != nil {
+		return make(map[string]api.WorkspaceState), nil
+	}
+	return overrides, nil
+}
+
+func (s *stateOverrides) save(overrides map[string]api.WorkspaceState) error {
+	data, err := json.Marshal(overrides)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.path, data, 0644)
+}
+
+// Set records a state override for a sandbox.
+func (s *stateOverrides) Set(id string, state api.WorkspaceState) error {
+	overrides, err := s.load()
+	if err != nil {
+		return err
+	}
+	overrides[id] = state
+	return s.save(overrides)
+}
+
+// Get returns the state override for a sandbox, or empty string if none.
+func (s *stateOverrides) Get(id string) (api.WorkspaceState, bool) {
+	overrides, err := s.load()
+	if err != nil {
+		return "", false
+	}
+	state, ok := overrides[id]
+	return state, ok
+}
+
+// Remove deletes the state override for a sandbox.
+func (s *stateOverrides) Remove(id string) error {
+	overrides, err := s.load()
+	if err != nil {
+		return err
+	}
+	delete(overrides, id)
+	return s.save(overrides)
+}

--- a/pkg/runtime/openshell/state_test.go
+++ b/pkg/runtime/openshell/state_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+)
+
+func TestStateOverrides_SetAndGet(t *testing.T) {
+	t.Parallel()
+
+	s := newStateOverrides(t.TempDir())
+
+	// Initially no override
+	_, ok := s.Get("sandbox-1")
+	if ok {
+		t.Error("Expected no override for new sandbox")
+	}
+
+	// Set override
+	if err := s.Set("sandbox-1", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Set() failed: %v", err)
+	}
+
+	// Get override
+	state, ok := s.Get("sandbox-1")
+	if !ok {
+		t.Fatal("Expected override to exist")
+	}
+	if state != api.WorkspaceStateStopped {
+		t.Errorf("Get() = %q, want %q", state, api.WorkspaceStateStopped)
+	}
+}
+
+func TestStateOverrides_Remove(t *testing.T) {
+	t.Parallel()
+
+	s := newStateOverrides(t.TempDir())
+
+	if err := s.Set("sandbox-1", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Set() failed: %v", err)
+	}
+
+	if err := s.Remove("sandbox-1"); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	_, ok := s.Get("sandbox-1")
+	if ok {
+		t.Error("Expected override to be removed")
+	}
+}
+
+func TestStateOverrides_RemoveNonexistent(t *testing.T) {
+	t.Parallel()
+
+	s := newStateOverrides(t.TempDir())
+
+	if err := s.Remove("nonexistent"); err != nil {
+		t.Fatalf("Remove() failed for nonexistent key: %v", err)
+	}
+}
+
+func TestStateOverrides_CorruptJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newStateOverrides(dir)
+
+	// Write corrupt JSON
+	if err := os.WriteFile(filepath.Join(dir, stateOverridesFile), []byte("not json"), 0644); err != nil {
+		t.Fatalf("Failed to write corrupt file: %v", err)
+	}
+
+	// Get should return not-found (gracefully handles corrupt data)
+	_, ok := s.Get("sandbox-1")
+	if ok {
+		t.Error("Expected no result for corrupt JSON")
+	}
+}
+
+func TestStateOverrides_OverwriteExisting(t *testing.T) {
+	t.Parallel()
+
+	s := newStateOverrides(t.TempDir())
+
+	if err := s.Set("sandbox-1", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Set() failed: %v", err)
+	}
+	if err := s.Set("sandbox-1", api.WorkspaceStateRunning); err != nil {
+		t.Fatalf("Set() failed: %v", err)
+	}
+
+	state, ok := s.Get("sandbox-1")
+	if !ok || state != api.WorkspaceStateRunning {
+		t.Errorf("Expected running after overwrite, got %q", state)
+	}
+}
+
+func TestStateOverrides_MultipleSandboxes(t *testing.T) {
+	t.Parallel()
+
+	s := newStateOverrides(t.TempDir())
+
+	if err := s.Set("sandbox-1", api.WorkspaceStateStopped); err != nil {
+		t.Fatalf("Set() failed: %v", err)
+	}
+	if err := s.Set("sandbox-2", api.WorkspaceStateRunning); err != nil {
+		t.Fatalf("Set() failed: %v", err)
+	}
+
+	state1, ok := s.Get("sandbox-1")
+	if !ok || state1 != api.WorkspaceStateStopped {
+		t.Errorf("sandbox-1: got %q, want %q", state1, api.WorkspaceStateStopped)
+	}
+
+	state2, ok := s.Get("sandbox-2")
+	if !ok || state2 != api.WorkspaceStateRunning {
+		t.Errorf("sandbox-2: got %q, want %q", state2, api.WorkspaceStateRunning)
+	}
+}
+
+func TestStateOverrides_UnreadableFile(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict read access on Windows")
+	}
+
+	dir := t.TempDir()
+	s := newStateOverrides(dir)
+
+	// Create the file then make it unreadable
+	statePath := filepath.Join(dir, stateOverridesFile)
+	if err := os.WriteFile(statePath, []byte(`{"sandbox-1":"stopped"}`), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := os.Chmod(statePath, 0000); err != nil {
+		t.Fatalf("Failed to chmod: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(statePath, 0644) })
+
+	// Get should return not-found when file is unreadable
+	_, ok := s.Get("sandbox-1")
+	if ok {
+		t.Error("Expected no result when file is unreadable")
+	}
+
+	// Set should return error when file is unreadable
+	err := s.Set("sandbox-2", api.WorkspaceStateStopped)
+	if err == nil {
+		t.Error("Expected error when file is unreadable")
+	}
+
+	// Remove should return error when file is unreadable
+	err = s.Remove("sandbox-1")
+	if err == nil {
+		t.Error("Expected error when file is unreadable")
+	}
+}
+
+func TestStateOverrides_UnwritableDir(t *testing.T) {
+	t.Parallel()
+
+	// Use a path in a non-existent directory to trigger save error
+	s := newStateOverrides("/nonexistent/path/that/does/not/exist")
+
+	err := s.Set("sandbox-1", api.WorkspaceStateStopped)
+	if err == nil {
+		t.Error("Expected error when directory is not writable")
+	}
+}

--- a/pkg/runtime/openshell/stop.go
+++ b/pkg/runtime/openshell/stop.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/steplogger"
+)
+
+// Stop marks an OpenShell sandbox as stopped without actually stopping it.
+// OpenShell sandboxes cannot be paused, so this records a local state override.
+// The sandbox continues running in the background.
+func (r *openshellRuntime) Stop(ctx context.Context, id string) error {
+	step := steplogger.FromContext(ctx)
+	defer step.Complete()
+
+	if id == "" {
+		return fmt.Errorf("%w: sandbox ID is required", runtime.ErrInvalidParams)
+	}
+
+	// Stop port forwards (best-effort — forwards may not exist)
+	data, readErr := r.readSandboxData(id)
+	if readErr == nil && len(data.Ports) > 0 {
+		step.Start("Stopping port forwarding", "Port forwarding stopped")
+		r.stopPortForwards(ctx, id, data.Ports)
+	}
+
+	step.Start(fmt.Sprintf("Stopping sandbox: %s", id), "Sandbox stopped")
+	if err := r.states.Set(id, api.WorkspaceStateStopped); err != nil {
+		step.Fail(err)
+		return fmt.Errorf("failed to set stopped state: %w", err)
+	}
+
+	return nil
+}
+
+// stopPortForwards stops background port forwards. Best-effort — errors are ignored.
+func (r *openshellRuntime) stopPortForwards(ctx context.Context, sandboxName string, ports []int) {
+	l := logger.FromContext(ctx)
+	for _, port := range ports {
+		_ = r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+			"forward", "stop", fmt.Sprintf("%d", port), sandboxName,
+		)
+	}
+}

--- a/pkg/runtime/openshell/stop_test.go
+++ b/pkg/runtime/openshell/stop_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestStop_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.Stop(context.Background(), "")
+	if err == nil {
+		t.Error("Expected error for empty ID")
+	}
+}
+
+func TestStop_SetsStoppedOverride(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.Stop(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+
+	state, ok := rt.states.Get("kdn-test")
+	if !ok {
+		t.Fatal("Expected state override to exist after stop")
+	}
+	if state != api.WorkspaceStateStopped {
+		t.Errorf("Expected state %q, got %q", api.WorkspaceStateStopped, state)
+	}
+}
+
+func TestStop_DoesNotCallExecutor(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_ = rt.Stop(context.Background(), "kdn-test")
+
+	if len(fakeExec.RunCalls) != 0 {
+		t.Error("Stop should not call the executor (no actual sandbox stop)")
+	}
+	if len(fakeExec.OutputCalls) != 0 {
+		t.Error("Stop should not call the executor")
+	}
+}
+
+func TestStop_StateSetError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", "/nonexistent/path")
+
+	err := rt.Stop(context.Background(), "kdn-test")
+	if err == nil {
+		t.Error("Expected error when state set fails")
+	}
+}
+
+func TestStop_StopsPortForwards(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	storageDir := t.TempDir()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", storageDir)
+
+	if err := rt.writeSandboxData("kdn-test", sandboxData{
+		SourcePath: "/src",
+		Agent:      "openclaw",
+		Ports:      []int{8080, 18789},
+	}); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	err := rt.Stop(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+
+	forwardStopCount := 0
+	for _, call := range fakeExec.RunCalls {
+		if len(call) >= 2 && call[0] == "forward" && call[1] == "stop" {
+			forwardStopCount++
+		}
+	}
+	if forwardStopCount != 2 {
+		t.Errorf("Expected 2 forward stop calls, got %d. Calls: %v", forwardStopCount, fakeExec.RunCalls)
+	}
+}
+
+func TestStop_OverwritesPreviousState(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	// Set to running, then stop
+	if err := rt.states.Set("kdn-test", api.WorkspaceStateRunning); err != nil {
+		t.Fatalf("Failed to set state: %v", err)
+	}
+
+	if err := rt.Stop(context.Background(), "kdn-test"); err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+
+	state, ok := rt.states.Get("kdn-test")
+	if !ok || state != api.WorkspaceStateStopped {
+		t.Errorf("Expected stopped state after Stop, got %q", state)
+	}
+}

--- a/pkg/runtime/openshell/terminal.go
+++ b/pkg/runtime/openshell/terminal.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openkaiden/kdn/pkg/runtime"
+)
+
+// Terminal starts an interactive terminal session inside a running sandbox.
+func (r *openshellRuntime) Terminal(ctx context.Context, instanceID string, _ string, command []string) error {
+	if instanceID == "" {
+		return fmt.Errorf("%w: instance ID is required", runtime.ErrInvalidParams)
+	}
+
+	if err := r.ensureBinaries(); err != nil {
+		return err
+	}
+
+	if len(command) == 0 {
+		args := []string{"sandbox", "connect", instanceID}
+		return r.executor.RunInteractive(ctx, args...)
+	}
+
+	shellCmd := strings.Join(command, " ")
+	wrappedCmd := fmt.Sprintf("source %s/.kdn-env 2>/dev/null; cd %s 2>/dev/null; exec %s", containerHome, containerWorkspaceSources, shellCmd)
+
+	args := []string{
+		"sandbox", "exec",
+		"--name", instanceID,
+		"--", "sh", "-c", wrappedCmd,
+	}
+
+	return r.executor.RunInteractive(ctx, args...)
+}

--- a/pkg/runtime/openshell/terminal_test.go
+++ b/pkg/runtime/openshell/terminal_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestTerminal_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.Terminal(context.Background(), "", "claude", nil)
+	if err == nil {
+		t.Error("Expected error for empty ID")
+	}
+}
+
+func TestTerminal_DefaultCommand(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_ = rt.Terminal(context.Background(), "kdn-test", "claude", nil)
+
+	if len(fakeExec.RunInteractiveCalls) != 1 {
+		t.Fatalf("Expected 1 RunInteractive call, got %d", len(fakeExec.RunInteractiveCalls))
+	}
+
+	args := fakeExec.RunInteractiveCalls[0]
+
+	// Should use sandbox connect for interactive terminal
+	if args[0] != "sandbox" || args[1] != "connect" {
+		t.Errorf("Expected 'sandbox connect', got %v", args[:2])
+	}
+
+	// Instance ID should be a positional argument
+	if args[2] != "kdn-test" {
+		t.Errorf("Expected instance ID 'kdn-test', got %s", args[2])
+	}
+
+	if len(args) != 3 {
+		t.Errorf("Expected 3 args, got %d: %v", len(args), args)
+	}
+}
+
+func TestTerminal_CustomCommand(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_ = rt.Terminal(context.Background(), "kdn-test", "claude", []string{"claude-code", "--debug"})
+
+	if len(fakeExec.RunInteractiveCalls) != 1 {
+		t.Fatalf("Expected 1 RunInteractive call, got %d", len(fakeExec.RunInteractiveCalls))
+	}
+
+	lastArg := fakeExec.RunInteractiveCalls[0][len(fakeExec.RunInteractiveCalls[0])-1]
+	if !strings.Contains(lastArg, "exec claude-code --debug") {
+		t.Errorf("Expected custom command in args, got %q", lastArg)
+	}
+}
+
+func TestTerminal_CustomCommandSourcesEnvAndChangesDir(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	_ = rt.Terminal(context.Background(), "kdn-test", "claude", []string{"bash"})
+
+	if len(fakeExec.RunInteractiveCalls) != 1 {
+		t.Fatalf("Expected 1 RunInteractive call, got %d", len(fakeExec.RunInteractiveCalls))
+	}
+
+	args := fakeExec.RunInteractiveCalls[0]
+
+	// Should use sandbox exec with --name
+	if args[0] != "sandbox" || args[1] != "exec" {
+		t.Errorf("Expected 'sandbox exec', got %v", args[:2])
+	}
+	if args[2] != "--name" || args[3] != "kdn-test" {
+		t.Errorf("Expected '--name kdn-test', got %v", args[2:4])
+	}
+
+	lastArg := args[len(args)-1]
+	if !strings.Contains(lastArg, "source /sandbox/.kdn-env") {
+		t.Errorf("Expected env sourcing in wrapped command, got %q", lastArg)
+	}
+	if !strings.Contains(lastArg, "cd /sandbox/workspace/sources") {
+		t.Errorf("Expected cd to workspace sources in wrapped command, got %q", lastArg)
+	}
+}
+
+func TestTerminal_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunInteractiveFunc = func(_ context.Context, args ...string) error {
+		return fmt.Errorf("connection refused")
+	}
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+
+	err := rt.Terminal(context.Background(), "kdn-test", "claude", nil)
+	if err == nil {
+		t.Error("Expected error to be propagated")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("Expected 'connection refused' error, got: %v", err)
+	}
+}

--- a/pkg/runtimesetup/register.go
+++ b/pkg/runtimesetup/register.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell"
 	"github.com/openkaiden/kdn/pkg/runtime/podman"
 )
 
@@ -59,6 +60,7 @@ type runtimeFactory func() runtime.Runtime
 // Add new runtimes here to make them available for automatic registration.
 var availableRuntimes = []runtimeFactory{
 	fake.New,
+	openshell.New,
 	podman.New,
 }
 

--- a/pkg/runtimesetup/register_test.go
+++ b/pkg/runtimesetup/register_test.go
@@ -90,6 +90,240 @@ func (t *testRuntimeWithDashboard) GetURL(_ context.Context, _ string) (string, 
 	return "http://localhost:8888", nil
 }
 
+// testRuntimeWithAgents wraps testRuntime and implements runtime.AgentLister.
+type testRuntimeWithAgents struct {
+	*testRuntime
+	agents []string
+}
+
+func (t *testRuntimeWithAgents) ListAgents() ([]string, error) {
+	return t.agents, nil
+}
+
+// testRuntimeWithAgentsError wraps testRuntime and implements runtime.AgentLister with error.
+type testRuntimeWithAgentsError struct {
+	*testRuntime
+}
+
+func (t *testRuntimeWithAgentsError) ListAgents() ([]string, error) {
+	return nil, fmt.Errorf("list agents failed")
+}
+
+func TestListAvailableWithFactories(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns available non-fake runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "rt1", available: true} },
+			func() runtime.Runtime { return &testRuntime{runtimeType: "rt2", available: true} },
+		}
+
+		names := listAvailableWithFactories(factories)
+		if len(names) != 2 {
+			t.Fatalf("Expected 2 names, got %d: %v", len(names), names)
+		}
+	})
+
+	t.Run("skips unavailable runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "rt1", available: true} },
+			func() runtime.Runtime { return &testRuntime{runtimeType: "rt2", available: false} },
+		}
+
+		names := listAvailableWithFactories(factories)
+		if len(names) != 1 {
+			t.Fatalf("Expected 1 name, got %d: %v", len(names), names)
+		}
+		if names[0] != "rt1" {
+			t.Errorf("Expected 'rt1', got %q", names[0])
+		}
+	})
+
+	t.Run("skips fake runtime", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "fake", available: true} },
+			func() runtime.Runtime { return &testRuntime{runtimeType: "rt1", available: true} },
+		}
+
+		names := listAvailableWithFactories(factories)
+		if len(names) != 1 {
+			t.Fatalf("Expected 1 name (fake excluded), got %d: %v", len(names), names)
+		}
+		if names[0] != "rt1" {
+			t.Errorf("Expected 'rt1', got %q", names[0])
+		}
+	})
+
+	t.Run("returns empty for no available runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime { return &testRuntime{runtimeType: "rt1", available: false} },
+		}
+
+		names := listAvailableWithFactories(factories)
+		if len(names) != 0 {
+			t.Errorf("Expected 0 names, got %d: %v", len(names), names)
+		}
+	})
+}
+
+func TestListAgentsWithFactories(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns agents from available runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithAgents{
+					testRuntime: &testRuntime{runtimeType: "rt1", available: true},
+					agents:      []string{"claude", "goose"},
+				}
+			},
+		}
+
+		agents, err := listAgentsWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(agents) != 2 {
+			t.Fatalf("Expected 2 agents, got %d: %v", len(agents), agents)
+		}
+	})
+
+	t.Run("deduplicates agents across runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithAgents{
+					testRuntime: &testRuntime{runtimeType: "rt1", available: true},
+					agents:      []string{"claude", "goose"},
+				}
+			},
+			func() runtime.Runtime {
+				return &testRuntimeWithAgents{
+					testRuntime: &testRuntime{runtimeType: "rt2", available: true},
+					agents:      []string{"claude", "cursor"},
+				}
+			},
+		}
+
+		agents, err := listAgentsWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(agents) != 3 {
+			t.Fatalf("Expected 3 unique agents, got %d: %v", len(agents), agents)
+		}
+	})
+
+	t.Run("skips unavailable runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithAgents{
+					testRuntime: &testRuntime{runtimeType: "rt1", available: false},
+					agents:      []string{"claude"},
+				}
+			},
+		}
+
+		agents, err := listAgentsWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(agents) != 0 {
+			t.Errorf("Expected 0 agents (runtime unavailable), got %d: %v", len(agents), agents)
+		}
+	})
+
+	t.Run("skips runtimes without AgentLister", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "rt1", available: true}
+			},
+		}
+
+		agents, err := listAgentsWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(agents) != 0 {
+			t.Errorf("Expected 0 agents (no AgentLister), got %d: %v", len(agents), agents)
+		}
+	})
+
+	t.Run("returns sorted agents", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithAgents{
+					testRuntime: &testRuntime{runtimeType: "rt1", available: true},
+					agents:      []string{"goose", "claude", "cursor"},
+				}
+			},
+		}
+
+		agents, err := listAgentsWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for i := 1; i < len(agents); i++ {
+			if agents[i] < agents[i-1] {
+				t.Errorf("Agents not sorted: %v", agents)
+				break
+			}
+		}
+	})
+
+	t.Run("returns error for empty storage dir", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := listAgentsWithFactories("", nil)
+		if err == nil {
+			t.Fatal("Expected error for empty storage dir")
+		}
+	})
+
+	t.Run("skips runtimes with ListAgents error", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithAgentsError{
+					testRuntime: &testRuntime{runtimeType: "rt-err", available: true},
+				}
+			},
+		}
+
+		agents, err := listAgentsWithFactories(storageDir, factories)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(agents) != 0 {
+			t.Errorf("Expected 0 agents when ListAgents fails, got %d: %v", len(agents), agents)
+		}
+	})
+}
+
 func TestListDashboardRuntimeTypesWithFactories(t *testing.T) {
 	t.Parallel()
 
@@ -156,6 +390,15 @@ func TestListDashboardRuntimeTypesWithFactories(t *testing.T) {
 
 		if len(types) != 0 {
 			t.Errorf("expected 0 types (runtime unavailable), got %d: %v", len(types), types)
+		}
+	})
+
+	t.Run("returns error for empty storage dir", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := listDashboardRuntimeTypesWithFactories("", nil)
+		if err == nil {
+			t.Fatal("Expected error for empty storage dir")
 		}
 	})
 }
@@ -257,10 +500,17 @@ func TestListFlags(t *testing.T) {
 	t.Parallel()
 
 	// ListFlags delegates to listFlagsWithFactories with the real availableRuntimes.
-	// Since no real runtime currently implements FlagProvider, it should return empty.
+	// The openshell runtime implements FlagProvider when available on this platform.
 	flags := ListFlags()
-	if len(flags) != 0 {
-		t.Errorf("expected 0 flags from real runtimes, got %d", len(flags))
+
+	flagNames := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		flagNames[f.Name] = true
+	}
+
+	if flagNames["openshell-driver"] != flagNames["openshell-allow-hosts"] {
+		t.Errorf("expected openshell flags to be either both present or both absent, got driver=%v allow-hosts=%v",
+			flagNames["openshell-driver"], flagNames["openshell-allow-hosts"])
 	}
 }
 


### PR DESCRIPTION
Implement a new OpenShell Gateway runtime that manages sandboxed workspaces via the openshell CLI. Includes sandbox lifecycle (create, start, stop, remove), gateway binary download with platform detection and codesigning on macOS, state management, terminal support, and an --openshell-driver flag on init.


(tested only on macOS)

podman driver: (default so you can omit --openshell-driver parameter ) 
```
kdn init --runtime openshell --agent openclaw --start
```


```
kdn init --runtime openshell --agent claude --start --openshell-driver podman
```

vm driver:
```
kdn init --runtime openshell --agent claude --start --openshell-driver vm
```

ℹ️ rebased on top of https://github.com/openkaiden/kdn/pull/400 to include specific flag for a runtime
