### PR TITLE
fix(podman): rewrite localhost URLs in MCP command args

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -21,18 +21,11 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"strings"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	kdnconfig "github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/containerurl"
 )
-
-// containerHost is the hostname used to reach the host machine from inside a container.
-const containerHost = "host.containers.internal"
-
-// localhostAliases lists hostnames and IPs that refer to the local machine.
-var localhostAliases = []string{"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"}
 
 const (
 	// OpenCodeConfigPath is the relative path to the OpenCode configuration file.
@@ -105,7 +98,7 @@ func (o *openCodeAgent) SetModel(settings map[string][]byte, modelID string) (ma
 			}
 			resolvedURL = defaultURL
 		} else {
-			resolvedURL = toContainerURL(resolvedURL)
+			resolvedURL = containerurl.RewriteURL(resolvedURL)
 		}
 		config["model"] = provider + "/" + modelName
 		if err := configureProvider(config, provider, modelName, resolvedURL); err != nil {
@@ -173,32 +166,8 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 	return nil
 }
 
-// toContainerURL replaces localhost aliases in a URL with host.containers.internal
-// so the URL is reachable from inside a container.
-func toContainerURL(rawURL string) string {
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return rawURL
-	}
-
-	hostname := parsed.Hostname()
-	for _, alias := range localhostAliases {
-		if strings.EqualFold(hostname, alias) {
-			port := parsed.Port()
-			if port != "" {
-				parsed.Host = containerHost + ":" + port
-			} else {
-				parsed.Host = containerHost
-			}
-			return parsed.String()
-		}
-	}
-
-	return rawURL
-}
-
 // defaultProviderBaseURLs maps known provider names to their default base URLs.
 var defaultProviderBaseURLs = map[string]string{
-	"ollama":   "http://host.containers.internal:11434/v1",
-	"ramalama": "http://host.containers.internal:8080/v1",
+	"ollama":   "http://" + containerurl.ContainerHost + ":11434/v1",
+	"ramalama": "http://" + containerurl.ContainerHost + ":8080/v1",
 }

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -520,34 +520,3 @@ func TestOpenCode_SetMCPServers(t *testing.T) {
 		}
 	})
 }
-
-func TestToContainerURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"localhost", "http://localhost:11434/v1", "http://host.containers.internal:11434/v1"},
-		{"127.0.0.1", "http://127.0.0.1:8080/v1", "http://host.containers.internal:8080/v1"},
-		{"0.0.0.0", "http://0.0.0.0:11434/v1", "http://host.containers.internal:11434/v1"},
-		{"::1", "http://[::1]:11434/v1", "http://host.containers.internal:11434/v1"},
-		{"remote host unchanged", "http://192.168.1.50:11434/v1", "http://192.168.1.50:11434/v1"},
-		{"hostname unchanged", "http://my-server:11434/v1", "http://my-server:11434/v1"},
-		{"https preserved", "https://localhost:11434/v1", "https://host.containers.internal:11434/v1"},
-		{"no port", "http://localhost/v1", "http://host.containers.internal/v1"},
-		{"invalid URL returned as-is", "not a url ://", "not a url ://"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := toContainerURL(tt.input)
-			if got != tt.expected {
-				t.Errorf("toContainerURL(%q) = %q, want %q", tt.input, got, tt.expected)
-			}
-		})
-	}
-}

--- a/pkg/containerurl/containerurl.go
+++ b/pkg/containerurl/containerurl.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package containerurl provides helpers for rewriting localhost URLs to
+// host.containers.internal so they are reachable from inside a container.
+package containerurl
+
+import (
+	"net/url"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+// ContainerHost is the hostname used to reach the host machine from inside a container.
+const ContainerHost = "host.containers.internal"
+
+// localhostAliases lists hostnames and IPs that refer to the local machine.
+var localhostAliases = []string{"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"}
+
+// RewriteURL replaces localhost aliases in a URL with host.containers.internal
+// so the URL is reachable from inside a container. If the input is not a valid
+// URL or does not reference localhost, it is returned unchanged.
+func RewriteURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	hostname := parsed.Hostname()
+	for _, alias := range localhostAliases {
+		if strings.EqualFold(hostname, alias) {
+			port := parsed.Port()
+			if port != "" {
+				parsed.Host = ContainerHost + ":" + port
+			} else {
+				parsed.Host = ContainerHost
+			}
+			return parsed.String()
+		}
+	}
+
+	return rawURL
+}
+
+// RewriteMCPCommandArgs rewrites localhost URLs in MCP command args so they
+// are reachable from inside a container. Only command-based MCP servers are
+// affected — these are spawned inside the container and may reference
+// localhost to reach host services. URL-based MCP servers (remote endpoints)
+// are not modified.
+func RewriteMCPCommandArgs(mcp *workspace.McpConfiguration) {
+	if mcp == nil || mcp.Commands == nil {
+		return
+	}
+
+	for i := range *mcp.Commands {
+		cmd := &(*mcp.Commands)[i]
+		if cmd.Args == nil {
+			continue
+		}
+		for j, arg := range *cmd.Args {
+			(*cmd.Args)[j] = RewriteURL(arg)
+		}
+	}
+}

--- a/pkg/containerurl/containerurl_test.go
+++ b/pkg/containerurl/containerurl_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerurl
+
+import (
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+func TestRewriteURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"localhost", "http://localhost:11434/v1", "http://host.containers.internal:11434/v1"},
+		{"127.0.0.1", "http://127.0.0.1:8080/v1", "http://host.containers.internal:8080/v1"},
+		{"0.0.0.0", "http://0.0.0.0:11434/v1", "http://host.containers.internal:11434/v1"},
+		{"::1", "http://[::1]:11434/v1", "http://host.containers.internal:11434/v1"},
+		{"remote host unchanged", "http://192.168.1.50:11434/v1", "http://192.168.1.50:11434/v1"},
+		{"hostname unchanged", "http://my-server:11434/v1", "http://my-server:11434/v1"},
+		{"https preserved", "https://localhost:11434/v1", "https://host.containers.internal:11434/v1"},
+		{"no port", "http://localhost/v1", "http://host.containers.internal/v1"},
+		{"invalid URL returned as-is", "not a url ://", "not a url ://"},
+		{"non-URL arg unchanged", "mcp-server-milvus==0.1.1.dev8", "mcp-server-milvus==0.1.1.dev8"},
+		{"flag name unchanged", "--milvus-uri", "--milvus-uri"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := RewriteURL(tt.input)
+			if got != tt.expected {
+				t.Errorf("RewriteURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRewriteMCPCommandArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil mcp", func(t *testing.T) {
+		t.Parallel()
+		RewriteMCPCommandArgs(nil)
+	})
+
+	t.Run("nil commands", func(t *testing.T) {
+		t.Parallel()
+		mcp := &workspace.McpConfiguration{}
+		RewriteMCPCommandArgs(mcp)
+	})
+
+	t.Run("nil args", func(t *testing.T) {
+		t.Parallel()
+		cmds := []workspace.McpCommand{{Name: "test", Command: "uvx"}}
+		mcp := &workspace.McpConfiguration{Commands: &cmds}
+		RewriteMCPCommandArgs(mcp)
+		if (*mcp.Commands)[0].Args != nil {
+			t.Error("expected args to remain nil")
+		}
+	})
+
+	t.Run("rewrites localhost in args", func(t *testing.T) {
+		t.Parallel()
+		args := []string{
+			"mcp-server-milvus==0.1.1.dev8",
+			"--milvus-uri",
+			"http://localhost:51017",
+		}
+		cmds := []workspace.McpCommand{{
+			Name:    "milvus",
+			Command: "uvx",
+			Args:    &args,
+		}}
+		mcp := &workspace.McpConfiguration{Commands: &cmds}
+
+		RewriteMCPCommandArgs(mcp)
+
+		got := (*mcp.Commands)[0].Args
+		expected := []string{
+			"mcp-server-milvus==0.1.1.dev8",
+			"--milvus-uri",
+			"http://host.containers.internal:51017",
+		}
+		for i, v := range *got {
+			if v != expected[i] {
+				t.Errorf("arg[%d] = %q, want %q", i, v, expected[i])
+			}
+		}
+	})
+
+	t.Run("does not modify server URLs", func(t *testing.T) {
+		t.Parallel()
+		servers := []workspace.McpServer{{
+			Name: "github",
+			Url:  "https://api.githubcopilot.com/mcp",
+		}}
+		mcp := &workspace.McpConfiguration{Servers: &servers}
+
+		RewriteMCPCommandArgs(mcp)
+
+		if (*mcp.Servers)[0].Url != "https://api.githubcopilot.com/mcp" {
+			t.Errorf("server URL was modified: %q", (*mcp.Servers)[0].Url)
+		}
+	})
+
+	t.Run("multiple commands", func(t *testing.T) {
+		t.Parallel()
+		args1 := []string{"--url", "http://127.0.0.1:8080"}
+		args2 := []string{"--host", "http://localhost:3000/api"}
+		cmds := []workspace.McpCommand{
+			{Name: "svc1", Command: "npx", Args: &args1},
+			{Name: "svc2", Command: "node", Args: &args2},
+		}
+		mcp := &workspace.McpConfiguration{Commands: &cmds}
+
+		RewriteMCPCommandArgs(mcp)
+
+		if (*(*mcp.Commands)[0].Args)[1] != "http://host.containers.internal:8080" {
+			t.Errorf("cmd1 arg not rewritten: %q", (*(*mcp.Commands)[0].Args)[1])
+		}
+		if (*(*mcp.Commands)[1].Args)[1] != "http://host.containers.internal:3000/api" {
+			t.Errorf("cmd2 arg not rewritten: %q", (*(*mcp.Commands)[1].Args)[1])
+		}
+	})
+}

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -256,6 +256,14 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		return nil, fmt.Errorf("failed to get runtime: %w", err)
 	}
 
+	// Allow the runtime to transform the workspace config for its environment
+	// (e.g. rewriting localhost URLs for container networking).
+	if transformer, ok := rt.(runtime.ConfigTransformer); ok && mergedConfig != nil {
+		if err := transformer.TransformConfig(mergedConfig); err != nil {
+			return nil, fmt.Errorf("failed to transform workspace config: %w", err)
+		}
+	}
+
 	// Read agent settings files from storage config directory
 	agentSettings, err := m.readAgentSettings(m.storageDir, opts.Agent)
 	if err != nil {

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/containerurl"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
@@ -64,6 +66,9 @@ var _ runtime.AgentLister = (*podmanRuntime)(nil)
 // Ensure podmanRuntime implements runtime.SecretServiceRegistryAware at compile time.
 var _ runtime.SecretServiceRegistryAware = (*podmanRuntime)(nil)
 
+// Ensure podmanRuntime implements runtime.ConfigTransformer at compile time.
+var _ runtime.ConfigTransformer = (*podmanRuntime)(nil)
+
 // New creates a new Podman runtime instance.
 func New() runtime.Runtime {
 	cli := findPodmanCLI()
@@ -96,6 +101,16 @@ func (p *podmanRuntime) Available() bool {
 // can resolve host patterns for secrets when configuring deny-mode networking.
 func (p *podmanRuntime) SetSecretServiceRegistry(reg secretservice.Registry) {
 	p.secretServiceRegistry = reg
+}
+
+// TransformConfig implements runtime.ConfigTransformer.
+// It rewrites localhost URLs in MCP command args to host.containers.internal
+// so that MCP servers spawned inside the container can reach host services.
+func (p *podmanRuntime) TransformConfig(config *workspace.WorkspaceConfiguration) error {
+	if config != nil && config.Mcp != nil {
+		containerurl.RewriteMCPCommandArgs(config.Mcp)
+	}
+	return nil
 }
 
 // Initialize implements runtime.StorageAware.

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
 	"github.com/openkaiden/kdn/pkg/system"
@@ -483,6 +484,53 @@ func TestPodmanRuntime_ListAgents(t *testing.T) {
 		expected := []string{"claude", "cursor", "goose", "opencode"}
 		if !slices.Equal(agents, expected) {
 			t.Errorf("Expected %v, got: %v", expected, agents)
+		}
+	})
+}
+
+func TestPodmanRuntime_TransformConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rewrites localhost URLs in MCP command args", func(t *testing.T) {
+		t.Parallel()
+
+		rt := &podmanRuntime{}
+		args := []string{"--url", "http://localhost:8080/api"}
+		config := &workspace.WorkspaceConfiguration{
+			Mcp: &workspace.McpConfiguration{
+				Commands: &[]workspace.McpCommand{
+					{Name: "test", Command: "cmd", Args: &args},
+				},
+			},
+		}
+
+		if err := rt.TransformConfig(config); err != nil {
+			t.Fatalf("TransformConfig() error = %v", err)
+		}
+
+		got := (*(*config.Mcp.Commands)[0].Args)[1]
+		want := "http://host.containers.internal:8080/api"
+		if got != want {
+			t.Errorf("arg = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("handles nil config", func(t *testing.T) {
+		t.Parallel()
+
+		rt := &podmanRuntime{}
+		if err := rt.TransformConfig(nil); err != nil {
+			t.Fatalf("TransformConfig(nil) error = %v", err)
+		}
+	})
+
+	t.Run("handles config without MCP", func(t *testing.T) {
+		t.Parallel()
+
+		rt := &podmanRuntime{}
+		config := &workspace.WorkspaceConfiguration{}
+		if err := rt.TransformConfig(config); err != nil {
+			t.Fatalf("TransformConfig() error = %v", err)
 		}
 	})
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -222,6 +222,28 @@ type FlagProvider interface {
 	Flags() []FlagDef
 }
 
+// ConfigTransformer is an optional interface for runtimes that need to
+// transform workspace configuration before it is processed by agents.
+// For example, a container runtime may rewrite localhost URLs in MCP
+// command args to make host services reachable from inside the container.
+//
+// TransformConfig is called after configuration merging but before
+// agent settings are generated (e.g., before SetMCPServers bakes MCP
+// config into agent setting files). Implementations should mutate the
+// config in place.
+//
+// Example implementation:
+//
+//	func (r *myRuntime) TransformConfig(config *workspace.WorkspaceConfiguration) error {
+//	    if config.Mcp != nil {
+//	        rewriteLocalhostURLs(config.Mcp)
+//	    }
+//	    return nil
+//	}
+type ConfigTransformer interface {
+	TransformConfig(config *workspace.WorkspaceConfiguration) error
+}
+
 // ValidateState validates that a runtime state is one of the valid WorkspaceState values.
 // Valid states are: "running", "stopped", "error", "unknown".
 // Returns an error if the state is not valid.


### PR DESCRIPTION
## Summary
- Extracts `toContainerURL` helper from `pkg/agent/opencode.go` into a shared `pkg/containerurl` package
- Applies URL rewriting to MCP command args in the manager before `SetMCPServers`, so spawned MCP servers inside containers can reach host services (e.g. `http://localhost:51017` → `http://host.containers.internal:51017`)
- Only affects command-based MCP servers (spawned locally), not URL-based MCP servers (remote endpoints)

Fixes: https://github.com/openkaiden/kdn/issues/410

## Test plan
- [x] Unit tests for `RewriteURL` covering localhost, 127.0.0.1, [::1], 0.0.0.0, remote hosts, non-URL strings
- [x] Unit tests for `RewriteMCPCommandArgs` covering nil inputs, mixed args, multiple commands, server URLs untouched
- [x] All existing tests pass (`make ci-checks`)
- [ ] E2E: init workspace with MCP command referencing `http://localhost:<port>`, verify agent settings contain `host.containers.internal`

related: https://github.com/openkaiden/kaiden/issues/1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)