### PR TITLE
feat(ports): add port forwarding from workspace config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ The `pkg/devcontainers/features` package models, downloads, and orders Dev Conta
 - `WorkspaceConfigDir` is required in `CreateParams` so `FromMap` can resolve `./local-feature` paths
 - In the Containerfile, feature `COPY`/`RUN`/`ENV` instructions are placed after user creation (`useradd -m agent`) but before `USER agent:agent` — features still run as root so they can install system-wide tools, but `/home/agent` and the `agent` account exist so install scripts can `chown`, write dotfiles, and `su` to the target user. `_REMOTE_USER` and `_REMOTE_USER_HOME` are exported as `ENV` immediately before the feature block
 
-**Config merger requirement:** The `pkg/config/merger.go` `Merge()` and `copyConfig()` functions must explicitly handle every field of `WorkspaceConfiguration`. Fields not wired in are silently dropped. `Features` is handled via `mergeFeatures()` / `copyFeatures()`.
+**Config merger requirement:** The `pkg/config/merger.go` `Merge()` and `copyConfig()` functions must explicitly handle every field of `WorkspaceConfiguration`. Fields not wired in are silently dropped. `Features` is handled via `mergeFeatures()` / `copyFeatures()`; `Ports` is handled via `mergePorts()` / inline copy.
 
 **For full implementation details, use:** `/working-with-devcontainers`
 

--- a/README.md
+++ b/README.md
@@ -1999,7 +1999,7 @@ Forward ports from the workspace to the host so that services running inside the
 **Fields:**
 - Each entry is an integer workspace port to forward
 
-At workspace creation time, kdn allocates a free host port for each requested workspace port and binds it to `127.0.0.1`. The assigned host ports are reported in the `forwards` field of the workspace JSON output (`kdn list --output json` / `kdn get --output json`):
+At workspace creation time, kdn allocates a free host port for each requested workspace port and binds it to `127.0.0.1`. The assigned host ports are reported in the `forwards` field of the workspace JSON output (`kdn list --output json` / `kdn workspace list --output json`):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1985,6 +1985,33 @@ Each key is a feature ID — either an OCI reference (`ghcr.io/org/repo/feature:
 }
 ```
 
+### Port Forwarding
+
+Forward ports from the workspace to the host so that services running inside the workspace are reachable from the host machine.
+
+**Structure:**
+```json
+{
+  "ports": [8080, 3000]
+}
+```
+
+**Fields:**
+- Each entry is an integer workspace port to forward
+
+At workspace creation time, kdn allocates a free host port for each requested workspace port and binds it to `127.0.0.1`. The assigned host ports are reported in the `forwards` field of the workspace JSON output (`kdn list --output json` / `kdn get --output json`):
+
+```json
+{
+  "forwards": [
+    {"bind": "127.0.0.1", "port": 54321, "target": 8080},
+    {"bind": "127.0.0.1", "port": 54322, "target": 3000}
+  ]
+}
+```
+
+**Merging behaviour:** When configuration is merged across levels, port lists are union-merged and deduplicated (base ports first, then override ports with duplicates removed).
+
 ### Configuration Validation
 
 When you register a workspace with `kdn init`, the configuration is automatically validated. If `workspace.json` exists and contains invalid data, the registration will fail with a descriptive error message.

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.9.0
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.9.0
+	github.com/openkaiden/kdn-api/cli/go v0.10.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.10.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -77,10 +77,10 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/openkaiden/kdn-api/cli/go v0.9.0 h1:zXiPTgDtW3FBKHptdaFgU9jnNaRwXajMH4mKoKgfSQQ=
-github.com/openkaiden/kdn-api/cli/go v0.9.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.9.0 h1:fYqSzynKbNn/qo4RjCx/mEXzFtLwY145+sq48h4RDrQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.9.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.10.0 h1:SjYWSTUd2Dasn6XfNuQ3VgQFbxZyqJvoKsi2+w2BxH4=
+github.com/openkaiden/kdn-api/cli/go v0.10.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.10.0 h1:tD+fdFtx8OQXv3jTdNwO9kHv7Lt3v75VyH1AscU3wrg=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.10.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/pkg/cmd/conversion.go
+++ b/pkg/cmd/conversion.go
@@ -36,12 +36,13 @@ func instanceToWorkspaceId(instance instances.Instance) api.WorkspaceId {
 
 // instanceToWorkspace converts an Instance to an api.Workspace
 func instanceToWorkspace(instance instances.Instance) api.Workspace {
+	runtimeData := instance.GetRuntimeData()
 	ws := api.Workspace{
 		Id:      instance.GetID(),
 		Name:    instance.GetName(),
 		Project: instance.GetProject(),
 		Agent:   instance.GetAgent(),
-		State:   instance.GetRuntimeData().State,
+		State:   runtimeData.State,
 		Paths: api.WorkspacePaths{
 			Configuration: instance.GetConfigDir(),
 			Source:        instance.GetSourceDir(),
@@ -49,6 +50,7 @@ func instanceToWorkspace(instance instances.Instance) api.Workspace {
 		Timestamps: api.WorkspaceTimestamps{
 			Created: instance.GetCreatedAt().UnixMilli(),
 		},
+		Forwards: []api.WorkspaceForward{},
 	}
 	if model := instance.GetModel(); model != "" {
 		ws.Model = &model
@@ -56,6 +58,12 @@ func instanceToWorkspace(instance instances.Instance) api.Workspace {
 	if startedAt := instance.GetStartedAt(); !startedAt.IsZero() {
 		ms := startedAt.UnixMilli()
 		ws.Timestamps.Started = &ms
+	}
+	if forwardsJSON, ok := runtimeData.Info["forwards"]; ok {
+		var forwards []api.WorkspaceForward
+		if err := json.Unmarshal([]byte(forwardsJSON), &forwards); err == nil {
+			ws.Forwards = forwards
+		}
 	}
 	return ws
 }

--- a/pkg/cmd/conversion_test.go
+++ b/pkg/cmd/conversion_test.go
@@ -527,3 +527,144 @@ func TestOutputErrorIfJSON(t *testing.T) {
 		}
 	})
 }
+
+func TestInstanceToWorkspace_Forwards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates forwards from runtime info", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+
+		instanceData := instances.InstanceData{
+			ID:    "fwd-test-id",
+			Name:  "fwd-workspace",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				Info: map[string]string{
+					"forwards": `[{"bind":"127.0.0.1","port":54321,"target":8080}]`,
+				},
+			},
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		if len(result.Forwards) != 1 {
+			t.Fatalf("Expected 1 forward, got %d", len(result.Forwards))
+		}
+		fwd := result.Forwards[0]
+		if fwd.Bind != "127.0.0.1" {
+			t.Errorf("Expected Bind '127.0.0.1', got '%s'", fwd.Bind)
+		}
+		if fwd.Port != 54321 {
+			t.Errorf("Expected Port 54321, got %d", fwd.Port)
+		}
+		if fwd.Target != 8080 {
+			t.Errorf("Expected Target 8080, got %d", fwd.Target)
+		}
+	})
+
+	t.Run("returns empty forwards when no runtime info", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+
+		instanceData := instances.InstanceData{
+			ID:    "no-fwd-id",
+			Name:  "no-fwd-workspace",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		if result.Forwards == nil {
+			t.Fatal("Expected Forwards to be non-nil (empty slice)")
+		}
+		if len(result.Forwards) != 0 {
+			t.Errorf("Expected 0 forwards, got %d", len(result.Forwards))
+		}
+	})
+
+	t.Run("returns empty forwards when forwards JSON is invalid", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+
+		instanceData := instances.InstanceData{
+			ID:    "bad-fwd-id",
+			Name:  "bad-fwd-workspace",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				Info: map[string]string{
+					"forwards": "not-valid-json",
+				},
+			},
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		if result.Forwards == nil {
+			t.Fatal("Expected Forwards to be non-nil (empty slice)")
+		}
+		if len(result.Forwards) != 0 {
+			t.Errorf("Expected 0 forwards when JSON is invalid, got %d", len(result.Forwards))
+		}
+	})
+
+	t.Run("forwards field appears in JSON output", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+
+		instanceData := instances.InstanceData{
+			ID:    "json-fwd-id",
+			Name:  "json-fwd-workspace",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				Info: map[string]string{
+					"forwards": `[{"bind":"127.0.0.1","port":12345,"target":3000},{"bind":"127.0.0.1","port":12346,"target":9090}]`,
+				},
+			},
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		jsonData, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("Failed to marshal result: %v", err)
+		}
+
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(jsonData, &parsed); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+
+		forwards, ok := parsed["forwards"].([]interface{})
+		if !ok {
+			t.Fatal("Expected 'forwards' field to be an array in JSON")
+		}
+		if len(forwards) != 2 {
+			t.Errorf("Expected 2 forwards in JSON, got %d", len(forwards))
+		}
+	})
+}

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -81,6 +81,9 @@ func (m *merger) Merge(base, override *workspace.WorkspaceConfiguration) *worksp
 	// Merge features
 	result.Features = mergeFeatures(base.Features, override.Features)
 
+	// Merge ports
+	result.Ports = mergePorts(base.Ports, override.Ports)
+
 	return result
 }
 
@@ -552,6 +555,13 @@ func copyConfig(cfg *workspace.WorkspaceConfiguration) *workspace.WorkspaceConfi
 	// Copy features
 	result.Features = copyFeatures(cfg.Features)
 
+	// Copy ports
+	if cfg.Ports != nil {
+		portsCopy := make([]int, len(*cfg.Ports))
+		copy(portsCopy, *cfg.Ports)
+		result.Ports = &portsCopy
+	}
+
 	return result
 }
 
@@ -576,6 +586,33 @@ func copyFeatures(feats *map[string]map[string]interface{}) *map[string]map[stri
 	result := make(map[string]map[string]interface{}, len(*feats))
 	for id, opts := range *feats {
 		result[id] = copyFeatureOptions(opts)
+	}
+	return &result
+}
+
+// mergePorts merges two port slices, deduplicating port numbers.
+// Base ports come first; override ports are appended if not already present.
+func mergePorts(base, override *[]int) *[]int {
+	if base == nil && override == nil {
+		return nil
+	}
+	seen := make(map[int]bool)
+	var result []int
+
+	for _, slice := range []*[]int{base, override} {
+		if slice == nil {
+			continue
+		}
+		for _, port := range *slice {
+			if !seen[port] {
+				seen[port] = true
+				result = append(result, port)
+			}
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
 	}
 	return &result
 }

--- a/pkg/config/merger_test.go
+++ b/pkg/config/merger_test.go
@@ -1555,3 +1555,85 @@ func TestMerger_Features(t *testing.T) {
 		}
 	})
 }
+
+func TestMerger_Ports(t *testing.T) {
+	t.Parallel()
+
+	merger := NewMerger()
+
+	t.Run("base ports preserved when override has none", func(t *testing.T) {
+		t.Parallel()
+
+		ports := []int{8080, 9090}
+		base := &workspace.WorkspaceConfiguration{Ports: &ports}
+
+		result := merger.Merge(base, &workspace.WorkspaceConfiguration{})
+		if result.Ports == nil {
+			t.Fatal("Expected Ports to be preserved from base")
+		}
+		if len(*result.Ports) != 2 {
+			t.Errorf("Expected 2 ports, got %d", len(*result.Ports))
+		}
+	})
+
+	t.Run("override ports added when base has none", func(t *testing.T) {
+		t.Parallel()
+
+		ports := []int{3000}
+		override := &workspace.WorkspaceConfiguration{Ports: &ports}
+
+		result := merger.Merge(&workspace.WorkspaceConfiguration{}, override)
+		if result.Ports == nil {
+			t.Fatal("Expected Ports to be present from override")
+		}
+		if len(*result.Ports) != 1 || (*result.Ports)[0] != 3000 {
+			t.Errorf("Expected [3000], got %v", *result.Ports)
+		}
+	})
+
+	t.Run("ports are union-merged and deduplicated", func(t *testing.T) {
+		t.Parallel()
+
+		basePorts := []int{8080, 9090}
+		overridePorts := []int{9090, 3000}
+		base := &workspace.WorkspaceConfiguration{Ports: &basePorts}
+		override := &workspace.WorkspaceConfiguration{Ports: &overridePorts}
+
+		result := merger.Merge(base, override)
+		if result.Ports == nil {
+			t.Fatal("Expected Ports to be present")
+		}
+		if len(*result.Ports) != 3 {
+			t.Errorf("Expected 3 unique ports, got %d: %v", len(*result.Ports), *result.Ports)
+		}
+	})
+
+	t.Run("nil ports when both nil", func(t *testing.T) {
+		t.Parallel()
+
+		base := &workspace.WorkspaceConfiguration{}
+		override := &workspace.WorkspaceConfiguration{}
+
+		result := merger.Merge(base, override)
+		if result.Ports != nil {
+			t.Errorf("Expected Ports to be nil, got %v", *result.Ports)
+		}
+	})
+
+	t.Run("copyConfig copies ports independently", func(t *testing.T) {
+		t.Parallel()
+
+		ports := []int{8080}
+		cfg := &workspace.WorkspaceConfiguration{Ports: &ports}
+
+		result := merger.Merge(nil, cfg)
+		if result.Ports == nil {
+			t.Fatal("Expected Ports to be copied")
+		}
+		// Modify original; copy must be independent
+		(*cfg.Ports)[0] = 9999
+		if (*result.Ports)[0] == 9999 {
+			t.Error("Expected Ports copy to be independent of original")
+		}
+	})
+}

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -17,6 +17,7 @@ package podman
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -53,6 +54,7 @@ type podTemplateData struct {
 	ProjectID          string
 	Agent              string
 	ApprovalHandlerDir string
+	Forwards           []api.WorkspaceForward
 }
 
 // validateCreateParams validates the create parameters.
@@ -400,6 +402,13 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to allocate free ports: %w", err)
 	}
 
+	// Allocate host ports for each requested container port before rendering the pod YAML,
+	// since ports must be declared at the pod level (not on individual containers).
+	forwards, err := p.buildForwards(params)
+	if err != nil {
+		return runtime.RuntimeInfo{}, err
+	}
+
 	// Prepare the approval-handler directory with the embedded Node.js script
 	// so it is available as a hostPath volume when the pod is created.
 	approvalHandlerDir := filepath.Join(p.storageDir, "approval-handler", params.Name)
@@ -419,6 +428,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		ProjectID:          params.ProjectID,
 		Agent:              params.Agent,
 		ApprovalHandlerDir: podmanSystem.HostPathToMachinePath(approvalHandlerDir),
+		Forwards:           forwards,
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")
@@ -513,12 +523,40 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 	if ccArgs != nil && ccArgs.caContainerPath != "" {
 		info["ca_container_path"] = ccArgs.caContainerPath
 	}
+	if len(forwards) > 0 {
+		forwardsJSON, jsonErr := json.Marshal(forwards)
+		if jsonErr == nil {
+			info["forwards"] = string(forwardsJSON)
+		}
+	}
 
 	return runtime.RuntimeInfo{
 		ID:    containerID,
 		State: api.WorkspaceStateStopped,
 		Info:  info,
 	}, nil
+}
+
+// buildForwards allocates a free host port for each container port in WorkspaceConfig.Ports
+// and returns the resulting WorkspaceForward slice. Returns nil when no ports are configured.
+func (p *podmanRuntime) buildForwards(params runtime.CreateParams) ([]api.WorkspaceForward, error) {
+	if params.WorkspaceConfig == nil || params.WorkspaceConfig.Ports == nil || len(*params.WorkspaceConfig.Ports) == 0 {
+		return nil, nil
+	}
+	containerPorts := *params.WorkspaceConfig.Ports
+	hostPorts, err := findFreePorts(len(containerPorts))
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate host ports: %w", err)
+	}
+	forwards := make([]api.WorkspaceForward, len(containerPorts))
+	for i, containerPort := range containerPorts {
+		forwards[i] = api.WorkspaceForward{
+			Bind:   "127.0.0.1",
+			Port:   hostPorts[i],
+			Target: containerPort,
+		}
+	}
+	return forwards, nil
 }
 
 // setupOnecli starts postgres, waits for it, then starts onecli to avoid migration race conditions.

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
@@ -1749,4 +1750,139 @@ func assertDirectoryRemoved(t *testing.T, dir string) {
 			t.Logf("Instance directory contents: %v", entries)
 		}
 	}
+}
+
+func TestRenderPodYAML_Ports(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders port declarations in pod YAML when forwards are set", func(t *testing.T) {
+		t.Parallel()
+
+		data := podTemplateData{
+			Name:               "port-workspace",
+			OnecliWebPort:      11000,
+			OnecliVersion:      "1.17",
+			AgentUID:           1000,
+			BaseImageRegistry:  "registry.example.com/base",
+			BaseImageVersion:   "latest",
+			SourcePath:         "/workspace/sources",
+			ApprovalHandlerDir: "/tmp/approval",
+			Forwards: []api.WorkspaceForward{
+				{Bind: "127.0.0.1", Port: 54321, Target: 8080},
+				{Bind: "127.0.0.1", Port: 54322, Target: 3000},
+			},
+		}
+
+		rendered, err := renderPodYAML(data)
+		if err != nil {
+			t.Fatalf("renderPodYAML() failed: %v", err)
+		}
+
+		yaml := string(rendered)
+		if !strings.Contains(yaml, "containerPort: 8080") {
+			t.Errorf("Expected containerPort 8080 in YAML:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "hostPort: 54321") {
+			t.Errorf("Expected hostPort 54321 in YAML:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "containerPort: 3000") {
+			t.Errorf("Expected containerPort 3000 in YAML:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "hostPort: 54322") {
+			t.Errorf("Expected hostPort 54322 in YAML:\n%s", yaml)
+		}
+	})
+
+	t.Run("omits ports section when no forwards configured", func(t *testing.T) {
+		t.Parallel()
+
+		data := podTemplateData{
+			Name:               "no-port-workspace",
+			OnecliWebPort:      11001,
+			OnecliVersion:      "1.17",
+			AgentUID:           1000,
+			BaseImageRegistry:  "registry.example.com/base",
+			BaseImageVersion:   "latest",
+			SourcePath:         "/workspace/sources",
+			ApprovalHandlerDir: "/tmp/approval",
+		}
+
+		rendered, err := renderPodYAML(data)
+		if err != nil {
+			t.Fatalf("renderPodYAML() failed: %v", err)
+		}
+
+		yaml := string(rendered)
+		// The only ports section should be for OneCLI (containerPort: 10254), not user ports
+		if strings.Contains(yaml, "containerPort: 8080") {
+			t.Errorf("Expected no user containerPort in YAML:\n%s", yaml)
+		}
+	})
+}
+
+func TestBuildForwards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when no workspace config", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		params := runtime.CreateParams{}
+
+		forwards, err := p.buildForwards(params)
+		if err != nil {
+			t.Fatalf("buildForwards() failed: %v", err)
+		}
+		if forwards != nil {
+			t.Errorf("Expected nil forwards, got %v", forwards)
+		}
+	})
+
+	t.Run("returns nil when ports is nil", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		params := runtime.CreateParams{
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{},
+		}
+
+		forwards, err := p.buildForwards(params)
+		if err != nil {
+			t.Fatalf("buildForwards() failed: %v", err)
+		}
+		if forwards != nil {
+			t.Errorf("Expected nil forwards, got %v", forwards)
+		}
+	})
+
+	t.Run("allocates host ports for each container port", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		ports := []int{8080, 3000}
+		params := runtime.CreateParams{
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Ports: &ports,
+			},
+		}
+
+		forwards, err := p.buildForwards(params)
+		if err != nil {
+			t.Fatalf("buildForwards() failed: %v", err)
+		}
+		if len(forwards) != 2 {
+			t.Fatalf("Expected 2 forwards, got %d", len(forwards))
+		}
+		for i, fwd := range forwards {
+			if fwd.Bind != "127.0.0.1" {
+				t.Errorf("Forward %d: expected Bind '127.0.0.1', got '%s'", i, fwd.Bind)
+			}
+			if fwd.Target != ports[i] {
+				t.Errorf("Forward %d: expected Target %d, got %d", i, ports[i], fwd.Target)
+			}
+			if fwd.Port <= 0 || fwd.Port > 65535 {
+				t.Errorf("Forward %d: Port %d is out of valid range", i, fwd.Port)
+			}
+		}
+	})
 }

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1791,6 +1791,9 @@ func TestRenderPodYAML_Ports(t *testing.T) {
 		if !strings.Contains(yaml, "hostPort: 54322") {
 			t.Errorf("Expected hostPort 54322 in YAML:\n%s", yaml)
 		}
+		if !strings.Contains(yaml, `hostIP: "127.0.0.1"`) {
+			t.Errorf("Expected hostIP 127.0.0.1 in YAML:\n%s", yaml)
+		}
 	})
 
 	t.Run("omits ports section when no forwards configured", func(t *testing.T) {

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1886,3 +1886,99 @@ func TestBuildForwards(t *testing.T) {
 		}
 	})
 }
+
+func TestCreate_ForwardsInRuntimeInfo(t *testing.T) {
+	t.Parallel()
+
+	newRuntime := func(t *testing.T) (*podmanRuntime, context.Context) {
+		t.Helper()
+		storageDir := t.TempDir()
+		sourcePath := t.TempDir()
+		onecliServer := newOnecliTestServer(t)
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(ctx context.Context, args ...string) error { return nil }
+		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+			return []byte("container-id-123"), nil
+		}
+
+		p := &podmanRuntime{
+			system:          &fakeSystem{},
+			executor:        fakeExec,
+			storageDir:      storageDir,
+			config:          &fakeConfig{},
+			onecliBaseURLFn: func(_ int) string { return onecliServer.URL },
+		}
+		ctx := steplogger.WithLogger(context.Background(), &fakeStepLogger{})
+		_ = sourcePath
+		return p, ctx
+	}
+
+	t.Run("forwards written to RuntimeInfo when ports configured", func(t *testing.T) {
+		t.Parallel()
+
+		p, ctx := newRuntime(t)
+		ports := []int{8080, 3000}
+		params := runtime.CreateParams{
+			Name:       "fwd-workspace",
+			SourcePath: t.TempDir(),
+			Agent:      "test_agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Ports: &ports,
+			},
+		}
+
+		info, err := p.Create(ctx, params)
+		if err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		forwardsJSON, ok := info.Info["forwards"]
+		if !ok {
+			t.Fatal("Expected 'forwards' key in RuntimeInfo.Info")
+		}
+
+		var forwards []api.WorkspaceForward
+		if err := json.Unmarshal([]byte(forwardsJSON), &forwards); err != nil {
+			t.Fatalf("Failed to unmarshal forwards JSON: %v", err)
+		}
+		if len(forwards) != 2 {
+			t.Fatalf("Expected 2 forwards, got %d", len(forwards))
+		}
+		targets := map[int]bool{}
+		for _, fwd := range forwards {
+			targets[fwd.Target] = true
+			if fwd.Bind != "127.0.0.1" {
+				t.Errorf("Expected Bind '127.0.0.1', got '%s'", fwd.Bind)
+			}
+			if fwd.Port <= 0 || fwd.Port > 65535 {
+				t.Errorf("Port %d out of valid range", fwd.Port)
+			}
+		}
+		for _, want := range ports {
+			if !targets[want] {
+				t.Errorf("Expected target port %d in forwards, got %v", want, forwards)
+			}
+		}
+	})
+
+	t.Run("forwards absent from RuntimeInfo when no ports configured", func(t *testing.T) {
+		t.Parallel()
+
+		p, ctx := newRuntime(t)
+		params := runtime.CreateParams{
+			Name:       "no-fwd-workspace",
+			SourcePath: t.TempDir(),
+			Agent:      "test_agent",
+		}
+
+		info, err := p.Create(ctx, params)
+		if err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		if _, ok := info.Info["forwards"]; ok {
+			t.Errorf("Expected no 'forwards' key in RuntimeInfo.Info when no ports configured")
+		}
+	})
+}

--- a/pkg/runtime/podman/pods/onecli-pod.yaml
+++ b/pkg/runtime/podman/pods/onecli-pod.yaml
@@ -66,4 +66,8 @@ spec:
       securityContext:
         capabilities:
           add: ["NET_ADMIN"]
-      command: ["sleep", "infinity"]
+      command: ["sleep", "infinity"]{{if .Forwards}}
+      ports:{{range .Forwards}}
+        - containerPort: {{.Target}}
+          hostPort: {{.Port}}
+          hostIP: "{{.Bind}}"{{end}}{{end}}


### PR DESCRIPTION
The workspace configuration now supports a `ports` list. At creation time, kdn allocates a free host port for each requested workspace port, declares the mappings in the pod YAML, and persists them as JSON in the RuntimeInfo so `kdn list/get --output json` can report them via the new `forwards` field on the Workspace type.

Also bumps kdn-api to v0.10.0, which introduces WorkspaceForward and the Ports field on WorkspaceConfiguration.

Fixes #385 