### PR TITLE
feat(runtime): add runtime list command

### DIFF
--- a/.agents/skills/add-runtime/SKILL.md
+++ b/.agents/skills/add-runtime/SKILL.md
@@ -63,6 +63,16 @@ func (r *<runtime-name>Runtime) Type() string {
     return "<runtime-name>"
 }
 
+// Description returns a human-readable description of the runtime.
+func (r *<runtime-name>Runtime) Description() string {
+    return "<short description of what this runtime provides>"
+}
+
+// Local reports whether the runtime executes workspaces on the local machine.
+func (r *<runtime-name>Runtime) Local() bool {
+    return true // set to false for remote runtimes (e.g., Kubernetes)
+}
+
 // Initialize implements runtime.StorageAware (optional)
 func (r *<runtime-name>Runtime) Initialize(storageDir string) error {
     r.storageDir = storageDir
@@ -409,6 +419,8 @@ All runtimes MUST implement:
 ```go
 type Runtime interface {
     Type() string
+    Description() string
+    Local() bool
     WorkspaceSourcesPath() string
     Create(ctx context.Context, params CreateParams) (RuntimeInfo, error)
     Start(ctx context.Context, id string) (RuntimeInfo, error)

--- a/.agents/skills/working-with-runtime-system/SKILL.md
+++ b/.agents/skills/working-with-runtime-system/SKILL.md
@@ -91,6 +91,20 @@ func (r *myRuntime) Create(ctx context.Context, params runtime.CreateParams) (ru
 }
 ```
 
+### Listing Runtimes
+
+`runtimesetup.ListRuntimes()` returns structured information about all available runtimes (excluding the internal `fake` runtime). It is used by `kdn runtime list`.
+
+The function relies on two mandatory methods that all runtimes must implement:
+
+```go
+// Description returns a human-readable description of the runtime.
+Description() string
+
+// Local reports whether the runtime executes workspaces on the local machine.
+Local() bool
+```
+
 ### AgentLister Interface
 
 The AgentLister interface enables runtimes to report which agents they support. This is used by the `info` command to discover available agents without requiring direct knowledge of runtime-specific configuration.

--- a/README.md
+++ b/README.md
@@ -3781,3 +3781,59 @@ Error: no port forward found for port 9999 in workspace "my-project"
 - Opening the browser is best-effort; errors are silently ignored
 - Tab completion for the first argument suggests running workspaces; for the second argument it suggests the available target port numbers
 - JSON output is **not supported** for this command
+
+### `runtime list` - List Available Runtimes
+
+Lists all runtime environments available for workspaces in the current environment.
+
+#### Usage
+
+```bash
+kdn runtime list [flags]
+```
+
+#### Flags
+
+- `--output, -o <format>` - Output format (supported: `json`)
+- `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
+
+#### Examples
+
+**List all available runtimes (human-readable table):**
+```bash
+kdn runtime list
+```
+Output:
+```text
+NAME        DESCRIPTION                                  LOCAL
+podman      Container-based workspaces using Podman      yes
+openshell   Sandbox-based workspaces using OpenShell...  no
+```
+
+**List runtimes in JSON format:**
+```bash
+kdn runtime list --output json
+```
+Output:
+```json
+{
+  "items": [
+    {
+      "name": "podman",
+      "description": "Container-based workspaces using Podman",
+      "local": true
+    }
+  ]
+}
+```
+
+**List using short flag:**
+```bash
+kdn runtime list -o json
+```
+
+#### Notes
+
+- Only runtimes available in the current environment are listed (e.g., the Podman runtime only appears if the `podman` CLI is installed)
+- The `local` field indicates whether the runtime executes workspaces on the local machine (`true`) or on a remote system (`false`)
+- **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -71,6 +71,10 @@ func NewRootCmd() *cobra.Command {
 		ID:    "config",
 		Title: "Configuration Commands:",
 	})
+	rootCmd.AddGroup(&cobra.Group{
+		ID:    "runtime",
+		Title: "Runtime Commands:",
+	})
 
 	// Add subcommands with groups
 	initCmd := NewInitCmd()
@@ -116,6 +120,10 @@ func NewRootCmd() *cobra.Command {
 	autoconfCmd := NewAutoconfCmd()
 	autoconfCmd.GroupID = "config"
 	rootCmd.AddCommand(autoconfCmd)
+
+	runtimeCmd := NewRuntimeCmd()
+	runtimeCmd.GroupID = "runtime"
+	rootCmd.AddCommand(runtimeCmd)
 
 	// Commands without a group (will appear under "Additional Commands")
 	rootCmd.AddCommand(NewVersionCmd())

--- a/pkg/cmd/runtime.go
+++ b/pkg/cmd/runtime.go
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewRuntimeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runtime",
+		Short: "Manage runtimes",
+		Long:  "Manage runtime environments available for workspaces",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewRuntimeListCmd())
+
+	return cmd
+}

--- a/pkg/cmd/runtime_list.go
+++ b/pkg/cmd/runtime_list.go
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fatih/color"
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/runtimesetup"
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+)
+
+// runtimeListCmd contains the configuration for the runtime list command.
+type runtimeListCmd struct {
+	output string
+	listFn func() []api.RuntimeInfo
+}
+
+// preRun validates the parameters and flags.
+func (r *runtimeListCmd) preRun(cmd *cobra.Command, args []string) error {
+	if r.output != "" && r.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", r.output)
+	}
+
+	if r.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
+	return nil
+}
+
+// run executes the runtime list command logic.
+func (r *runtimeListCmd) run(cmd *cobra.Command, args []string) error {
+	runtimes := r.listFn()
+
+	if r.output == "json" {
+		return r.outputJSON(cmd, runtimes)
+	}
+
+	return r.displayTable(cmd, runtimes)
+}
+
+// displayTable displays the runtimes in a formatted table.
+func (r *runtimeListCmd) displayTable(cmd *cobra.Command, runtimes []api.RuntimeInfo) error {
+	out := cmd.OutOrStdout()
+	if len(runtimes) == 0 {
+		fmt.Fprintln(out, "No runtimes available")
+		return nil
+	}
+
+	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+	columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+	tbl := table.New("NAME", "DESCRIPTION", "LOCAL")
+	tbl.WithWriter(out)
+	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+	for _, rt := range runtimes {
+		local := "no"
+		if rt.Local {
+			local = "yes"
+		}
+		tbl.AddRow(rt.Name, rt.Description, local)
+	}
+
+	tbl.Print()
+
+	return nil
+}
+
+// outputJSON outputs the runtimes as JSON.
+func (r *runtimeListCmd) outputJSON(cmd *cobra.Command, runtimes []api.RuntimeInfo) error {
+	items := runtimes
+	if items == nil {
+		items = []api.RuntimeInfo{}
+	}
+
+	list := api.RuntimesList{
+		Items: items,
+	}
+
+	jsonData, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, r.output, fmt.Errorf("failed to marshal runtimes to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
+func NewRuntimeListCmd() *cobra.Command {
+	c := &runtimeListCmd{
+		listFn: runtimesetup.ListRuntimes,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List available runtimes",
+		Long:  "List all runtime environments available for workspaces",
+		Example: `# List all available runtimes
+kdn runtime list
+
+# List runtimes in JSON format
+kdn runtime list --output json
+
+# List using short flag
+kdn runtime list -o json`,
+		Args:    cobra.NoArgs,
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
+
+	return cmd
+}

--- a/pkg/cmd/runtime_list_test.go
+++ b/pkg/cmd/runtime_list_test.go
@@ -1,0 +1,422 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/spf13/cobra"
+)
+
+func TestRuntimeListCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRuntimeListCmd()
+	if cmd == nil {
+		t.Fatal("NewRuntimeListCmd() returned nil")
+	}
+
+	if cmd.Use != "list" {
+		t.Errorf("Expected Use to be 'list', got '%s'", cmd.Use)
+	}
+}
+
+func TestRuntimeListCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts empty output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{output: ""}
+		cmd := &cobra.Command{}
+
+		err := c.preRun(cmd, nil)
+		if err != nil {
+			t.Fatalf("preRun failed: %v", err)
+		}
+	})
+
+	t.Run("accepts json output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{output: "json"}
+		cmd := &cobra.Command{}
+
+		err := c.preRun(cmd, nil)
+		if err != nil {
+			t.Fatalf("preRun failed: %v", err)
+		}
+	})
+
+	t.Run("rejects unsupported output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{output: "yaml"}
+		cmd := &cobra.Command{}
+
+		err := c.preRun(cmd, nil)
+		if err == nil {
+			t.Fatal("Expected error for unsupported output format, got nil")
+		}
+		if !strings.Contains(err.Error(), "unsupported output format") {
+			t.Errorf("Expected error about unsupported format, got: %s", err.Error())
+		}
+	})
+}
+
+func TestRuntimeListCmd_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("displays table with runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			listFn: func() []api.RuntimeInfo {
+				return []api.RuntimeInfo{
+					{Name: "podman", Description: "Container-based workspaces using Podman", Local: true},
+				}
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "podman") {
+			t.Errorf("Expected output to contain 'podman', got: %s", output)
+		}
+		if !strings.Contains(output, "Container-based workspaces using Podman") {
+			t.Errorf("Expected output to contain description, got: %s", output)
+		}
+		if !strings.Contains(output, "yes") {
+			t.Errorf("Expected output to contain 'yes' for local, got: %s", output)
+		}
+	})
+
+	t.Run("displays remote runtime as no", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			listFn: func() []api.RuntimeInfo {
+				return []api.RuntimeInfo{
+					{Name: "k8s", Description: "Kubernetes-based workspaces", Local: false},
+				}
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "no") {
+			t.Errorf("Expected output to contain 'no' for remote runtime, got: %s", output)
+		}
+	})
+
+	t.Run("displays message when no runtimes available", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			listFn: func() []api.RuntimeInfo {
+				return nil
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "No runtimes available") {
+			t.Errorf("Expected 'No runtimes available', got: %s", output)
+		}
+	})
+
+	t.Run("displays multiple runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			listFn: func() []api.RuntimeInfo {
+				return []api.RuntimeInfo{
+					{Name: "podman", Description: "Container-based workspaces using Podman", Local: true},
+					{Name: "k8s", Description: "Kubernetes-based workspaces", Local: false},
+				}
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "podman") {
+			t.Errorf("Expected output to contain 'podman', got: %s", output)
+		}
+		if !strings.Contains(output, "k8s") {
+			t.Errorf("Expected output to contain 'k8s', got: %s", output)
+		}
+	})
+}
+
+func TestRuntimeListCmd_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("outputs valid JSON with runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			output: "json",
+			listFn: func() []api.RuntimeInfo {
+				return []api.RuntimeInfo{
+					{Name: "podman", Description: "Container-based workspaces using Podman", Local: true},
+				}
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		var result api.RuntimesList
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if len(result.Items) != 1 {
+			t.Fatalf("Expected 1 item, got %d", len(result.Items))
+		}
+		if result.Items[0].Name != "podman" {
+			t.Errorf("Expected name 'podman', got %q", result.Items[0].Name)
+		}
+		if result.Items[0].Description != "Container-based workspaces using Podman" {
+			t.Errorf("Expected description mismatch, got %q", result.Items[0].Description)
+		}
+		if !result.Items[0].Local {
+			t.Error("Expected local to be true")
+		}
+	})
+
+	t.Run("outputs empty items array when no runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			output: "json",
+			listFn: func() []api.RuntimeInfo {
+				return nil
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		var result api.RuntimesList
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if result.Items == nil {
+			t.Fatal("Expected items to be an empty array, got nil")
+		}
+		if len(result.Items) != 0 {
+			t.Errorf("Expected 0 items, got %d", len(result.Items))
+		}
+	})
+
+	t.Run("outputs multiple runtimes with correct local flags", func(t *testing.T) {
+		t.Parallel()
+
+		c := &runtimeListCmd{
+			output: "json",
+			listFn: func() []api.RuntimeInfo {
+				return []api.RuntimeInfo{
+					{Name: "podman", Description: "Container-based workspaces", Local: true},
+					{Name: "k8s", Description: "Kubernetes workspaces", Local: false},
+				}
+			},
+		}
+
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		err := c.run(cmd, nil)
+		if err != nil {
+			t.Fatalf("run failed: %v", err)
+		}
+
+		var result api.RuntimesList
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if len(result.Items) != 2 {
+			t.Fatalf("Expected 2 items, got %d", len(result.Items))
+		}
+		if !result.Items[0].Local {
+			t.Error("Expected first runtime to be local")
+		}
+		if result.Items[1].Local {
+			t.Error("Expected second runtime to not be local")
+		}
+	})
+}
+
+func TestRuntimeListCmd_E2E(t *testing.T) {
+	t.Parallel()
+
+	t.Run("runtime list text output", func(t *testing.T) {
+		t.Parallel()
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		rootCmd.SetArgs([]string{"runtime", "list"})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+	})
+
+	t.Run("runtime list json output", func(t *testing.T) {
+		t.Parallel()
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		rootCmd.SetArgs([]string{"runtime", "list", "--output", "json"})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		var result api.RuntimesList
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v\nOutput: %s", err, buf.String())
+		}
+
+		if result.Items == nil {
+			t.Fatal("Expected items array, got nil")
+		}
+	})
+
+	t.Run("runtime list with short output flag", func(t *testing.T) {
+		t.Parallel()
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		rootCmd.SetArgs([]string{"runtime", "list", "-o", "json"})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		var result api.RuntimesList
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v\nOutput: %s", err, buf.String())
+		}
+	})
+
+	t.Run("runtime list with unsupported output format", func(t *testing.T) {
+		t.Parallel()
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		rootCmd.SetArgs([]string{"runtime", "list", "--output", "yaml"})
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error for unsupported output format")
+		}
+		if !strings.Contains(err.Error(), "unsupported output format") {
+			t.Errorf("Expected error about unsupported format, got: %s", err.Error())
+		}
+	})
+}
+
+func TestRuntimeListCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	listCmd := NewRuntimeListCmd()
+
+	if listCmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(listCmd.Example)
+	if err != nil {
+		t.Fatalf("Failed to parse examples: %v", err)
+	}
+
+	if len(commands) == 0 {
+		t.Fatal("Expected at least one example command")
+	}
+
+	rootCmd := NewRootCmd()
+	err = testutil.ValidateCommandExamples(rootCmd, listCmd.Example)
+	if err != nil {
+		t.Errorf("Example validation failed: %v", err)
+	}
+}

--- a/pkg/cmd/runtime_test.go
+++ b/pkg/cmd/runtime_test.go
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRuntimeCmd()
+	if cmd == nil {
+		t.Fatal("NewRuntimeCmd() returned nil")
+	}
+
+	if cmd.Use != "runtime" {
+		t.Errorf("Expected Use to be 'runtime', got '%s'", cmd.Use)
+	}
+
+	foundList := false
+	for _, subCmd := range cmd.Commands() {
+		if subCmd.Use == "list" {
+			foundList = true
+			break
+		}
+	}
+
+	if !foundList {
+		t.Error("Expected runtime command to have 'list' subcommand")
+	}
+}
+
+func TestRuntimeCmd_UnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"runtime", "foobar"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Expected Execute() to return an error for unknown command")
+	}
+
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("Expected error to contain 'unknown command', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "foobar") {
+		t.Errorf("Expected error to contain 'foobar', got: %s", err.Error())
+	}
+}

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -2886,9 +2886,9 @@ type invalidStateRuntime struct {
 	infoState   string
 }
 
-func (r *invalidStateRuntime) Type() string {
-	return "invalid-state-runtime"
-}
+func (r *invalidStateRuntime) Type() string        { return "invalid-state-runtime" }
+func (r *invalidStateRuntime) Description() string { return "invalid state runtime for testing" }
+func (r *invalidStateRuntime) Local() bool         { return true }
 
 func (r *invalidStateRuntime) WorkspaceSourcesPath() string {
 	return "/workspace/sources"
@@ -3828,8 +3828,9 @@ func newSpyRuntime(wrapped runtime.Runtime) *spyRuntime {
 	return &spyRuntime{wrapped: wrapped}
 }
 
-func (s *spyRuntime) Type() string { return s.wrapped.Type() }
-
+func (s *spyRuntime) Type() string                 { return s.wrapped.Type() }
+func (s *spyRuntime) Description() string          { return s.wrapped.Description() }
+func (s *spyRuntime) Local() bool                  { return s.wrapped.Local() }
 func (s *spyRuntime) WorkspaceSourcesPath() string { return s.wrapped.WorkspaceSourcesPath() }
 
 func (s *spyRuntime) Create(ctx context.Context, params runtime.CreateParams) (runtime.RuntimeInfo, error) {

--- a/pkg/runtime/fake/fake.go
+++ b/pkg/runtime/fake/fake.go
@@ -166,6 +166,16 @@ func (f *fakeRuntime) Type() string {
 	return "fake"
 }
 
+// Description returns a human-readable description of the fake runtime.
+func (f *fakeRuntime) Description() string {
+	return "In-memory runtime for testing"
+}
+
+// Local reports whether the runtime executes workspaces locally.
+func (f *fakeRuntime) Local() bool {
+	return true
+}
+
 // WorkspaceSourcesPath returns the path where sources are mounted inside the workspace.
 func (f *fakeRuntime) WorkspaceSourcesPath() string {
 	return "/project/sources"

--- a/pkg/runtime/openshell/openshell.go
+++ b/pkg/runtime/openshell/openshell.go
@@ -166,6 +166,16 @@ func (r *openshellRuntime) Type() string {
 	return "openshell"
 }
 
+// Description returns a human-readable description of the OpenShell runtime.
+func (r *openshellRuntime) Description() string {
+	return "Sandbox-based workspaces using OpenShell Gateway"
+}
+
+// Local reports whether the runtime executes workspaces locally.
+func (r *openshellRuntime) Local() bool {
+	return false
+}
+
 // WorkspaceSourcesPath returns the path where sources are mounted inside the sandbox.
 func (r *openshellRuntime) WorkspaceSourcesPath() string {
 	return containerWorkspaceSources

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -251,6 +251,16 @@ func (p *podmanRuntime) Type() string {
 	return "podman"
 }
 
+// Description returns a human-readable description of the Podman runtime.
+func (p *podmanRuntime) Description() string {
+	return "Container-based workspaces using Podman"
+}
+
+// Local reports whether the runtime executes workspaces locally.
+func (p *podmanRuntime) Local() bool {
+	return true
+}
+
 // WorkspaceSourcesPath returns the path where sources are mounted inside the workspace.
 func (p *podmanRuntime) WorkspaceSourcesPath() string {
 	return containerWorkspaceSources

--- a/pkg/runtime/registry_test.go
+++ b/pkg/runtime/registry_test.go
@@ -28,10 +28,9 @@ type fakeRuntime struct {
 	typeID string
 }
 
-func (f *fakeRuntime) Type() string {
-	return f.typeID
-}
-
+func (f *fakeRuntime) Type() string        { return f.typeID }
+func (f *fakeRuntime) Description() string { return "fake runtime for testing" }
+func (f *fakeRuntime) Local() bool         { return true }
 func (f *fakeRuntime) WorkspaceSourcesPath() string {
 	return "/workspace/sources"
 }
@@ -350,10 +349,9 @@ type storageAwareRuntime struct {
 	initializeErr error
 }
 
-func (s *storageAwareRuntime) Type() string {
-	return s.typeID
-}
-
+func (s *storageAwareRuntime) Type() string        { return s.typeID }
+func (s *storageAwareRuntime) Description() string { return "storage-aware runtime for testing" }
+func (s *storageAwareRuntime) Local() bool         { return true }
 func (s *storageAwareRuntime) WorkspaceSourcesPath() string {
 	return "/workspace/sources"
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -32,6 +32,13 @@ type Runtime interface {
 	// Type returns the runtime type identifier (e.g., "podman", "docker", "process", "fake").
 	Type() string
 
+	// Description returns a human-readable description of the runtime.
+	Description() string
+
+	// Local reports whether the runtime executes workspaces on the local machine.
+	// Returns true for local runtimes (e.g., Podman), false for remote ones (e.g., Kubernetes).
+	Local() bool
+
 	// WorkspaceSourcesPath returns the path where sources will be mounted inside the workspace.
 	// This is a constant for each runtime type and doesn't require an instance to exist.
 	WorkspaceSourcesPath() string

--- a/pkg/runtimesetup/register.go
+++ b/pkg/runtimesetup/register.go
@@ -18,6 +18,7 @@ package runtimesetup
 import (
 	"sort"
 
+	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
 	"github.com/openkaiden/kdn/pkg/runtime/openshell"
@@ -211,6 +212,37 @@ func registerAllWithAvailable(registrar Registrar, factories []runtimeFactory) e
 	}
 
 	return nil
+}
+
+// ListRuntimes returns structured information about all available runtimes,
+// excluding internal runtimes like "fake" (used only for testing).
+func ListRuntimes() []api.RuntimeInfo {
+	return listRuntimesWithFactories(availableRuntimes)
+}
+
+// listRuntimesWithFactories returns runtime info from the given factories.
+func listRuntimesWithFactories(factories []runtimeFactory) []api.RuntimeInfo {
+	var runtimes []api.RuntimeInfo
+
+	for _, factory := range factories {
+		rt := factory()
+
+		if avail, ok := rt.(Available); ok && !avail.Available() {
+			continue
+		}
+
+		if rt.Type() == "fake" {
+			continue
+		}
+
+		runtimes = append(runtimes, api.RuntimeInfo{
+			Name:        rt.Type(),
+			Description: rt.Description(),
+			Local:       rt.Local(),
+		})
+	}
+
+	return runtimes
 }
 
 // ListFlags returns the CLI flag definitions declared by all available runtimes

--- a/pkg/runtimesetup/register_test.go
+++ b/pkg/runtimesetup/register_test.go
@@ -40,10 +40,16 @@ func (f *fakeRegistrar) RegisterRuntime(rt runtime.Runtime) error {
 // testRuntime is a simple test runtime implementation
 type testRuntime struct {
 	runtimeType string
+	description string
+	local       bool
 	available   bool
 }
 
 func (t *testRuntime) Type() string { return t.runtimeType }
+
+func (t *testRuntime) Description() string { return t.description }
+
+func (t *testRuntime) Local() bool { return t.local }
 
 func (t *testRuntime) WorkspaceSourcesPath() string { return "/workspace/sources" }
 
@@ -512,6 +518,114 @@ func TestListFlags(t *testing.T) {
 		t.Errorf("expected openshell flags to be either both present or both absent, got driver=%v allow-hosts=%v",
 			flagNames["openshell-driver"], flagNames["openshell-allow-hosts"])
 	}
+}
+
+func TestListRuntimesWithFactories(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns info for available runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "container-rt", description: "Containers", local: true, available: true}
+			},
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "remote-rt", description: "Remote clusters", local: false, available: true}
+			},
+		}
+
+		runtimes := listRuntimesWithFactories(factories)
+
+		if len(runtimes) != 2 {
+			t.Fatalf("expected 2 runtimes, got %d", len(runtimes))
+		}
+		if runtimes[0].Name != "container-rt" {
+			t.Errorf("expected name 'container-rt', got %q", runtimes[0].Name)
+		}
+		if runtimes[0].Description != "Containers" {
+			t.Errorf("expected description 'Containers', got %q", runtimes[0].Description)
+		}
+		if !runtimes[0].Local {
+			t.Error("expected container-rt to be local")
+		}
+		if runtimes[1].Name != "remote-rt" {
+			t.Errorf("expected name 'remote-rt', got %q", runtimes[1].Name)
+		}
+		if runtimes[1].Local {
+			t.Error("expected remote-rt to not be local")
+		}
+	})
+
+	t.Run("skips unavailable runtimes", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "avail-rt", description: "Available", local: true, available: true}
+			},
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "unavail-rt", description: "Unavailable", local: true, available: false}
+			},
+		}
+
+		runtimes := listRuntimesWithFactories(factories)
+
+		if len(runtimes) != 1 {
+			t.Fatalf("expected 1 runtime, got %d", len(runtimes))
+		}
+		if runtimes[0].Name != "avail-rt" {
+			t.Errorf("expected name 'avail-rt', got %q", runtimes[0].Name)
+		}
+	})
+
+	t.Run("skips fake runtime", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "fake", description: "Fake", local: true, available: true}
+			},
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "real-rt", description: "Real", local: true, available: true}
+			},
+		}
+
+		runtimes := listRuntimesWithFactories(factories)
+
+		if len(runtimes) != 1 {
+			t.Fatalf("expected 1 runtime, got %d", len(runtimes))
+		}
+		if runtimes[0].Name != "real-rt" {
+			t.Errorf("expected name 'real-rt', got %q", runtimes[0].Name)
+		}
+	})
+
+	t.Run("returns empty when no runtimes available", func(t *testing.T) {
+		t.Parallel()
+
+		factories := []runtimeFactory{
+			func() runtime.Runtime {
+				return &testRuntime{runtimeType: "unavail-rt", description: "Unavailable", local: true, available: false}
+			},
+		}
+
+		runtimes := listRuntimesWithFactories(factories)
+
+		if len(runtimes) != 0 {
+			t.Errorf("expected 0 runtimes, got %d", len(runtimes))
+		}
+	})
+
+	t.Run("returns nil when factory list is empty", func(t *testing.T) {
+		t.Parallel()
+
+		runtimes := listRuntimesWithFactories(nil)
+
+		if runtimes != nil {
+			t.Errorf("expected nil, got %v", runtimes)
+		}
+	})
 }
 
 func TestListFlagsWithFactories(t *testing.T) {


### PR DESCRIPTION
Adds Description() and Local() to the Runtime interface, implements them in the fake and podman runtimes, and exposes ListRuntimes() in runtimesetup. Wires up kdn runtime list with table and JSON output.

<img width="1003" height="659" alt="Screenshot 2026-05-05 at 7 31 50" src="https://github.com/user-attachments/assets/44ad5671-7f1f-4961-9193-1ff8bfbc012b" />

Closes https://github.com/openkaiden/kdn/issues/227
