### PR TITLE
feat(agent): add native OpenClaw support

### DIFF
--- a/.agents/skills/working-with-podman-runtime-config/SKILL.md
+++ b/.agents/skills/working-with-podman-runtime-config/SKILL.md
@@ -29,7 +29,7 @@ The Podman runtime configuration allows customization of the base image, install
 - **Config Interface** (`pkg/runtime/podman/config/config.go`): Interface for managing Podman runtime configuration
 - **ImageConfig** (`pkg/runtime/podman/config/types.go`): Base image configuration (Fedora version, packages, sudo binaries, custom RUN commands)
 - **AgentConfig** (`pkg/runtime/podman/config/types.go`): Agent-specific configuration (packages, RUN commands, terminal command)
-- **Defaults** (`pkg/runtime/podman/config/defaults.go`): Default configurations for image and agents (Claude, Goose, Cursor, OpenCode)
+- **Defaults** (`pkg/runtime/podman/config/defaults.go`): Default configurations for image and agents (Claude, Goose, Cursor, OpenCode, OpenClaw)
 
 ## Configuration Storage
 
@@ -40,7 +40,8 @@ Configuration files are stored in the runtime's storage directory:
 ├── image.json      # Base image configuration
 ├── claude.json     # Claude agent configuration
 ├── goose.json      # Goose agent configuration
-└── opencode.json   # OpenCode agent configuration
+├── opencode.json   # OpenCode agent configuration
+└── openclaw.json   # OpenClaw agent configuration
 ```
 
 ## Configuration Files
@@ -64,7 +65,7 @@ Configuration files are stored in the runtime's storage directory:
 
 ### Agent-Specific Configuration
 
-Agent configurations are named `<agent-name>.json`. The Podman runtime provides default configurations for Claude Code, Goose, Cursor, and OpenCode.
+Agent configurations are named `<agent-name>.json`. The Podman runtime provides default configurations for Claude Code, Goose, Cursor, OpenCode, and OpenClaw.
 
 **claude.json - Claude Code Agent:**
 
@@ -102,6 +103,23 @@ Agent configurations are named `<agent-name>.json`. The Podman runtime provides 
     "mkdir -p /home/agent/.config/opencode"
   ],
   "terminal_command": ["opencode"]
+}
+```
+
+**openclaw.json - OpenClaw Agent:**
+
+```json
+{
+  "packages": [],
+  "run_commands": [
+    "curl -fsSL https://openclaw.ai/install-cli.sh | bash",
+    "mkdir -p /home/agent/.local/bin && ln -sf /home/agent/.openclaw/bin/openclaw /home/agent/.local/bin/openclaw"
+  ],
+  "terminal_command": ["sh", "-c", "curl -sf http://127.0.0.1:18789/ >/dev/null 2>&1 || { openclaw gateway run >/dev/null 2>&1 & for i in $(seq 1 30); do curl -sf http://127.0.0.1:18789/ >/dev/null 2>&1 && break; sleep 0.5; done; }; openclaw"],
+  "env_vars": {
+    "OPENCLAW_PROXY_ACTIVE": "1",
+    "NODE_NO_WARNINGS": "1"
+  }
 }
 ```
 
@@ -157,6 +175,7 @@ The config system validates:
   - **Claude Code** - Installs from the official install script at `claude.ai/install.sh`
   - **Goose** - Installs from the official installer at `github.com/block/goose`
   - **OpenCode** - Installs from the official installer at `opencode.ai/install`
+  - **OpenClaw** - Installs from the official installer at `openclaw.ai/install-cli.sh`; the terminal command uses `sh -c` to start the gateway in the background on port 18789 (waiting up to 15s for readiness) then opens the `openclaw` CLI
 
 ## Containerfile Generation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-kdn is a command-line interface for launching and managing AI agents (Claude Code, Goose, Cursor, OpenCode) with custom configurations. It provides a unified way to start different agents with specific settings including skills, MCP server connections, and LLM integrations.
+kdn is a command-line interface for launching and managing AI agents (Claude Code, Goose, Cursor, OpenCode, OpenClaw) with custom configurations. It provides a unified way to start different agents with specific settings including skills, MCP server connections, and LLM integrations.
 
 ## Build and Test Commands
 
@@ -372,8 +372,29 @@ The Podman runtime supports runtime-specific configuration for **building and co
 - `<storage-dir>/runtimes/podman/config/claude.json` - Claude agent configuration
 - `<storage-dir>/runtimes/podman/config/goose.json` - Goose agent configuration
 - `<storage-dir>/runtimes/podman/config/opencode.json` - OpenCode agent configuration
+- `<storage-dir>/runtimes/podman/config/openclaw.json` - OpenClaw agent configuration
 
 **For Podman runtime configuration details, use:** `/working-with-podman-runtime-config`
+
+### OpenClaw on Podman
+
+The OpenClaw agent runs a local gateway on port 18789 inside the container. The terminal command starts the gateway in the background, waits for it to be ready, then launches the `openclaw` CLI. Type `talk to agent` in the CLI to start a chatbot conversation.
+
+To access the OpenClaw web UI, first start the workspace terminal and wait for the CLI to become ready:
+
+```bash
+kdn terminal <workspace-name>
+```
+
+Then, in a separate session, open the web UI:
+
+```bash
+kdn workspace open <workspace-name>
+```
+
+This opens the browser to the gateway's control UI. Enter `openclaw123` as the gateway token to authenticate.
+
+The gateway token and other defaults are configured via `SkipOnboarding()` in `pkg/agent/openclaw.go`, which writes to `.openclaw/openclaw.json` inside the container.
 
 ### Skills System
 
@@ -394,6 +415,7 @@ Skills can be provided to workspaces via the `skills` field in `workspace.json` 
 | Goose | `$HOME/.agents/skills/` |
 | Cursor | `$HOME/.cursor/skills/` |
 | OpenCode | `$HOME/.opencode/skills/` |
+| OpenClaw | `$HOME/.openclaw/skills/` |
 
 The `Agent` interface (`pkg/agent/agent.go`) exposes `SkillsDir() string` which returns the container path (using the `$HOME` variable) where skill directories should be mounted. The manager calls this during `Add()` to convert `WorkspaceConfig.Skills` entries into `workspace.Mount` entries before passing the config to the runtime.
 

--- a/README.md
+++ b/README.md
@@ -1716,6 +1716,10 @@ Controls agent-specific packages and installation steps. The Podman runtime prov
   - Must have at least one element
   - Can include flags: `["claude", "--verbose"]`
 
+- `env_vars` (optional) - Environment variables to inject into the container
+  - Key-value pairs set as `-e KEY=VALUE` on the container
+  - Skipped if the key collides with a workspace or OneCLI environment variable
+
 #### Applying Configuration Changes
 
 Configuration changes take effect when you **register a new workspace with `init`**. The Containerfile is generated and the image is built during workspace registration, using the configuration files that exist at that time.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ kdn is part of the [Kaiden](https://openkaiden.ai/) project — an open platform
 - **Cursor** - AI-powered code editor agent
 - **Goose** - AI agent for development tasks
 - **OpenCode** - Open-source AI coding agent
+- **OpenClaw** - Open-source AI coding agent
 
 **Supported Runtimes**
 
@@ -1537,6 +1538,12 @@ The Podman runtime includes default configurations for the following AI agents:
 - Open-source AI coding agent
 - The installer places the binary in `~/.opencode/bin/`, which is symlinked into `~/.local/bin/` for PATH access
 
+**OpenClaw** - Installed using the official installer from `openclaw.ai/install-cli.sh`:
+- Open-source AI coding agent
+- The installer places Node.js and OpenClaw under `~/.openclaw/`, with the binary symlinked into `~/.local/bin/` for PATH access
+- The default terminal command starts the gateway in the background, polls until it is ready, then launches the CLI — type `talk to agent` to start a chatbot conversation
+- To access the web UI, run `kdn workspace open <workspace>` in a separate session (after starting the workspace with `kdn terminal <workspace>`) and enter `openclaw123` as the gateway token to authenticate
+
 The agent runs within the container environment and has access to the mounted workspace sources and dependencies.
 
 ### Working Directory
@@ -1591,7 +1598,8 @@ $HOME/.kdn/runtimes/podman/config/
 ├── image.json      # Base image configuration
 ├── claude.json     # Claude agent configuration
 ├── goose.json      # Goose agent configuration
-└── opencode.json   # OpenCode agent configuration
+├── opencode.json   # OpenCode agent configuration
+└── openclaw.json   # OpenClaw agent configuration
 ```
 
 Or if using a custom storage directory:
@@ -1655,7 +1663,7 @@ Controls the container's base image, packages, and sudo permissions.
 
 #### Agent Configuration
 
-Controls agent-specific packages and installation steps. The Podman runtime provides default configurations for Claude Code (`claude.json`), Goose (`goose.json`), Cursor (`cursor.json`), and OpenCode (`opencode.json`).
+Controls agent-specific packages and installation steps. The Podman runtime provides default configurations for Claude Code (`claude.json`), Goose (`goose.json`), Cursor (`cursor.json`), OpenCode (`opencode.json`), and OpenClaw (`openclaw.json`).
 
 **Structure (claude.json):**
 
@@ -1699,6 +1707,25 @@ Controls agent-specific packages and installation steps. The Podman runtime prov
   "terminal_command": [
     "opencode"
   ]
+}
+```
+
+**Structure (openclaw.json):**
+
+```json
+{
+  "packages": [],
+  "run_commands": [
+    "curl -fsSL https://openclaw.ai/install-cli.sh | bash",
+    "mkdir -p /home/agent/.local/bin && ln -sf /home/agent/.openclaw/bin/openclaw /home/agent/.local/bin/openclaw"
+  ],
+  "terminal_command": [
+    "openclaw"
+  ],
+  "env_vars": {
+    "OPENCLAW_PROXY_ACTIVE": "1",
+    "NODE_NO_WARNINGS": "1"
+  }
 }
 ```
 
@@ -1937,6 +1964,7 @@ Each skill directory is mounted read-only under the agent's skills directory ins
 | Goose | `~/.agents/skills/<basename>/` |
 | Cursor | `~/.cursor/skills/<basename>/` |
 | OpenCode | `~/.opencode/skills/<basename>/` |
+| OpenClaw | `~/.openclaw/skills/<basename>/` |
 
 For example, a skills path of `/home/user/commit-skill` is mounted at `~/.claude/skills/commit-skill/` for Claude Code, making the skill discoverable by the agent.
 
@@ -3187,7 +3215,7 @@ kdn init /tmp/workspace --runtime podman --agent claude
 
 - **Runtime is required**: You must specify a runtime using either the `--runtime` flag or the `KDN_DEFAULT_RUNTIME` environment variable
 - **Agent is required**: You must specify an agent using either the `--agent` flag or the `KDN_DEFAULT_AGENT` environment variable
-- **Model is optional**: Use `--model` to specify a model ID for the agent. The flag takes precedence over any model defined in the agent's default settings files (`~/.kdn/config/<agent>/`). If not provided, the agent uses its default model or the one configured in settings. All agents support model configuration: Claude (via `.claude/settings.json`), Goose (via `config.yaml`), Cursor (via `.cursor/cli-config.json`), and OpenCode (via `.config/opencode/opencode.json`)
+- **Model is optional**: Use `--model` to specify a model ID for the agent. The flag takes precedence over any model defined in the agent's default settings files (`~/.kdn/config/<agent>/`). If not provided, the agent uses its default model or the one configured in settings. All agents support model configuration: Claude (via `.claude/settings.json`), Goose (via `config.yaml`), Cursor (via `.cursor/cli-config.json`), OpenCode (via `.config/opencode/opencode.json`), and OpenClaw (via `.openclaw/openclaw.json`)
 - **Provider configuration**: The `--model` flag supports a `provider::model` format (e.g. `ollama::gemma4:26b`) that auto-configures the provider endpoint and stores the model ID as `provider/model`. Known providers (`ollama`, `ramalama`) have default base URLs pointing to `host.containers.internal`; unknown providers require the full format `provider::model::baseURL`. Localhost aliases (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) in base URLs are automatically converted to `host.containers.internal` for container accessibility
 - **Project auto-detection**: The project identifier is automatically detected from git repository information or source directory path. Use `--project` flag to override with a custom identifier
 - **Auto-start**: Use the `--start` flag or set `KDN_INIT_AUTO_START=1` to automatically start the workspace after registration, combining `init` and `start` into a single operation
@@ -3951,7 +3979,7 @@ The environment where workspaces run. kdn's runtime system is extensible — new
 The isolated execution environment created by the runtime for a workspace. The sandbox contains the mounted project source code, the configured agent, and any injected environment variables, secrets, and mounts. Network access is controlled per workspace: outbound traffic can be fully allowed, restricted to an explicit list of hosts, or denied entirely — preventing the agent from reaching unintended external services. Depending on the runtime, the sandbox is implemented as a container (Podman) or a VM-based environment (OpenShell).
 
 ### Agent
-An AI assistant that can perform tasks autonomously. In kdn, agents are the different AI tools (Claude Code, Cursor, Goose, OpenCode) that can be launched and configured.
+An AI assistant that can perform tasks autonomously. In kdn, agents are the different AI tools (Claude Code, Cursor, Goose, OpenCode, OpenClaw) that can be launched and configured.
 
 ### LLM (Large Language Model)
 The underlying AI model that powers the agents. Examples include Claude (by Anthropic), Gemini (by Google), GPT (by OpenAI), and open-source models such as Llama (by Meta), Gemma (by Google), and Granite (by IBM).

--- a/pkg/agent/openclaw.go
+++ b/pkg/agent/openclaw.go
@@ -1,0 +1,260 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	kdnconfig "github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/containerurl"
+)
+
+const (
+	// OpenclawConfigPath is the relative path to the OpenClaw configuration file.
+	OpenclawConfigPath = ".openclaw/openclaw.json"
+)
+
+var openclawProviderAliases = map[string]string{
+	"gemini":   "google",
+	"vertexai": "anthropic-vertex",
+}
+
+// openclawAgent is the implementation of Agent for OpenClaw.
+type openclawAgent struct{}
+
+// Compile-time checks
+var _ Agent = (*openclawAgent)(nil)
+var _ PortProvider = (*openclawAgent)(nil)
+
+// NewOpenclaw creates a new OpenClaw agent implementation.
+func NewOpenclaw() Agent {
+	return &openclawAgent{}
+}
+
+// Name returns the agent name.
+func (c *openclawAgent) Name() string {
+	return "openclaw"
+}
+
+// SkipOnboarding modifies OpenClaw settings to disable gateway auth and enable
+// the control UI. All other fields in the settings file are preserved.
+func (c *openclawAgent) SkipOnboarding(settings map[string]SettingsFile, _ string, _ []string) (map[string]SettingsFile, error) {
+	settings = EnsureSettings(settings)
+
+	existingContent := GetContent(settings, OpenclawConfigPath, []byte("{}"))
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(existingContent, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing %s: %w", OpenclawConfigPath, err)
+	}
+
+	// Get or create the gateway map
+	gateway, _ := config["gateway"].(map[string]interface{})
+	if gateway == nil {
+		gateway = make(map[string]interface{})
+	}
+
+	// Set auth mode to "token" with a default token (gateway.auth)
+	gateway["auth"] = map[string]interface{}{
+		"mode":  "token",
+		"token": "openclaw123",
+	}
+
+	// Enable the control UI (gateway.controlUi.enabled)
+	controlUi, _ := gateway["controlUi"].(map[string]interface{})
+	if controlUi == nil {
+		controlUi = make(map[string]interface{})
+	}
+	controlUi["enabled"] = true
+	controlUi["allowedOrigins"] = []string{"*"}
+	gateway["controlUi"] = controlUi
+
+	gateway["bind"] = "lan"
+	gateway["mode"] = "local"
+
+	config["gateway"] = gateway
+
+	modifiedContent, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified %s: %w", OpenclawConfigPath, err)
+	}
+
+	SetContent(settings, OpenclawConfigPath, modifiedContent)
+	return settings, nil
+}
+
+func (c *openclawAgent) DefaultPorts() []int { return []int{18789} }
+
+// SkillsDir returns the container path under which skill directories are mounted for OpenClaw.
+func (c *openclawAgent) SkillsDir() string {
+	return "$HOME/.openclaw/skills"
+}
+
+// SetMCPServers configures MCP servers in OpenClaw settings.
+// It writes MCP server entries into openclaw.json under the "mcp.servers" key.
+// Command-based servers use {command, args, env} with no transport field
+// (OpenClaw infers stdio from the presence of a command key).
+// URL-based servers use transport "streamable-http" with {url, headers}.
+// All other fields in the settings file are preserved.
+// If mcp is nil, settings are returned unchanged.
+func (c *openclawAgent) SetMCPServers(settings map[string]SettingsFile, mcp *workspace.McpConfiguration) (map[string]SettingsFile, error) {
+	if mcp == nil {
+		return settings, nil
+	}
+	settings = EnsureSettings(settings)
+
+	existingContent := GetContent(settings, OpenclawConfigPath, []byte("{}"))
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(existingContent, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing %s: %w", OpenclawConfigPath, err)
+	}
+
+	// Get or create the mcp map
+	mcpConfig, _ := config["mcp"].(map[string]interface{})
+	if mcpConfig == nil {
+		mcpConfig = make(map[string]interface{})
+	}
+
+	// Get or create the servers map
+	servers, _ := mcpConfig["servers"].(map[string]interface{})
+	if servers == nil {
+		servers = make(map[string]interface{})
+	}
+
+	if mcp.Commands != nil {
+		for _, cmd := range *mcp.Commands {
+			entry := map[string]interface{}{
+				"command": cmd.Command,
+				"args":    []string{},
+				"env":     map[string]string{},
+			}
+			if cmd.Args != nil {
+				entry["args"] = *cmd.Args
+			}
+			if cmd.Env != nil {
+				entry["env"] = *cmd.Env
+			}
+			servers[cmd.Name] = entry
+		}
+	}
+
+	if mcp.Servers != nil {
+		for _, srv := range *mcp.Servers {
+			entry := map[string]interface{}{
+				"transport": "streamable-http",
+				"url":       srv.Url,
+			}
+			if srv.Headers != nil {
+				entry["headers"] = *srv.Headers
+			}
+			servers[srv.Name] = entry
+		}
+	}
+
+	if len(servers) > 0 {
+		mcpConfig["servers"] = servers
+		config["mcp"] = mcpConfig
+	}
+
+	modifiedContent, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified %s: %w", OpenclawConfigPath, err)
+	}
+
+	SetContent(settings, OpenclawConfigPath, modifiedContent)
+	return settings, nil
+}
+
+// SetModel configures the model ID in OpenClaw settings.
+// It sets agents.defaults.model in openclaw.json. OpenClaw uses provider/model
+// format (e.g. "google/gemini-2.5-pro"). When the kdn provider::model format is
+// used, it is converted to provider/model. Plain model IDs without a provider
+// are passed through as-is.
+// All other fields in the settings file are preserved.
+func (c *openclawAgent) SetModel(settings map[string]SettingsFile, modelID string) (map[string]SettingsFile, error) {
+	settings = EnsureSettings(settings)
+
+	existingContent := GetContent(settings, OpenclawConfigPath, []byte("{}"))
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(existingContent, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing %s: %w", OpenclawConfigPath, err)
+	}
+
+	// Get or create the agents map
+	agents, _ := config["agents"].(map[string]interface{})
+	if agents == nil {
+		agents = make(map[string]interface{})
+	}
+
+	// Get or create the defaults map
+	defaults, _ := agents["defaults"].(map[string]interface{})
+	if defaults == nil {
+		defaults = make(map[string]interface{})
+	}
+
+	provider, modelName, baseURL := kdnconfig.ParseModelID(modelID)
+	if alias, ok := openclawProviderAliases[provider]; ok {
+		provider = alias
+	}
+	if provider != "" || baseURL != "" {
+		if provider == "" {
+			provider = "local"
+		}
+		defaults["model"] = provider + "/" + modelName
+		if baseURL != "" {
+			configureOpenclawProvider(config, provider, modelName, containerurl.RewriteURL(baseURL))
+		}
+	} else {
+		defaults["model"] = modelID
+	}
+	agents["defaults"] = defaults
+	config["agents"] = agents
+
+	modifiedContent, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified %s: %w", OpenclawConfigPath, err)
+	}
+
+	SetContent(settings, OpenclawConfigPath, modifiedContent)
+	return settings, nil
+}
+
+func configureOpenclawProvider(config map[string]interface{}, provider, modelName, baseURL string) {
+	models, _ := config["models"].(map[string]interface{})
+	if models == nil {
+		models = make(map[string]interface{})
+	}
+	providers, _ := models["providers"].(map[string]interface{})
+	if providers == nil {
+		providers = make(map[string]interface{})
+	}
+
+	providers[provider] = map[string]interface{}{
+		"baseUrl": baseURL,
+		"apiKey":  "local-no-auth",
+		"api":     "openai-completions",
+		"models":  []map[string]interface{}{{"id": modelName, "name": modelName}},
+	}
+	models["providers"] = providers
+	config["models"] = models
+}

--- a/pkg/agent/openclaw_test.go
+++ b/pkg/agent/openclaw_test.go
@@ -1,0 +1,777 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+func TestOpenclaw_Name(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	if got := agent.Name(); got != "openclaw" {
+		t.Errorf("Name() = %q, want %q", got, "openclaw")
+	}
+}
+
+func TestOpenclaw_SkipOnboarding_NoExistingSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := make(map[string]SettingsFile)
+
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
+	if err != nil {
+		t.Fatalf("SkipOnboarding() error = %v", err)
+	}
+
+	sf, exists := result[OpenclawConfigPath]
+	if !exists {
+		t.Fatalf("Expected %s to be created", OpenclawConfigPath)
+	}
+	openclawJSON := sf.Content
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(openclawJSON, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	gateway, ok := config["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("gateway is not a map: %v", config["gateway"])
+	}
+
+	auth, ok := gateway["auth"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("gateway.auth is not a map: %v", gateway["auth"])
+	}
+	if auth["mode"] != "token" {
+		t.Errorf("gateway.auth.mode = %v, want %q", auth["mode"], "token")
+	}
+	if auth["token"] != "openclaw123" {
+		t.Errorf("gateway.auth.token = %v, want %q", auth["token"], "openclaw123")
+	}
+
+	controlUi, ok := gateway["controlUi"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("gateway.controlUi is not a map: %v", gateway["controlUi"])
+	}
+	if enabled, ok := controlUi["enabled"].(bool); !ok || !enabled {
+		t.Errorf("gateway.controlUi.enabled = %v, want true", controlUi["enabled"])
+	}
+
+	if gateway["bind"] != "lan" {
+		t.Errorf("gateway.bind = %v, want %q", gateway["bind"], "lan")
+	}
+}
+
+func TestOpenclaw_SkipOnboarding_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	result, err := agent.SkipOnboarding(nil, "/workspace/sources", nil)
+	if err != nil {
+		t.Fatalf("SkipOnboarding() error = %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected non-nil result map")
+	}
+
+	if _, exists := result[OpenclawConfigPath]; !exists {
+		t.Errorf("Expected %s to be created", OpenclawConfigPath)
+	}
+}
+
+func TestOpenclaw_SkipOnboarding_PreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	existingSettings := map[string]interface{}{
+		"customField": "custom value",
+		"gateway": map[string]interface{}{
+			"port": 9999,
+			"auth": map[string]interface{}{
+				"mode":        "token",
+				"otherOption": "preserved",
+			},
+			"controlUi": map[string]interface{}{
+				"enabled":  false,
+				"basePath": "/custom",
+			},
+		},
+	}
+
+	existingJSON, err := json.Marshal(existingSettings)
+	if err != nil {
+		t.Fatalf("Failed to marshal existing settings: %v", err)
+	}
+
+	settings := map[string]SettingsFile{
+		OpenclawConfigPath: {Content: existingJSON},
+	}
+
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
+	if err != nil {
+		t.Fatalf("SkipOnboarding() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if config["customField"] != "custom value" {
+		t.Errorf("customField = %v, want %q", config["customField"], "custom value")
+	}
+
+	gateway := config["gateway"].(map[string]interface{})
+	if gateway["port"] != float64(9999) {
+		t.Errorf("gateway.port = %v, want 9999", gateway["port"])
+	}
+
+	auth := gateway["auth"].(map[string]interface{})
+	if auth["mode"] != "token" {
+		t.Errorf("gateway.auth.mode = %v, want %q", auth["mode"], "token")
+	}
+	if auth["token"] != "openclaw123" {
+		t.Errorf("gateway.auth.token = %v, want %q", auth["token"], "openclaw123")
+	}
+	if _, hasOther := auth["otherOption"]; hasOther {
+		t.Error("expected otherOption to be removed when auth is replaced")
+	}
+
+	controlUi := gateway["controlUi"].(map[string]interface{})
+	if enabled, ok := controlUi["enabled"].(bool); !ok || !enabled {
+		t.Errorf("gateway.controlUi.enabled = %v, want true", controlUi["enabled"])
+	}
+	if controlUi["basePath"] != "/custom" {
+		t.Errorf("gateway.controlUi.basePath = %v, want %q", controlUi["basePath"], "/custom")
+	}
+}
+
+func TestOpenclaw_SkipOnboarding_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	settings := map[string]SettingsFile{
+		OpenclawConfigPath: {Content: []byte("invalid json {{{")},
+	}
+
+	_, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func TestOpenclaw_SetModel_NoExistingSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := make(map[string]SettingsFile)
+
+	result, err := agent.SetModel(settings, "gpt-4o")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	sf, exists := result[OpenclawConfigPath]
+	if !exists {
+		t.Fatalf("Expected %s to be created", OpenclawConfigPath)
+	}
+	openclawJSON := sf.Content
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(openclawJSON, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	agents, ok := config["agents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("agents is not a map: %v", config["agents"])
+	}
+	defaults, ok := agents["defaults"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("agents.defaults is not a map: %v", agents["defaults"])
+	}
+	if model, ok := defaults["model"].(string); !ok || model != "gpt-4o" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "gpt-4o")
+	}
+}
+
+func TestOpenclaw_SetModel_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	result, err := agent.SetModel(nil, "gpt-4o")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected non-nil result map")
+	}
+
+	if _, exists := result[OpenclawConfigPath]; !exists {
+		t.Errorf("Expected %s to be created", OpenclawConfigPath)
+	}
+}
+
+func TestOpenclaw_SetModel_ProviderModelFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := make(map[string]SettingsFile)
+
+	result, err := agent.SetModel(settings, "anthropic::claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	agents := config["agents"].(map[string]interface{})
+	defaults := agents["defaults"].(map[string]interface{})
+	if model, ok := defaults["model"].(string); !ok || model != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "anthropic/claude-sonnet-4-6")
+	}
+}
+
+func TestOpenclaw_SetModel_GeminiAlias(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := make(map[string]SettingsFile)
+
+	result, err := agent.SetModel(settings, "gemini::gemini-2.5-pro")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	agents := config["agents"].(map[string]interface{})
+	defaults := agents["defaults"].(map[string]interface{})
+	if model, ok := defaults["model"].(string); !ok || model != "google/gemini-2.5-pro" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "google/gemini-2.5-pro")
+	}
+}
+
+func TestOpenclaw_SetModel_VertexAIAlias(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := make(map[string]SettingsFile)
+
+	result, err := agent.SetModel(settings, "vertexai::claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	agents := config["agents"].(map[string]interface{})
+	defaults := agents["defaults"].(map[string]interface{})
+	if model, ok := defaults["model"].(string); !ok || model != "anthropic-vertex/claude-sonnet-4-6" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "anthropic-vertex/claude-sonnet-4-6")
+	}
+}
+
+func TestOpenclaw_SetModel_ProviderModelURLFormat(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := make(map[string]SettingsFile)
+
+	result, err := agent.SetModel(settings, "openai::gpt-4o::http://localhost:8080/v1")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	agents := config["agents"].(map[string]interface{})
+	defaults := agents["defaults"].(map[string]interface{})
+	if model, ok := defaults["model"].(string); !ok || model != "openai/gpt-4o" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "openai/gpt-4o")
+	}
+
+	models := config["models"].(map[string]interface{})
+	providers := models["providers"].(map[string]interface{})
+	p := providers["openai"].(map[string]interface{})
+	if p["baseUrl"] != "http://host.containers.internal:8080/v1" {
+		t.Errorf("baseUrl = %v, want %q", p["baseUrl"], "http://host.containers.internal:8080/v1")
+	}
+	pModels := p["models"].([]interface{})
+	if len(pModels) != 1 {
+		t.Fatalf("Expected 1 model, got %d", len(pModels))
+	}
+	modelEntry := pModels[0].(map[string]interface{})
+	if modelEntry["id"] != "gpt-4o" {
+		t.Errorf("model id = %v, want %q", modelEntry["id"], "gpt-4o")
+	}
+	if modelEntry["name"] != "gpt-4o" {
+		t.Errorf("model name = %v, want %q", modelEntry["name"], "gpt-4o")
+	}
+}
+
+func TestOpenclaw_SetModel_NoProviderWithURL(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	result, err := agent.SetModel(nil, "::tester::http://localhost:8080/v1")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	agents := config["agents"].(map[string]interface{})
+	defaults := agents["defaults"].(map[string]interface{})
+	if defaults["model"] != "local/tester" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "local/tester")
+	}
+
+	models := config["models"].(map[string]interface{})
+	providers := models["providers"].(map[string]interface{})
+	p := providers["local"].(map[string]interface{})
+	if p["baseUrl"] != "http://host.containers.internal:8080/v1" {
+		t.Errorf("baseUrl = %v, want %q", p["baseUrl"], "http://host.containers.internal:8080/v1")
+	}
+	if p["api"] != "openai-completions" {
+		t.Errorf("api = %v, want %q", p["api"], "openai-completions")
+	}
+}
+
+func TestOpenclaw_SetModel_CloudProviderNoProviderBlock(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	result, err := agent.SetModel(nil, "anthropic::claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if _, hasModels := config["models"]; hasModels {
+		t.Error("Expected no models.providers block for cloud provider")
+	}
+}
+
+func TestOpenclaw_SetModel_PreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	existingSettings := map[string]interface{}{
+		"customField": "custom value",
+		"agents": map[string]interface{}{
+			"defaults": map[string]interface{}{
+				"model":       "old-model",
+				"otherOption": "preserved",
+			},
+			"otherAgent": map[string]interface{}{
+				"name": "test",
+			},
+		},
+	}
+
+	existingJSON, err := json.Marshal(existingSettings)
+	if err != nil {
+		t.Fatalf("Failed to marshal existing settings: %v", err)
+	}
+
+	settings := map[string]SettingsFile{
+		OpenclawConfigPath: {Content: existingJSON},
+	}
+
+	result, err := agent.SetModel(settings, "new-model")
+	if err != nil {
+		t.Fatalf("SetModel() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if config["customField"] != "custom value" {
+		t.Errorf("customField = %v, want %q", config["customField"], "custom value")
+	}
+
+	agents := config["agents"].(map[string]interface{})
+	defaults := agents["defaults"].(map[string]interface{})
+	if defaults["model"] != "new-model" {
+		t.Errorf("agents.defaults.model = %v, want %q", defaults["model"], "new-model")
+	}
+	if defaults["otherOption"] != "preserved" {
+		t.Errorf("agents.defaults.otherOption = %v, want %q", defaults["otherOption"], "preserved")
+	}
+	if _, ok := agents["otherAgent"]; !ok {
+		t.Error("agents.otherAgent was not preserved")
+	}
+}
+
+func TestOpenclaw_SetModel_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+
+	settings := map[string]SettingsFile{
+		OpenclawConfigPath: {Content: []byte("invalid json {{{")},
+	}
+
+	_, err := agent.SetModel(settings, "gpt-4o")
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func TestOpenclaw_SkillsDir(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	if got := agent.SkillsDir(); got != "$HOME/.openclaw/skills" {
+		t.Errorf("SkillsDir() = %q, want %q", got, "$HOME/.openclaw/skills")
+	}
+}
+
+func TestOpenclaw_SetMCPServers_NilMCP(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	settings := map[string]SettingsFile{
+		OpenclawConfigPath: {Content: []byte(`{"gateway":{"auth":false}}`)},
+	}
+
+	result, err := agent.SetMCPServers(settings, nil)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	if string(result[OpenclawConfigPath].Content) != `{"gateway":{"auth":false}}` {
+		t.Errorf("SetMCPServers() with nil MCP modified settings unexpectedly: %s", result[OpenclawConfigPath].Content)
+	}
+}
+
+func TestOpenclaw_SetMCPServers_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	args := []string{"-y", "@modelcontextprotocol/server-filesystem"}
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "filesystem", Command: "npx", Args: &args},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected non-nil result map")
+	}
+	if _, exists := result[OpenclawConfigPath]; !exists {
+		t.Errorf("Expected %s to be created", OpenclawConfigPath)
+	}
+}
+
+func TestOpenclaw_SetMCPServers_CommandBased(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	args := []string{"-y", "@modelcontextprotocol/server-filesystem", "/workspace"}
+	env := map[string]string{"NODE_ENV": "production"}
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "filesystem", Command: "npx", Args: &args, Env: &env},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpMap := config["mcp"].(map[string]interface{})
+	servers := mcpMap["servers"].(map[string]interface{})
+	fsServer := servers["filesystem"].(map[string]interface{})
+
+	if _, hasTransport := fsServer["transport"]; hasTransport {
+		t.Errorf("expected no transport field for command-based server, got %v", fsServer["transport"])
+	}
+	if fsServer["command"] != "npx" {
+		t.Errorf("command = %v, want %q", fsServer["command"], "npx")
+	}
+
+	gotArgs, ok := fsServer["args"].([]interface{})
+	if !ok {
+		t.Fatalf("args is not a slice: %v", fsServer["args"])
+	}
+	if len(gotArgs) != 3 || gotArgs[0] != "-y" {
+		t.Errorf("args = %v, want %v", gotArgs, args)
+	}
+
+	gotEnv, ok := fsServer["env"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("env is not a map: %v", fsServer["env"])
+	}
+	if gotEnv["NODE_ENV"] != "production" {
+		t.Errorf("env.NODE_ENV = %v, want %q", gotEnv["NODE_ENV"], "production")
+	}
+}
+
+func TestOpenclaw_SetMCPServers_URLBased(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	headers := map[string]string{"Authorization": "Bearer token123"}
+	mcp := &workspace.McpConfiguration{
+		Servers: &[]workspace.McpServer{
+			{Name: "remote", Url: "https://example.com/mcp", Headers: &headers},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpMap := config["mcp"].(map[string]interface{})
+	servers := mcpMap["servers"].(map[string]interface{})
+	remoteServer := servers["remote"].(map[string]interface{})
+
+	if remoteServer["transport"] != "streamable-http" {
+		t.Errorf("transport = %v, want %q", remoteServer["transport"], "streamable-http")
+	}
+	if remoteServer["url"] != "https://example.com/mcp" {
+		t.Errorf("url = %v, want %q", remoteServer["url"], "https://example.com/mcp")
+	}
+
+	gotHeaders, ok := remoteServer["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers is not a map: %v", remoteServer["headers"])
+	}
+	if gotHeaders["Authorization"] != "Bearer token123" {
+		t.Errorf("headers.Authorization = %v, want %q", gotHeaders["Authorization"], "Bearer token123")
+	}
+}
+
+func TestOpenclaw_SetMCPServers_URLBased_NoHeaders(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	mcp := &workspace.McpConfiguration{
+		Servers: &[]workspace.McpServer{
+			{Name: "simple", Url: "https://example.com/mcp"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpMap := config["mcp"].(map[string]interface{})
+	servers := mcpMap["servers"].(map[string]interface{})
+	server := servers["simple"].(map[string]interface{})
+
+	if _, hasHeaders := server["headers"]; hasHeaders {
+		t.Errorf("Expected no headers field when Headers is nil, got: %v", server["headers"])
+	}
+}
+
+func TestOpenclaw_SetMCPServers_Mixed(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "local-tool", Command: "python3", Args: &[]string{"/scripts/mcp.py"}},
+		},
+		Servers: &[]workspace.McpServer{
+			{Name: "remote-api", Url: "https://api.example.com/mcp"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpMap := config["mcp"].(map[string]interface{})
+	servers, ok := mcpMap["servers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcp.servers is not a map")
+	}
+	if _, ok := servers["local-tool"]; !ok {
+		t.Error("Expected local-tool server to be present")
+	}
+	if _, ok := servers["remote-api"]; !ok {
+		t.Error("Expected remote-api server to be present")
+	}
+}
+
+func TestOpenclaw_SetMCPServers_PreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	existing := map[string]interface{}{
+		"gateway": map[string]interface{}{"auth": false},
+		"mcp": map[string]interface{}{
+			"servers": map[string]interface{}{
+				"existing-server": map[string]interface{}{
+					"transport": "stdio",
+					"command":   "existing-cmd",
+				},
+			},
+		},
+	}
+	existingJSON, _ := json.Marshal(existing)
+
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "new-tool", Command: "new-cmd"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(map[string]SettingsFile{OpenclawConfigPath: {Content: existingJSON}}, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	gateway := config["gateway"].(map[string]interface{})
+	if gateway["auth"] != false {
+		t.Error("gateway.auth was not preserved")
+	}
+
+	mcpMap := config["mcp"].(map[string]interface{})
+	servers := mcpMap["servers"].(map[string]interface{})
+	if _, ok := servers["existing-server"]; !ok {
+		t.Error("existing-server was not preserved")
+	}
+	if _, ok := servers["new-tool"]; !ok {
+		t.Error("new-tool was not added")
+	}
+}
+
+func TestOpenclaw_SetMCPServers_CommandNoArgs(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "tool", Command: "mytool"},
+		},
+	}
+
+	result, err := agent.SetMCPServers(nil, mcp)
+	if err != nil {
+		t.Fatalf("SetMCPServers() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[OpenclawConfigPath].Content, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	mcpMap := config["mcp"].(map[string]interface{})
+	servers := mcpMap["servers"].(map[string]interface{})
+	server := servers["tool"].(map[string]interface{})
+
+	args, ok := server["args"].([]interface{})
+	if !ok || len(args) != 0 {
+		t.Errorf("args = %v, want empty slice", server["args"])
+	}
+	envMap, ok := server["env"].(map[string]interface{})
+	if !ok || len(envMap) != 0 {
+		t.Errorf("env = %v, want empty map", server["env"])
+	}
+}
+
+func TestOpenclaw_SetMCPServers_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	agent := NewOpenclaw()
+	mcp := &workspace.McpConfiguration{
+		Commands: &[]workspace.McpCommand{
+			{Name: "tool", Command: "mytool"},
+		},
+	}
+
+	_, err := agent.SetMCPServers(map[string]SettingsFile{OpenclawConfigPath: {Content: []byte("invalid json {{{}")}}, mcp)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}

--- a/pkg/agentsetup/register.go
+++ b/pkg/agentsetup/register.go
@@ -38,6 +38,7 @@ type agentFactory func() agent.Agent
 // Add new agents here to make them available for automatic registration.
 var availableAgents = []agentFactory{
 	agent.NewClaude,
+	agent.NewOpenclaw,
 	agent.NewCursor,
 	agent.NewGoose,
 	agent.NewOpenCode,

--- a/pkg/cmd/info_test.go
+++ b/pkg/cmd/info_test.go
@@ -217,7 +217,7 @@ func TestInfoCmd_E2E(t *testing.T) {
 			t.Fatalf("Failed to parse JSON: %v", err)
 		}
 
-		expected := []string{"claude", "cursor", "goose", "opencode"}
+		expected := []string{"claude", "cursor", "goose", "openclaw", "opencode"}
 		if !slices.Equal(response.Agents, expected) {
 			t.Errorf("Expected agents %v, got: %v", expected, response.Agents)
 		}

--- a/pkg/runtime/podman/config/config.go
+++ b/pkg/runtime/podman/config/config.go
@@ -200,6 +200,7 @@ func (c *config) GenerateDefaults() error {
 	configs := map[string]interface{}{
 		ImageConfigFileName:    defaultImageConfig(),
 		ClaudeConfigFileName:   defaultClaudeConfig(),
+		OpenClawConfigFileName: defaultOpenClawConfig(),
 		GooseConfigFileName:    defaultGooseConfig(),
 		CursorConfigFileName:   defaultCursorConfig(),
 		OpenCodeConfigFileName: defaultOpenCodeConfig(),

--- a/pkg/runtime/podman/config/config_test.go
+++ b/pkg/runtime/podman/config/config_test.go
@@ -857,7 +857,7 @@ func TestListAgents(t *testing.T) {
 		}
 
 		// GenerateDefaults creates configs for all default agents
-		expected := []string{"claude", "cursor", "goose", "opencode"}
+		expected := []string{"claude", "cursor", "goose", "openclaw", "opencode"}
 		if !slices.Equal(agents, expected) {
 			t.Errorf("Expected %v, got: %v", expected, agents)
 		}

--- a/pkg/runtime/podman/config/defaults.go
+++ b/pkg/runtime/podman/config/defaults.go
@@ -38,6 +38,9 @@ const (
 
 	// OpenCodeConfigFileName is the filename for OpenCode agent configuration
 	OpenCodeConfigFileName = "opencode.json"
+
+	// OpenClawConfigFileName is the filename for OpenClaw agent configuration
+	OpenClawConfigFileName = "openclaw.json"
 )
 
 // defaultImageConfig returns the default base image configuration.
@@ -114,5 +117,24 @@ func defaultOpenCodeConfig() *AgentConfig {
 			fmt.Sprintf("mkdir -p /home/%s/.config/opencode", constants.ContainerUser),
 		},
 		TerminalCommand: []string{"opencode"},
+	}
+}
+
+// defaultOpenClawConfig returns the default OpenClaw agent configuration.
+// The local-prefix installer places Node.js and OpenClaw under ~/.openclaw
+// without requiring system packages or sudo. The binary is symlinked into
+// ~/.local/bin/ which is already in the container's PATH.
+func defaultOpenClawConfig() *AgentConfig {
+	return &AgentConfig{
+		Packages: []string{},
+		RunCommands: []string{
+			"curl -fsSL https://openclaw.ai/install-cli.sh | bash",
+			fmt.Sprintf("mkdir -p /home/%s/.local/bin && ln -sf /home/%s/.openclaw/bin/openclaw /home/%s/.local/bin/openclaw", constants.ContainerUser, constants.ContainerUser, constants.ContainerUser),
+		},
+		TerminalCommand: []string{"sh", "-c", "curl -sf http://127.0.0.1:18789/ >/dev/null 2>&1 || { openclaw gateway run >/dev/null 2>&1 & for i in $(seq 1 30); do curl -sf http://127.0.0.1:18789/ >/dev/null 2>&1 && break; sleep 0.5; done; }; openclaw"},
+		EnvVars: map[string]string{
+			"OPENCLAW_PROXY_ACTIVE": "1",
+			"NODE_NO_WARNINGS":      "1",
+		},
 	}
 }

--- a/pkg/runtime/podman/config/types.go
+++ b/pkg/runtime/podman/config/types.go
@@ -24,7 +24,8 @@ type ImageConfig struct {
 
 // AgentConfig represents agent-specific configuration.
 type AgentConfig struct {
-	Packages        []string `json:"packages"`
-	RunCommands     []string `json:"run_commands"`
-	TerminalCommand []string `json:"terminal_command"`
+	Packages        []string          `json:"packages"`
+	RunCommands     []string          `json:"run_commands"`
+	TerminalCommand []string          `json:"terminal_command"`
+	EnvVars         map[string]string `json:"env_vars,omitempty"`
 }

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -253,7 +253,7 @@ type containerConfigArgs struct {
 type mountKey struct{ host, target string }
 
 // buildContainerArgs builds the arguments for creating the workspace container inside the pod.
-func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string, ccArgs *containerConfigArgs) ([]string, error) {
+func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string, ccArgs *containerConfigArgs, agentConfig *config.AgentConfig) ([]string, error) {
 	args := []string{"create", "--pod", params.Name, "--name", params.Name, "--device", "/dev/fuse"}
 
 	// Collect workspace env var names for collision detection
@@ -289,6 +289,11 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 			!onecliEnvNames["NO_PROXY"] && !onecliEnvNames["no_proxy"] {
 			const noProxy = "localhost,127.0.0.1,host.containers.internal"
 			args = append(args, "-e", "NO_PROXY="+noProxy, "-e", "no_proxy="+noProxy)
+		}
+		for k, v := range agentConfig.EnvVars {
+			if !workspaceEnvNames[k] && !onecliEnvNames[k] {
+				args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+			}
 		}
 		if ccArgs.caFilePath != "" && ccArgs.caContainerPath != "" {
 			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", ccArgs.caFilePath, ccArgs.caContainerPath))
@@ -607,7 +612,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 
 	// Build workspace container args with proxy env vars and CA cert mount from OneCLI
 	stepLogger.Start(fmt.Sprintf("Creating workspace container: %s", params.Name), "Workspace container created")
-	createArgs, err := p.buildContainerArgs(params, imageName, ccArgs)
+	createArgs, err := p.buildContainerArgs(params, imageName, ccArgs, agentConfig)
 	if err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -417,7 +417,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -472,7 +472,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -521,7 +521,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -558,7 +558,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -609,7 +609,10 @@ func TestBuildContainerArgs(t *testing.T) {
 			caContainerPath: "/etc/ssl/certs/onecli-ca.pem",
 		}
 
-		args, err := p.buildContainerArgs(params, imageName, ccArgs)
+		clawConfig := &config.AgentConfig{
+			EnvVars: map[string]string{"OPENCLAW_PROXY_ACTIVE": "1"},
+		}
+		args, err := p.buildContainerArgs(params, imageName, ccArgs, clawConfig)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -630,6 +633,11 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		if !strings.Contains(argsStr, "-e no_proxy=localhost,127.0.0.1,host.containers.internal") {
 			t.Errorf("Expected no_proxy env var in args: %s", argsStr)
+		}
+
+		// Verify agent env vars are injected when proxy is active
+		if !strings.Contains(argsStr, "-e OPENCLAW_PROXY_ACTIVE=1") {
+			t.Errorf("Expected OPENCLAW_PROXY_ACTIVE=1 env var in args: %s", argsStr)
 		}
 
 		// Verify CA cert volume mount
@@ -659,7 +667,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			},
 		}
 
-		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs)
+		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -696,7 +704,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			envVars: map[string]string{"HTTP_PROXY": "http://proxy:8080"},
 		}
 
-		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs)
+		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -722,7 +730,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			Agent:      "test_agent",
 		}
 
-		args, err := p.buildContainerArgs(params, "kdn-test", nil)
+		args, err := p.buildContainerArgs(params, "kdn-test", nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -758,7 +766,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			},
 		}
 
-		args, err := p.buildContainerArgs(params, imageName, ccArgs)
+		args, err := p.buildContainerArgs(params, imageName, ccArgs, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -821,7 +829,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -880,7 +888,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -917,7 +925,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, &config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -490,7 +490,7 @@ func TestPodmanRuntime_ListAgents(t *testing.T) {
 			t.Fatalf("ListAgents() failed: %v", err)
 		}
 
-		expected := []string{"claude", "cursor", "goose", "opencode"}
+		expected := []string{"claude", "cursor", "goose", "openclaw", "opencode"}
 		if !slices.Equal(agents, expected) {
 			t.Errorf("Expected %v, got: %v", expected, agents)
 		}


### PR DESCRIPTION
## Summary

- Adds OpenClaw as a new agent with full support for model configuration, MCP servers, skills, and onboarding skip
- Includes default Podman runtime configuration (`openclaw.json`) with installer and environment variables
- Sets `OPENCLAW_PROXY_ACTIVE=1` so OpenClaw routes LLM requests through OneCLI's proxy for credential injection
- Adds `env_vars` field to agent configuration for injecting environment variables into the container
-  Port 18789 is the default openclaw port and you will see the number referenced a few times in this pr. But that port is only internal to the pod/container KDN will remap the port to a random free host port

## Usage

### Start a workspace

```bash
kdn init --runtime podman --agent claw --model "google::gemini-2.5-flash" --name my-claw /path/to/project
kdn start my-claw
kdn terminal my-claw
```

Type `talk to agent` in the CLI to start a chatbot conversation.

### Access the web UI

In a separate session, after the terminal is running:

```bash
kdn workspace open my-claw
```

Enter `openclaw123` as the gateway token to authenticate.

Videos

https://github.com/user-attachments/assets/bd88741d-d035-4138-b930-aaf0ae3b3232


https://github.com/user-attachments/assets/63d8da5e-20dd-42c1-99eb-1d223b139e80

Check https://github.com/openkaiden/kaiden/pull/1800

for kaiden to launch the webui

it has a video there too


## Test plan

- [x] `make build` compiles
- [x] `go test ./pkg/...` all pass
- [x] E2E: init with `--agent claw` creates workspace, starts, runs OpenClaw CLI
- [x] Verified `OPENCLAW_PROXY_ACTIVE=1` fixes OpenClaw's STRICT fetch guard bypassing the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)