### PR TITLE
ci: release an install.sh script

### DIFF
--- a/.config/binstaller.yml
+++ b/.config/binstaller.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/binary-install/binstaller/main/schema/InstallSpec.json
+schema: v1
+repo: openkaiden/kdn
+asset:
+  template: kdn_${VERSION}_${OS}_${ARCH}${EXT}
+  default_extension: .tar.gz
+  rules:
+  - when:
+      os: windows
+    ext: .zip
+checksums:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
 
       - name: Install binst
-        run: go install github.com/binary-install/binstaller/cmd/binst@v0.12.0
+        run: go install github.com/binary-install/binstaller/cmd/binst@e53d3e79dc475ac4049887dc30ff8df09fd1ea25
 
       - name: Generate install.sh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,19 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
 
+      - name: Install binst
+        run: go install github.com/binary-install/binstaller/cmd/binst@v0.12.0
+
+      - name: Generate install.sh
+        run: |
+          binst embed-checksums --config .config/binstaller.yml --mode calculate
+          binst gen --config=.config/binstaller.yml -o install.sh
+
+      - name: Upload install.sh to release
+        run: gh release upload ${{ github.ref_name }} install.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   bump-next-version:
     name: Bump Next Version
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist/
 # MkDocs build output
 website/site/
 website/docs/*.md
+
+install.sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,3 +73,14 @@ release:
   github:
     owner: openkaiden
     name: kdn
+  footer: |
+
+    ---
+
+    ## Install
+
+    ```sh
+    curl -sSfL https://github.com/openkaiden/kdn/releases/download/{{ .Tag }}/install.sh | sh
+    ```
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).


### PR DESCRIPTION
Builds an install.sh script (using https://github.com/binary-install/binstaller) with checksums verification.

Part of #389 