### PR TITLE
fix(podman): add SELinux relabel to approval-handler volume mount

### DIFF
--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -57,7 +57,7 @@ spec:
       command: ["sh", "-c", "cp /app/* . 2>/dev/null; npm install --omit=optional && npx tsx approval-handler.ts"]
       volumeMounts:
         - name: approval-handler
-          mountPath: /app
+          mountPath: /app:Z
 
     - name: network-guard
       image: {{.BaseImageRegistry}}:{{.BaseImageVersion}}


### PR DESCRIPTION
## Summary
- On SELinux-enforcing systems (Fedora, RHEL), the approval-handler sidecar container crashes because it cannot read files from its hostPath volume mount
- `podman kube play` does not automatically relabel hostPath volumes for container access
- Adding `:Z` to the `mountPath` in the pod YAML triggers SELinux relabeling (see [podman#10339](https://github.com/containers/podman/pull/10339))
- Without this fix, deny-mode networking is completely broken on SELinux-enforcing systems — all outbound requests time out because no approval-handler is running

## Test plan
- [ ] On Fedora/RHEL: create a workspace with `"network": {"mode": "deny"}`, verify `podman logs <name>-approval-handler` shows successful startup
- [ ] Verify approval-handler approves allowed hosts and denies others
- [ ] On macOS/non-SELinux Linux: verify no regression (`:Z` is ignored when SELinux is not present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)