### PR TITLE
feat(agent): allow provider::model without base URL for opencode

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -67,7 +67,8 @@ func (o *openCodeAgent) SkipOnboarding(settings map[string][]byte, _ string) (ma
 // SetModel configures the model ID in OpenCode settings.
 // The modelID supports three formats:
 //   - "model" — sets the model directly
-//   - "provider::model" — sets provider/model and auto-configures the provider with its default base URL
+//   - "provider::model" — sets provider/model; uses default base URL for known providers (ollama, ramalama),
+//     omits baseURL for others so the provider resolves its own endpoint
 //   - "provider::model::baseURL" — sets provider/model and configures the provider with the given base URL
 //
 // All other fields in .config/opencode/opencode.json are preserved.
@@ -99,11 +100,7 @@ func (o *openCodeAgent) SetModel(settings map[string][]byte, modelID string) (ma
 		}
 		resolvedURL := baseURL
 		if resolvedURL == "" {
-			defaultURL, known := defaultProviderBaseURLs[provider]
-			if !known {
-				return nil, fmt.Errorf("unknown provider %q: append ::baseURL to specify the endpoint", provider)
-			}
-			resolvedURL = defaultURL
+			resolvedURL = defaultProviderBaseURLs[provider]
 		} else {
 			resolvedURL = toContainerURL(resolvedURL)
 		}
@@ -150,12 +147,14 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 			"npm":  "@ai-sdk/openai-compatible",
 		}
 	}
-	options, _ := providerEntry["options"].(map[string]interface{})
-	if options == nil {
-		options = make(map[string]interface{})
+	if baseURL != "" {
+		options, _ := providerEntry["options"].(map[string]interface{})
+		if options == nil {
+			options = make(map[string]interface{})
+		}
+		options["baseURL"] = baseURL
+		providerEntry["options"] = options
 	}
-	options["baseURL"] = baseURL
-	providerEntry["options"] = options
 	providers[provider] = providerEntry
 
 	models, _ := providerEntry["models"].(map[string]interface{})

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -376,15 +376,41 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown provider without baseURL returns error", func(t *testing.T) {
+	t.Run("unknown provider without baseURL configures provider without baseURL", func(t *testing.T) {
 		t.Parallel()
 
 		agent := NewOpenCode()
 		settings := make(map[string][]byte)
 
-		_, err := agent.SetModel(settings, "unknown::some-model")
-		if err == nil {
-			t.Fatal("Expected error for unknown provider without baseURL")
+		result, err := agent.SetModel(settings, "openrouter::anthropic/claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath], &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "openrouter/anthropic/claude-sonnet-4-6" {
+			t.Errorf("model = %v, want %q", config["model"], "openrouter/anthropic/claude-sonnet-4-6")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		openrouter := providers["openrouter"].(map[string]interface{})
+
+		if openrouter["npm"] != "@ai-sdk/openai-compatible" {
+			t.Errorf("npm = %v, want %q", openrouter["npm"], "@ai-sdk/openai-compatible")
+		}
+
+		models := openrouter["models"].(map[string]interface{})
+		modelEntry := models["anthropic/claude-sonnet-4-6"].(map[string]interface{})
+		if name := modelEntry["name"].(string); name != "anthropic/claude-sonnet-4-6" {
+			t.Errorf("model name = %q, want %q", name, "anthropic/claude-sonnet-4-6")
+		}
+
+		if _, hasOptions := openrouter["options"]; hasOptions {
+			t.Error("Provider without baseURL should not have options block")
 		}
 	})
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -343,6 +343,9 @@ kdn init --runtime podman --agent claude --model claude-sonnet-4-20250514
 # Register with a model provider (auto-configured base URL)
 kdn init --runtime podman --agent opencode --model ollama::gemma4:26b
 
+# Register with a model provider (provider resolves its own endpoint)
+kdn init --runtime podman --agent opencode --model openrouter::anthropic/claude-sonnet-4-6
+
 # Register with a model provider and custom endpoint
 kdn init --runtime podman --agent opencode --model ollama::gemma4:26b::http://192.168.1.50:11434/v1
 

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -2524,7 +2524,7 @@ func TestInitCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 11
+	expectedCount := 12
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}


### PR DESCRIPTION
Providers like openrouter have well-known endpoints and don't need an
explicit base URL. Remove the hard requirement to append ::baseURL for
unknown providers — only set baseURL when provided or when the provider
has a known default (ollama, ramalama).

Closes #354

Tested with 

- configure an OPENROUTER_API_KEY secret such that 
   * host pattern  = openrouter.ai
   * path pattern = /api/v1/*
 
> ./kdn init /path/to/my-workspace --agent opencode --model openrouter::google/gemma-4-31b-it:free

(after relaxing network constraints)

<img width="744" height="915" alt="Screenshot 2026-05-05 at 17 24 31" src="https://github.com/user-attachments/assets/201ded45-ea30-4197-81c2-50a654f1289c" />
