### PR TITLE
chore(docs): add OpenShift token workaround scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,84 @@ kdn secret create my-github-token-private --type github --value ghp_private
 - The project identifier used as the key must match what kdn detected during `init` — run `kdn list -o json` to see the project field for each registered workspace
 - Configuration changes in `projects.json` take effect the next time you run `kdn init` for that workspace; already-registered workspaces need to be removed and re-registered
 
+### Protecting an OpenShift Token
+
+> **Note:** This is a temporary workaround. Native support for OpenShift token injection will be added to the `kdn init` command in a future release.
+
+This scenario demonstrates how to connect to an OpenShift cluster from inside a workspace without embedding your real token in the kubeconfig file. The token is stored securely with `kdn secret create` and injected by OneCLI as a `Bearer` Authorization header on every request to the OpenShift API server.
+
+**Prerequisites:**
+
+- The `oc` CLI installed on your host machine
+- An OpenShift cluster reachable from your host
+
+**Step 1: Log in to the cluster with a dedicated kubeconfig**
+
+Use the `--kubeconfig` flag to write the credentials to a separate file that will be shared with the workspace, rather than modifying your default `~/.kube/config`:
+
+```bash
+oc login --kubeconfig=$HOME/kubeconfig-agent \
+  --token=sha256~<real-token> \
+  --server=https://my-openshift-server:6443
+```
+
+**Step 2: Replace the real token with a placeholder**
+
+Edit `$HOME/kubeconfig-agent` and replace `sha256~<real-token>` with `sha256-placeholder`. The file is now safe to mount read-only into workspaces because it contains no real credentials.
+
+**Step 3: Create the kdn secret**
+
+Store the real token once in the system keychain:
+
+```bash
+kdn secret create oc \
+  --type other \
+  --header Authorization \
+  --headerTemplate 'Bearer ${value}' \
+  --host my-openshift-server \
+  --value sha256~<real-token>
+```
+
+This tells kdn to instruct OneCLI to inject `Authorization: Bearer sha256~<real-token>` on every outbound request to `my-openshift-server`, replacing the placeholder in the kubeconfig.
+
+**Step 4: Declare the secret and mount the kubeconfig**
+
+Add the following to your `.kaiden/workspace.json`:
+
+```json
+{
+  "secrets": ["oc"],
+  "mounts": [
+    {
+      "host": "$HOME/kubeconfig-agent",
+      "target": "$HOME/.kube/config",
+      "ro": true
+    }
+  ]
+}
+```
+
+The `secrets` entry tells kdn to provision the `oc` secret into OneCLI when the workspace starts. The mount makes the placeholder kubeconfig available at the standard `~/.kube/config` path inside the container.
+
+**Step 5: Register and start the workspace**
+
+```bash
+# Register a workspace
+kdn init /path/to/project --runtime podman --agent claude
+
+# Start the workspace
+kdn start my-project
+
+# Connect — oc and kubectl commands reach the cluster via OneCLI
+kdn terminal my-project
+```
+
+**Notes:**
+
+- The real token never appears in `workspace.json` or any config file — only the secret name does
+- OneCLI intercepts outbound HTTPS requests to `my-openshift-server` and injects the real `Authorization` header, so `oc` and `kubectl` work transparently inside the container
+- The placeholder value (`sha256-placeholder`) in the kubeconfig must differ from the real token so that the kubeconfig file is safe to share or commit; OneCLI replaces it at the network level
+
 ### Working with Git Worktrees
 
 This scenario demonstrates how to run multiple agents in parallel, each working on a different branch of the same repository. Git worktrees allow each branch to live in its own directory, so each agent gets its own isolated workspace.


### PR DESCRIPTION
Documents how to protect an OpenShift token by storing it as a kdn secret and mounting a placeholder kubeconfig into the workspace, until native support is added to the kdn init command.

Closes #405