### PR TITLE
feat(runtime): add FlagProvider interface for runtime-specific CLI flags

### DIFF
--- a/.agents/skills/add-runtime/SKILL.md
+++ b/.agents/skills/add-runtime/SKILL.md
@@ -50,6 +50,9 @@ var _ runtime.Runtime = (*<runtime-name>Runtime)(nil)
 // Ensure implementation of runtime.StorageAware at compile time (optional)
 var _ runtime.StorageAware = (*<runtime-name>Runtime)(nil)
 
+// Uncomment only if this runtime implements runtime.FlagProvider.
+// var _ runtime.FlagProvider = (*<runtime-name>Runtime)(nil)
+
 // New creates a new runtime instance
 func New() runtime.Runtime {
     return &<runtime-name>Runtime{}
@@ -444,6 +447,23 @@ Use this to:
 - Report agents discovered from configuration files
 - Enable the `info` command to display available agents
 - Allow agent discovery without runtime-specific knowledge
+
+### FlagProvider Interface (optional)
+
+Implement if the runtime needs to expose CLI flags on the `init` command:
+
+```go
+type FlagProvider interface {
+    Flags() []FlagDef
+}
+```
+
+Use this to:
+- Declare runtime-specific flags (e.g., `--openshell-driver`)
+- Provide shell completion values for those flags
+- Keep the init command runtime-agnostic — flag values flow through `CreateParams.RuntimeOptions` as `map[string]string`
+
+The `runtimesetup.ListFlags()` bridge discovers and deduplicates flags from all available `FlagProvider` runtimes.
 
 ### Available Interface (optional)
 

--- a/.agents/skills/working-with-runtime-system/SKILL.md
+++ b/.agents/skills/working-with-runtime-system/SKILL.md
@@ -121,6 +121,47 @@ func (p *podmanRuntime) ListAgents() ([]string, error) {
 
 This pattern decouples agent discovery from runtime-specific configuration details, allowing the `info` command to query agents generically through the runtime interface.
 
+### FlagProvider Interface
+
+The FlagProvider interface enables runtimes to declare CLI flags that appear on the `init` command. This decouples runtime-specific options from the command layer.
+
+```go
+type FlagDef struct {
+    Name        string
+    Usage       string
+    Completions []string
+}
+
+type FlagProvider interface {
+    Flags() []FlagDef
+}
+```
+
+**How it works:**
+
+When a runtime implements FlagProvider:
+1. `runtimesetup.ListFlags()` discovers and deduplicates flags from all available FlagProvider runtimes
+2. The `init` command registers them as cobra flags (with shell completions if `Completions` is non-empty)
+3. Changed flag values are collected into a `map[string]string` and passed through `AddOptions.RuntimeOptions` → `CreateParams.RuntimeOptions`
+4. The runtime reads its values from `params.RuntimeOptions` in `Create()`
+
+**Example implementation:**
+
+```go
+func (r *myRuntime) Flags() []runtime.FlagDef {
+    return []runtime.FlagDef{{
+        Name:        "my-driver",
+        Usage:       "Driver to use (podman, vm)",
+        Completions: []string{"podman", "vm"},
+    }}
+}
+
+func (r *myRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {
+    driver := params.RuntimeOptions["my-driver"]
+    // ... use driver value ...
+}
+```
+
 ### Terminal Interface
 
 The Terminal interface enables interactive terminal sessions for connecting to running instances. This is used by the `terminal` command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 - **AgentLister**: Enables runtimes to report which agents they support
 - **Terminal**: Enables interactive terminal sessions with instances (auto-starts if needed)
 - **Dashboard**: Enables runtimes to expose a web dashboard URL (`GetURL(ctx, instanceID) (string, error)`)
+- **FlagProvider**: Enables runtimes to declare runtime-specific CLI flags (`Flags() []FlagDef`). Flag values flow through `AddOptions.RuntimeOptions` and `CreateParams.RuntimeOptions` as `map[string]string`, keeping the command layer runtime-agnostic. The `runtimesetup.ListFlags()` bridge discovers flags from all available runtimes for registration on cobra commands.
 
 **For detailed runtime implementation guidance, use:** `/working-with-runtime-system`
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/envvars"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
 	"github.com/openkaiden/kdn/pkg/secretservicesetup"
 	"github.com/openkaiden/kdn/pkg/steplogger"
@@ -54,6 +55,7 @@ type initCmd struct {
 	output             string
 	showLogs           bool
 	start              bool
+	runtimeOptions     map[string]string
 }
 
 // preRun validates the parameters and flags
@@ -118,6 +120,13 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 			return outputErrorIfJSON(cmd, i.output, fmt.Errorf("runtime is required: use --runtime flag or set KDN_DEFAULT_RUNTIME environment variable"))
 		}
 	}
+
+	// Collect runtime-specific flag values
+	runtimeOptions, err := collectRuntimeFlagValues(cmd, runtimesetup.ListFlags())
+	if err != nil {
+		return outputErrorIfJSON(cmd, i.output, err)
+	}
+	i.runtimeOptions = runtimeOptions
 
 	// Determine agent: flag takes precedence over environment variable
 	if i.agent == "" {
@@ -231,6 +240,7 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		Project:         i.project,
 		Agent:           i.agent,
 		Model:           i.model,
+		RuntimeOptions:  i.runtimeOptions,
 	})
 	if err != nil {
 		return outputErrorIfJSON(cmd, i.output, err)
@@ -380,5 +390,39 @@ kdn init --runtime podman --agent claude --show-logs`,
 
 	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
 
+	// Register runtime-provided flags
+	registerRuntimeFlags(cmd, runtimesetup.ListFlags())
+
 	return cmd
+}
+
+// registerRuntimeFlags registers runtime-declared flags on the given cobra command.
+func registerRuntimeFlags(cmd *cobra.Command, flags []runtime.FlagDef) {
+	for _, f := range flags {
+		cmd.Flags().String(f.Name, "", f.Usage)
+		if len(f.Completions) > 0 {
+			completions := f.Completions
+			cmd.RegisterFlagCompletionFunc(f.Name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+				return completions, cobra.ShellCompDirectiveNoFileComp
+			})
+		}
+	}
+}
+
+// collectRuntimeFlagValues reads changed flag values from the command for the given flag definitions.
+func collectRuntimeFlagValues(cmd *cobra.Command, flags []runtime.FlagDef) (map[string]string, error) {
+	var result map[string]string
+	for _, f := range flags {
+		if cmd.Flags().Changed(f.Name) {
+			val, err := cmd.Flags().GetString(f.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read --%s flag: %w", f.Name, err)
+			}
+			if result == nil {
+				result = make(map[string]string)
+			}
+			result[f.Name] = val
+		}
+	}
+	return result, nil
 }

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -30,6 +30,7 @@ import (
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/cmd/testutil"
 	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
 	"github.com/spf13/cobra"
 )
@@ -2534,4 +2535,148 @@ func TestInitCmd_Examples(t *testing.T) {
 	if err != nil {
 		t.Errorf("Example validation failed: %v", err)
 	}
+}
+
+func TestRegisterRuntimeFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registers flags on command", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{Use: "test"}
+		flags := []runtime.FlagDef{
+			{Name: "my-flag", Usage: "a test flag"},
+			{Name: "other-flag", Usage: "another flag", Completions: []string{"a", "b"}},
+		}
+
+		registerRuntimeFlags(cmd, flags)
+
+		f := cmd.Flags().Lookup("my-flag")
+		if f == nil {
+			t.Fatal("expected 'my-flag' to be registered")
+		}
+		if f.Usage != "a test flag" {
+			t.Errorf("expected usage 'a test flag', got %q", f.Usage)
+		}
+
+		f2 := cmd.Flags().Lookup("other-flag")
+		if f2 == nil {
+			t.Fatal("expected 'other-flag' to be registered")
+		}
+	})
+
+	t.Run("no-op with empty flags", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{Use: "test"}
+		registerRuntimeFlags(cmd, nil)
+
+		if cmd.Flags().HasFlags() {
+			t.Error("expected no flags to be registered")
+		}
+	})
+}
+
+func TestCollectRuntimeFlagValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects changed flag values", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{Use: "test", Run: func(_ *cobra.Command, _ []string) {}}
+		cmd.Flags().String("my-flag", "", "test")
+		cmd.Flags().String("other-flag", "", "test")
+
+		cmd.SetArgs([]string{"--my-flag", "val1", "--other-flag", "val2"})
+		_ = cmd.Execute()
+
+		flags := []runtime.FlagDef{
+			{Name: "my-flag"},
+			{Name: "other-flag"},
+		}
+
+		result, err := collectRuntimeFlagValues(cmd, flags)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Fatalf("expected 2 values, got %d", len(result))
+		}
+		if result["my-flag"] != "val1" {
+			t.Errorf("expected 'val1', got %q", result["my-flag"])
+		}
+		if result["other-flag"] != "val2" {
+			t.Errorf("expected 'val2', got %q", result["other-flag"])
+		}
+	})
+
+	t.Run("returns nil when no flags changed", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{Use: "test", Run: func(_ *cobra.Command, _ []string) {}}
+		cmd.Flags().String("my-flag", "", "test")
+
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		flags := []runtime.FlagDef{
+			{Name: "my-flag"},
+		}
+
+		result, err := collectRuntimeFlagValues(cmd, flags)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("returns nil with empty flags list", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{Use: "test", Run: func(_ *cobra.Command, _ []string) {}}
+
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		result, err := collectRuntimeFlagValues(cmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("collects only changed flags", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{Use: "test", Run: func(_ *cobra.Command, _ []string) {}}
+		cmd.Flags().String("set-flag", "", "test")
+		cmd.Flags().String("unset-flag", "", "test")
+
+		cmd.SetArgs([]string{"--set-flag", "value"})
+		_ = cmd.Execute()
+
+		flags := []runtime.FlagDef{
+			{Name: "set-flag"},
+			{Name: "unset-flag"},
+		}
+
+		result, err := collectRuntimeFlagValues(cmd, flags)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(result) != 1 {
+			t.Fatalf("expected 1 value, got %d", len(result))
+		}
+		if result["set-flag"] != "value" {
+			t.Errorf("expected 'value', got %q", result["set-flag"])
+		}
+	})
 }

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -65,6 +65,8 @@ type AddOptions struct {
 	Agent string
 	// Model is an optional model ID to configure for the agent
 	Model string
+	// RuntimeOptions contains runtime-specific flag values from the CLI.
+	RuntimeOptions map[string]string
 }
 
 // Manager handles instance storage and operations
@@ -353,6 +355,7 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		OnecliSecrets:      onecliSecrets,
 		SecretEnvVars:      secretEnvVars,
 		ProjectID:          project,
+		RuntimeOptions:     opts.RuntimeOptions,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -95,6 +95,11 @@ type CreateParams struct {
 	// ProjectID is the project identifier used to load per-project workspace
 	// configuration (e.g. network policy) during subsequent Start() calls.
 	ProjectID string
+
+	// RuntimeOptions contains runtime-specific flag values collected from
+	// the CLI. Keys are flag names (matching FlagDef.Name), values are the
+	// user-provided strings. This map is nil when no runtime flags were set.
+	RuntimeOptions map[string]string
 }
 
 // RuntimeInfo contains information about a runtime instance.
@@ -191,6 +196,30 @@ type Terminal interface {
 // during registration, enabling them to look up host patterns for secret-derived hosts.
 type SecretServiceRegistryAware interface {
 	SetSecretServiceRegistry(secretservice.Registry)
+}
+
+// FlagDef describes a CLI flag that a runtime wants to expose on the init command.
+type FlagDef struct {
+	// Name is the flag name (e.g., "openshell-driver").
+	Name string
+
+	// Usage is the help text shown for the flag.
+	Usage string
+
+	// Completions is an optional list of static values for shell completion.
+	Completions []string
+}
+
+// FlagProvider is an optional interface for runtimes that need additional CLI flags
+// on the init command. Runtimes implementing this interface declare their flags
+// via Flags(), and the command layer registers them on the cobra command.
+//
+// Flag values are collected into a map[string]string and passed through
+// AddOptions.RuntimeOptions and CreateParams.RuntimeOptions so that the
+// runtime's Create method can access them without the command layer
+// knowing what they mean.
+type FlagProvider interface {
+	Flags() []FlagDef
 }
 
 // ValidateState validates that a runtime state is one of the valid WorkspaceState values.

--- a/pkg/runtimesetup/register.go
+++ b/pkg/runtimesetup/register.go
@@ -210,3 +210,42 @@ func registerAllWithAvailable(registrar Registrar, factories []runtimeFactory) e
 
 	return nil
 }
+
+// ListFlags returns the CLI flag definitions declared by all available runtimes
+// that implement the FlagProvider interface.
+// Flags from unavailable runtimes and the internal "fake" runtime are excluded.
+func ListFlags() []runtime.FlagDef {
+	return listFlagsWithFactories(availableRuntimes)
+}
+
+// listFlagsWithFactories returns flag definitions from the given runtime factories.
+func listFlagsWithFactories(factories []runtimeFactory) []runtime.FlagDef {
+	seen := make(map[string]struct{})
+	var flags []runtime.FlagDef
+
+	for _, factory := range factories {
+		rt := factory()
+
+		if avail, ok := rt.(Available); ok && !avail.Available() {
+			continue
+		}
+
+		if rt.Type() == "fake" {
+			continue
+		}
+
+		fp, ok := rt.(runtime.FlagProvider)
+		if !ok {
+			continue
+		}
+
+		for _, f := range fp.Flags() {
+			if _, exists := seen[f.Name]; !exists {
+				seen[f.Name] = struct{}{}
+				flags = append(flags, f)
+			}
+		}
+	}
+
+	return flags
+}

--- a/pkg/runtimesetup/register_test.go
+++ b/pkg/runtimesetup/register_test.go
@@ -71,6 +71,16 @@ func (t *testRuntime) Available() bool {
 	return t.available
 }
 
+// testRuntimeWithFlags wraps testRuntime and implements runtime.FlagProvider.
+type testRuntimeWithFlags struct {
+	*testRuntime
+	flags []runtime.FlagDef
+}
+
+func (t *testRuntimeWithFlags) Flags() []runtime.FlagDef {
+	return t.flags
+}
+
 // testRuntimeWithDashboard wraps testRuntime and implements runtime.Dashboard.
 type testRuntimeWithDashboard struct {
 	*testRuntime
@@ -239,6 +249,193 @@ func TestRegisterAll(t *testing.T) {
 		err := registerAllWithAvailable(registrar, testFactories)
 		if err == nil {
 			t.Fatal("Expected error when registration fails, got nil")
+		}
+	})
+}
+
+func TestListFlags(t *testing.T) {
+	t.Parallel()
+
+	// ListFlags delegates to listFlagsWithFactories with the real availableRuntimes.
+	// Since no real runtime currently implements FlagProvider, it should return empty.
+	flags := ListFlags()
+	if len(flags) != 0 {
+		t.Errorf("expected 0 flags from real runtimes, got %d", len(flags))
+	}
+}
+
+func TestListFlagsWithFactories(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns flags from FlagProvider runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "flagged-rt", available: true},
+					flags: []runtime.FlagDef{
+						{Name: "my-flag", Usage: "a test flag", Completions: []string{"a", "b"}},
+					},
+				}
+			},
+		}
+
+		flags := listFlagsWithFactories(factories)
+
+		if len(flags) != 1 {
+			t.Fatalf("expected 1 flag, got %d", len(flags))
+		}
+		if flags[0].Name != "my-flag" {
+			t.Errorf("expected flag name 'my-flag', got %q", flags[0].Name)
+		}
+		if flags[0].Usage != "a test flag" {
+			t.Errorf("expected usage 'a test flag', got %q", flags[0].Usage)
+		}
+		if len(flags[0].Completions) != 2 {
+			t.Errorf("expected 2 completions, got %d", len(flags[0].Completions))
+		}
+	})
+
+	t.Run("skips runtimes without FlagProvider", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "plain-rt", available: true}
+			},
+		}
+
+		flags := listFlagsWithFactories(factories)
+
+		if len(flags) != 0 {
+			t.Errorf("expected 0 flags, got %d", len(flags))
+		}
+	})
+
+	t.Run("skips unavailable runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "unavail-rt", available: false},
+					flags: []runtime.FlagDef{
+						{Name: "hidden-flag", Usage: "should not appear"},
+					},
+				}
+			},
+		}
+
+		flags := listFlagsWithFactories(factories)
+
+		if len(flags) != 0 {
+			t.Errorf("expected 0 flags (runtime unavailable), got %d", len(flags))
+		}
+	})
+
+	t.Run("skips fake runtime", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "fake", available: true},
+					flags: []runtime.FlagDef{
+						{Name: "fake-flag", Usage: "should not appear"},
+					},
+				}
+			},
+		}
+
+		flags := listFlagsWithFactories(factories)
+
+		if len(flags) != 0 {
+			t.Errorf("expected 0 flags (fake runtime), got %d", len(flags))
+		}
+	})
+
+	t.Run("deduplicates flags by name across runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "rt1", available: true},
+					flags: []runtime.FlagDef{
+						{Name: "shared-flag", Usage: "from rt1"},
+					},
+				}
+			},
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "rt2", available: true},
+					flags: []runtime.FlagDef{
+						{Name: "shared-flag", Usage: "from rt2"},
+						{Name: "unique-flag", Usage: "only in rt2"},
+					},
+				}
+			},
+		}
+
+		flags := listFlagsWithFactories(factories)
+
+		if len(flags) != 2 {
+			t.Fatalf("expected 2 flags (deduplicated), got %d", len(flags))
+		}
+
+		names := make(map[string]bool)
+		for _, f := range flags {
+			names[f.Name] = true
+		}
+		if !names["shared-flag"] {
+			t.Error("expected 'shared-flag' to be present")
+		}
+		if !names["unique-flag"] {
+			t.Error("expected 'unique-flag' to be present")
+		}
+	})
+
+	t.Run("collects flags from multiple runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "rt-a", available: true},
+					flags: []runtime.FlagDef{
+						{Name: "flag-a", Usage: "from rt-a"},
+					},
+				}
+			},
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "rt-b", available: true}
+			},
+			func() runtime.Runtime {
+				return &testRuntimeWithFlags{
+					testRuntime: &testRuntime{runtimeType: "rt-c", available: true},
+					flags: []runtime.FlagDef{
+						{Name: "flag-c", Usage: "from rt-c"},
+					},
+				}
+			},
+		}
+
+		flags := listFlagsWithFactories(factories)
+
+		if len(flags) != 2 {
+			t.Fatalf("expected 2 flags, got %d", len(flags))
+		}
+
+		names := make(map[string]bool)
+		for _, f := range flags {
+			names[f.Name] = true
+		}
+		if !names["flag-a"] {
+			t.Error("expected 'flag-a' to be present")
+		}
+		if !names["flag-c"] {
+			t.Error("expected 'flag-c' to be present")
 		}
 	})
 }


### PR DESCRIPTION
Introduce a FlagProvider optional interface so runtimes can declare their own CLI flags without coupling the init command to runtime internals. Flag values flow through AddOptions and CreateParams as a generic map[string]string, keeping the command and manager layers runtime-agnostic.