### PR TITLE
fix(agent): extract model name from provider::model[::url] format

### DIFF
--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	kdnconfig "github.com/openkaiden/kdn/pkg/config"
 )
 
 const (
@@ -213,7 +214,8 @@ func (c *claudeAgent) SetModel(settings map[string][]byte, modelID string) (map[
 		return nil, fmt.Errorf("failed to parse existing %s: %w", ClaudeSettingsPath, err)
 	}
 
-	config["model"] = modelID
+	_, modelName, _ := kdnconfig.ParseModelID(modelID)
+	config["model"] = modelName
 
 	modifiedContent, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -496,6 +496,48 @@ func TestClaude_SetModel_OverwritesExistingModel(t *testing.T) {
 	}
 }
 
+func TestClaude_SetModel_ProviderModelFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	settings := make(map[string][]byte)
+
+	result, err := agent.SetModel(settings, "claude::gemma2:7b")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeSettingsPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if model, ok := config["model"].(string); !ok || model != "gemma2:7b" {
+		t.Errorf("model = %v, want %q", config["model"], "gemma2:7b")
+	}
+}
+
+func TestClaude_SetModel_ProviderModelURLFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	settings := make(map[string][]byte)
+
+	result, err := agent.SetModel(settings, "claude::gemma2:7b::http://localhost:11434/v1")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeSettingsPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if model, ok := config["model"].(string); !ok || model != "gemma2:7b" {
+		t.Errorf("model = %v, want %q", config["model"], "gemma2:7b")
+	}
+}
+
 func TestClaude_SkillsDir(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/cursor.go
+++ b/pkg/agent/cursor.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	kdnconfig "github.com/openkaiden/kdn/pkg/config"
 )
 
 // CursorCLIConfigPath is the path to Cursor's CLI configuration file.
@@ -105,11 +106,12 @@ func (c *cursorAgent) SetModel(settings map[string][]byte, modelID string) (map[
 		config = make(map[string]interface{})
 	}
 
+	_, modelName, _ := kdnconfig.ParseModelID(modelID)
 	config["model"] = map[string]interface{}{
-		"modelId":          modelID,
-		"displayModelId":   modelID,
-		"displayName":      modelID,
-		"displayNameShort": modelID,
+		"modelId":          modelName,
+		"displayModelId":   modelName,
+		"displayName":      modelName,
+		"displayNameShort": modelName,
 		"maxMode":          false,
 	}
 	config["hasChangedDefaultModel"] = true

--- a/pkg/agent/cursor_test.go
+++ b/pkg/agent/cursor_test.go
@@ -412,6 +412,58 @@ func TestCursor_SetModel_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestCursor_SetModel_ProviderModelFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+	settings := make(map[string][]byte)
+
+	result, err := agent.SetModel(settings, "cursor::gemma2:7b")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[CursorCLIConfigPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	modelObj, ok := config["model"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model is not an object: %v", config["model"])
+	}
+
+	if modelObj["modelId"] != "gemma2:7b" {
+		t.Errorf("modelId = %v, want %q", modelObj["modelId"], "gemma2:7b")
+	}
+}
+
+func TestCursor_SetModel_ProviderModelURLFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewCursor()
+	settings := make(map[string][]byte)
+
+	result, err := agent.SetModel(settings, "cursor::gemma2:7b::http://localhost:11434/v1")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[CursorCLIConfigPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	modelObj, ok := config["model"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model is not an object: %v", config["model"])
+	}
+
+	if modelObj["modelId"] != "gemma2:7b" {
+		t.Errorf("modelId = %v, want %q", modelObj["modelId"], "gemma2:7b")
+	}
+}
+
 func TestCursor_SkillsDir(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/goose.go
+++ b/pkg/agent/goose.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	kdnconfig "github.com/openkaiden/kdn/pkg/config"
 )
 
 const (
@@ -111,7 +112,8 @@ func (g *gooseAgent) SetModel(settings map[string][]byte, modelID string) (map[s
 		config = make(map[string]interface{})
 	}
 
-	config[gooseModelKey] = modelID
+	_, modelName, _ := kdnconfig.ParseModelID(modelID)
+	config[gooseModelKey] = modelName
 
 	modifiedContent, err := yaml.Marshal(config)
 	if err != nil {

--- a/pkg/agent/goose_test.go
+++ b/pkg/agent/goose_test.go
@@ -310,6 +310,48 @@ func TestGoose_SetModel_OverwritesExistingModel(t *testing.T) {
 	}
 }
 
+func TestGoose_SetModel_ProviderModelFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewGoose()
+	settings := make(map[string][]byte)
+
+	result, err := agent.SetModel(settings, "goose::gemma2:7b")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(result[GooseConfigPath], &config); err != nil {
+		t.Fatalf("Failed to parse result YAML: %v", err)
+	}
+
+	if model, ok := config[gooseModelKey].(string); !ok || model != "gemma2:7b" {
+		t.Errorf("%s = %v, want %q", gooseModelKey, config[gooseModelKey], "gemma2:7b")
+	}
+}
+
+func TestGoose_SetModel_ProviderModelURLFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewGoose()
+	settings := make(map[string][]byte)
+
+	result, err := agent.SetModel(settings, "goose::gemma2:7b::http://localhost:11434/v1")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(result[GooseConfigPath], &config); err != nil {
+		t.Fatalf("Failed to parse result YAML: %v", err)
+	}
+
+	if model, ok := config[gooseModelKey].(string); !ok || model != "gemma2:7b" {
+		t.Errorf("%s = %v, want %q", gooseModelKey, config[gooseModelKey], "gemma2:7b")
+	}
+}
+
 func TestGoose_SkillsDir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Claude, Goose, and Cursor agents were passing the full model ID string directly to their config files. They now use ParseModelID() to extract just the model name, consistent with how OpenCode already handles this format. Plain model IDs without a provider prefix are unaffected.

Closes #391