### PR TITLE
feat(cmd): add workspace open command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1999,7 +1999,7 @@ Forward ports from the workspace to the host so that services running inside the
 **Fields:**
 - Each entry is an integer workspace port to forward
 
-At workspace creation time, kdn allocates a free host port for each requested workspace port and binds it to `127.0.0.1`. The assigned host ports are reported in the `forwards` field of the workspace JSON output (`kdn list --output json` / `kdn workspace list --output json`):
+At workspace creation time, kdn allocates a free host port for each requested workspace port and binds it to `127.0.0.1`. The assigned host ports are reported in the `forwards` field of the workspace JSON output (`kdn list --output json` / `kdn workspace list --output json`). Use `kdn open` / `kdn workspace open` to open a forwarded port directly in the browser:
 
 ```json
 {
@@ -3687,4 +3687,87 @@ Error: dashboard not supported for workspace "my-project"
 - The URL is always printed to stdout, even when the browser opens successfully
 - Opening the browser is best-effort; errors are silently ignored
 - Tab completion suggests only running workspaces whose runtime supports the Dashboard interface
+- JSON output is **not supported** for this command
+
+### `workspace open` - Open a Forwarded Port in the Browser
+
+Prints the URL for a forwarded port of a running workspace and opens it in the default browser. Also available as the shorter alias `open`.
+
+This command uses the port forwards configured in `workspace.json` (see [Port Forwarding](#port-forwarding)). The host port and bind address are determined at workspace creation time.
+
+#### Usage
+
+```bash
+kdn workspace open NAME|ID [PORT] [flags]
+kdn open NAME|ID [PORT] [flags]
+```
+
+#### Arguments
+
+- `NAME|ID` - The workspace name or unique identifier (required)
+- `PORT` - The workspace (target) port to open. Optional when exactly one port is forwarded; required when multiple ports are configured. Tab completion lists the available target ports.
+
+#### Flags
+
+- `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
+
+#### Examples
+
+**Open the only forwarded port (single-port workspace):**
+```bash
+kdn workspace open my-project
+```
+Output: `http://127.0.0.1:54321` (URL printed; browser opened automatically)
+
+**Open a specific port (multi-port workspace):**
+```bash
+kdn workspace open my-project 8080
+kdn open my-project 8080
+```
+
+#### Error Handling
+
+**Workspace not found:**
+```bash
+kdn open invalid-id
+```
+Output:
+```text
+Error: workspace not found: invalid-id
+Use 'workspace list' to see available workspaces
+```
+
+**No ports configured:**
+```bash
+kdn open my-project
+```
+Output:
+```text
+Error: no port forwards configured for workspace "my-project"
+```
+
+**Multiple ports, no port argument:**
+```bash
+kdn open my-project
+```
+Output:
+```text
+Error: workspace "my-project" has multiple port forwards; specify a port
+```
+
+**Port not found:**
+```bash
+kdn open my-project 9999
+```
+Output:
+```text
+Error: no port forward found for port 9999 in workspace "my-project"
+```
+
+#### Notes
+
+- The workspace must be running with port forwards configured via the `ports` field in `workspace.json`
+- The URL is always printed to stdout, even when the browser opens successfully
+- Opening the browser is best-effort; errors are silently ignored
+- Tab completion for the first argument suggests running workspaces; for the second argument it suggests the available target port numbers
 - JSON output is **not supported** for this command

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/envvars"
@@ -231,4 +232,57 @@ func completeRuntimeFlag(cmd *cobra.Command, args []string, toComplete string) (
 	runtimes := runtimesetup.ListAvailable()
 
 	return runtimes, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeOpenArgs provides completion for the workspace open command.
+// The first argument completes to running workspace names/IDs; the second
+// argument completes to the available target port numbers for that workspace.
+func completeOpenArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return getFilteredWorkspaceIDs(cmd, func(state api.WorkspaceState) bool {
+			return state == api.WorkspaceStateRunning
+		})
+	}
+	if len(args) == 1 {
+		return completeOpenPort(cmd, args[0])
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeOpenPort returns the available target port numbers for the given workspace.
+func completeOpenPort(cmd *cobra.Command, nameOrID string) ([]string, cobra.ShellCompDirective) {
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	if _, err := os.Stat(absStorageDir); os.IsNotExist(err) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	manager, err := instances.NewManager(absStorageDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	instance, err := manager.Get(nameOrID)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	forwards := instanceForwards(instance)
+	if len(forwards) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ports := make([]string, 0, len(forwards))
+	for _, f := range forwards {
+		ports = append(ports, strconv.Itoa(f.Target))
+	}
+	return ports, cobra.ShellCompDirectiveNoFileComp
 }

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -1156,3 +1156,324 @@ func TestCompleteRuntimeFlag(t *testing.T) {
 		}
 	})
 }
+
+func TestCompleteOpenArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first arg completes running workspace IDs and names", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		storageDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+
+		// running instance
+		src1 := t.TempDir()
+		inst1, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: src1,
+			ConfigDir: filepath.Join(src1, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance1: %v", err)
+		}
+		added1, err := manager.Add(ctx, instances.AddOptions{Instance: inst1, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("failed to add instance1: %v", err)
+		}
+		if err := manager.Start(ctx, added1.GetID()); err != nil {
+			t.Fatalf("failed to start instance1: %v", err)
+		}
+
+		// stopped instance — must not appear
+		src2 := t.TempDir()
+		inst2, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: src2,
+			ConfigDir: filepath.Join(src2, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("failed to create instance2: %v", err)
+		}
+		if _, err := manager.Add(ctx, instances.AddOptions{Instance: inst2, RuntimeType: "fake"}); err != nil {
+			t.Fatalf("failed to add instance2: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenArgs(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		// Only running instance should appear (ID + name)
+		if len(completions) != 2 {
+			t.Fatalf("expected 2 completions (ID and name of running workspace), got %d: %v", len(completions), completions)
+		}
+		set := make(map[string]bool)
+		for _, c := range completions {
+			set[c] = true
+		}
+		if !set[added1.GetID()] {
+			t.Errorf("expected running workspace ID %q in completions, got %v", added1.GetID(), completions)
+		}
+		if !set[added1.GetName()] {
+			t.Errorf("expected running workspace name %q in completions, got %v", added1.GetName(), completions)
+		}
+	})
+
+	t.Run("second arg completes port numbers for the given workspace", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+			{"bind": "127.0.0.1", "port": 45679, "target": 9090},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenArgs(cmd, []string{id}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 2 {
+			t.Fatalf("expected 2 port completions, got %d: %v", len(completions), completions)
+		}
+		set := make(map[string]bool)
+		for _, c := range completions {
+			set[c] = true
+		}
+		if !set["8080"] {
+			t.Errorf("expected %q in port completions, got %v", "8080", completions)
+		}
+		if !set["9090"] {
+			t.Errorf("expected %q in port completions, got %v", "9090", completions)
+		}
+	})
+
+	t.Run("third arg and beyond returns no completions", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", t.TempDir(), "")
+
+		completions, directive := completeOpenArgs(cmd, []string{"my-workspace", "8080"}, "")
+
+		if completions != nil {
+			t.Errorf("expected nil completions for third arg, got %v", completions)
+		}
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+	})
+
+	t.Run("first arg returns error directive when storage flag is missing", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+
+		_, directive := completeOpenArgs(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("directive = %v, want ShellCompDirectiveError", directive)
+		}
+	})
+}
+
+func TestCompleteOpenPort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error directive when storage flag is missing", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+
+		_, directive := completeOpenPort(cmd, "my-workspace")
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("directive = %v, want ShellCompDirectiveError", directive)
+		}
+	})
+
+	t.Run("returns no completions when storage directory does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", filepath.Join(t.TempDir(), "nonexistent"), "")
+
+		completions, directive := completeOpenPort(cmd, "my-workspace")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns no completions when workspace is not found", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		// Create an empty manager (no instances)
+		if _, err := instances.NewManager(storageDir); err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenPort(cmd, "nonexistent")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns no completions when workspace has no forwards", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		id := setupWorkspaceWithForwards(t, storageDir, nil)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenPort(cmd, id)
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns target port numbers for a workspace with forwards", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+			{"bind": "127.0.0.1", "port": 45679, "target": 3000},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenPort(cmd, id)
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 2 {
+			t.Fatalf("expected 2 port completions, got %d: %v", len(completions), completions)
+		}
+		set := make(map[string]bool)
+		for _, c := range completions {
+			set[c] = true
+		}
+		if !set["8080"] {
+			t.Errorf("expected %q in completions, got %v", "8080", completions)
+		}
+		if !set["3000"] {
+			t.Errorf("expected %q in completions, got %v", "3000", completions)
+		}
+	})
+
+	t.Run("returns a single port number for a single-forward workspace", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenPort(cmd, id)
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 1 {
+			t.Fatalf("expected 1 port completion, got %d: %v", len(completions), completions)
+		}
+		if completions[0] != "8080" {
+			t.Errorf("expected %q, got %q", "8080", completions[0])
+		}
+	})
+
+	t.Run("lookup by name as well as ID", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+		}
+		setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		// Get the name from the stored instance.
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("failed to register fake runtime: %v", err)
+		}
+		list, err := manager.List()
+		if err != nil || len(list) == 0 {
+			t.Fatalf("failed to list instances: %v", err)
+		}
+		name := list[0].GetName()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeOpenPort(cmd, name)
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+		}
+		if len(completions) != 1 || completions[0] != "8080" {
+			t.Errorf("expected [\"8080\"], got %v", completions)
+		}
+	})
+}
+
+func TestCompleteDashboardWorkspaceIDWith_ListError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error directive when listDashboardTypes fails", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		_, directive := completeDashboardWorkspaceIDWith(cmd, func(_ string) ([]string, error) {
+			return nil, filepath.ErrBadPattern
+		})
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("directive = %v, want ShellCompDirectiveError", directive)
+		}
+	})
+}

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -19,35 +19,22 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
-func NewWorkspaceCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "workspace",
-		Short: "Manage workspaces",
-		Long:  "Manage workspaces registered with kdn init",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
-	}
+func NewOpenCmd() *cobra.Command {
+	workspaceOpenCmd := NewWorkspaceOpenCmd()
 
-	// Add subcommands
-	cmd.AddCommand(NewWorkspaceDashboardCmd())
-	cmd.AddCommand(NewWorkspaceListCmd())
-	cmd.AddCommand(NewWorkspaceOpenCmd())
-	cmd.AddCommand(NewWorkspaceRemoveCmd())
-	cmd.AddCommand(NewWorkspaceStartCmd())
-	cmd.AddCommand(NewWorkspaceStopCmd())
-	cmd.AddCommand(NewWorkspaceTerminalCmd())
+	cmd := &cobra.Command{
+		Use:               "open NAME|ID [PORT]",
+		Short:             workspaceOpenCmd.Short + " (alias for 'workspace open')",
+		Long:              workspaceOpenCmd.Long,
+		Example:           AdaptExampleForAlias(workspaceOpenCmd.Example, "workspace open", "open"),
+		Args:              workspaceOpenCmd.Args,
+		ValidArgsFunction: workspaceOpenCmd.ValidArgsFunction,
+		PreRunE:           workspaceOpenCmd.PreRunE,
+		RunE:              workspaceOpenCmd.RunE,
+	}
 
 	return cmd
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -97,6 +97,10 @@ func NewRootCmd() *cobra.Command {
 	dashboardCmd.GroupID = "main"
 	rootCmd.AddCommand(dashboardCmd)
 
+	openCmd := NewOpenCmd()
+	openCmd.GroupID = "main"
+	rootCmd.AddCommand(openCmd)
+
 	terminalCmd := NewTerminalCmd()
 	terminalCmd.GroupID = "main"
 	rootCmd.AddCommand(terminalCmd)

--- a/pkg/cmd/workspace_open.go
+++ b/pkg/cmd/workspace_open.go
@@ -1,0 +1,154 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/runtimesetup"
+	"github.com/spf13/cobra"
+)
+
+// workspaceOpenCmd contains the configuration for the workspace open command
+type workspaceOpenCmd struct {
+	manager     instances.Manager
+	nameOrID    string
+	port        int // target port, 0 means not specified
+	openBrowser func(ctx context.Context, url string) error
+}
+
+// preRun validates the parameters and flags
+func (w *workspaceOpenCmd) preRun(cmd *cobra.Command, args []string) error {
+	w.nameOrID = args[0]
+
+	if len(args) > 1 {
+		port, err := strconv.Atoi(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid port %q: must be a number", args[1])
+		}
+		w.port = port
+	}
+
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return fmt.Errorf("failed to read --storage flag: %w", err)
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve absolute path for storage directory: %w", err)
+	}
+
+	manager, err := instances.NewManager(absStorageDir)
+	if err != nil {
+		return fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	if err := runtimesetup.RegisterAll(manager); err != nil {
+		return fmt.Errorf("failed to register runtimes: %w", err)
+	}
+
+	w.manager = manager
+	return nil
+}
+
+// run executes the workspace open command logic
+func (w *workspaceOpenCmd) run(cmd *cobra.Command, args []string) error {
+	instance, err := w.manager.Get(w.nameOrID)
+	if err != nil {
+		if errors.Is(err, instances.ErrInstanceNotFound) {
+			return fmt.Errorf("workspace not found: %s\nUse 'workspace list' to see available workspaces", w.nameOrID)
+		}
+		return err
+	}
+
+	forwards := instanceForwards(instance)
+	if len(forwards) == 0 {
+		return fmt.Errorf("no port forwards configured for workspace %q", w.nameOrID)
+	}
+
+	var forward *api.WorkspaceForward
+	if w.port == 0 {
+		if len(forwards) > 1 {
+			return fmt.Errorf("workspace %q has multiple port forwards; specify a port", w.nameOrID)
+		}
+		forward = &forwards[0]
+	} else {
+		for i := range forwards {
+			if forwards[i].Target == w.port {
+				forward = &forwards[i]
+				break
+			}
+		}
+		if forward == nil {
+			return fmt.Errorf("no port forward found for port %d in workspace %q", w.port, w.nameOrID)
+		}
+	}
+
+	url := fmt.Sprintf("http://%s:%d", forward.Bind, forward.Port)
+	fmt.Fprintln(cmd.OutOrStdout(), url)
+	if w.openBrowser != nil {
+		_ = w.openBrowser(cmd.Context(), url)
+	}
+	return nil
+}
+
+// instanceForwards extracts the port forwards from an instance's runtime data.
+func instanceForwards(instance instances.Instance) []api.WorkspaceForward {
+	runtimeData := instance.GetRuntimeData()
+	forwardsJSON, ok := runtimeData.Info["forwards"]
+	if !ok {
+		return nil
+	}
+	var forwards []api.WorkspaceForward
+	if err := json.Unmarshal([]byte(forwardsJSON), &forwards); err != nil {
+		return nil
+	}
+	return forwards
+}
+
+func NewWorkspaceOpenCmd() *cobra.Command {
+	c := &workspaceOpenCmd{
+		openBrowser: openBrowser,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "open NAME|ID [PORT]",
+		Short: "Open a forwarded port of a workspace in the browser",
+		Long:  "Open a forwarded port of a running workspace in the default browser and print the URL",
+		Example: `# Open the only forwarded port of a workspace
+kdn workspace open my-project
+
+# Open a specific forwarded port of a workspace
+kdn workspace open my-project 8080`,
+		Args:              cobra.RangeArgs(1, 2),
+		ValidArgsFunction: completeOpenArgs,
+		PreRunE:           c.preRun,
+		RunE:              c.run,
+	}
+
+	return cmd
+}

--- a/pkg/cmd/workspace_open_test.go
+++ b/pkg/cmd/workspace_open_test.go
@@ -1,0 +1,431 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/runtime/fake"
+	"github.com/spf13/cobra"
+)
+
+// injectForwards writes the given WorkspaceForward list as JSON into the "forwards"
+// key of the first instance stored in storageDir.
+func injectForwards(t *testing.T, storageDir string, instanceID string, forwards []map[string]any) {
+	t.Helper()
+	storageFile := filepath.Join(storageDir, instances.DefaultStorageFileName)
+	data, err := os.ReadFile(storageFile)
+	if err != nil {
+		t.Fatalf("injectForwards: read storage: %v", err)
+	}
+
+	var all []map[string]any
+	if err := json.Unmarshal(data, &all); err != nil {
+		t.Fatalf("injectForwards: unmarshal: %v", err)
+	}
+
+	forwardsJSON, err := json.Marshal(forwards)
+	if err != nil {
+		t.Fatalf("injectForwards: marshal forwards: %v", err)
+	}
+
+	for i, entry := range all {
+		id, _ := entry["id"].(string)
+		if id != instanceID {
+			continue
+		}
+		rt, ok := entry["runtime"].(map[string]any)
+		if !ok {
+			rt = make(map[string]any)
+			all[i]["runtime"] = rt
+		}
+		info, ok := rt["info"].(map[string]any)
+		if !ok {
+			info = make(map[string]any)
+			rt["info"] = info
+		}
+		info["forwards"] = string(forwardsJSON)
+		all[i]["runtime"] = rt
+		break
+	}
+
+	updated, err := json.Marshal(all)
+	if err != nil {
+		t.Fatalf("injectForwards: marshal updated: %v", err)
+	}
+	if err := os.WriteFile(storageFile, updated, 0644); err != nil {
+		t.Fatalf("injectForwards: write storage: %v", err)
+	}
+}
+
+func setupWorkspaceWithForwards(t *testing.T, storageDir string, forwards []map[string]any) string {
+	t.Helper()
+	sourceDir := t.TempDir()
+
+	manager, err := instances.NewManager(storageDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := manager.RegisterRuntime(fake.New()); err != nil {
+		t.Fatalf("RegisterRuntime: %v", err)
+	}
+
+	inst, err := instances.NewInstance(instances.NewInstanceParams{
+		SourceDir: sourceDir,
+		ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+
+	added, err := manager.Add(context.Background(), instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+	if err != nil {
+		t.Fatalf("manager.Add: %v", err)
+	}
+	if err := manager.Start(context.Background(), added.GetID()); err != nil {
+		t.Fatalf("manager.Start: %v", err)
+	}
+
+	if len(forwards) > 0 {
+		injectForwards(t, storageDir, added.GetID(), forwards)
+	}
+
+	return added.GetID()
+}
+
+func TestWorkspaceOpenCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewWorkspaceOpenCmd()
+	if cmd == nil {
+		t.Fatal("NewWorkspaceOpenCmd() returned nil")
+	}
+
+	if cmd.Use != "open NAME|ID [PORT]" {
+		t.Errorf("Expected Use to be 'open NAME|ID [PORT]', got %q", cmd.Use)
+	}
+}
+
+func TestWorkspaceOpenCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts name from args and creates manager", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		c := &workspaceOpenCmd{}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		if err := c.preRun(cmd, []string{"my-workspace"}); err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+		if c.nameOrID != "my-workspace" {
+			t.Errorf("nameOrID = %q, want %q", c.nameOrID, "my-workspace")
+		}
+		if c.port != 0 {
+			t.Errorf("port = %d, want 0", c.port)
+		}
+		if c.manager == nil {
+			t.Error("Expected manager to be created")
+		}
+	})
+
+	t.Run("parses optional port argument", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		c := &workspaceOpenCmd{}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		if err := c.preRun(cmd, []string{"my-workspace", "8080"}); err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+		if c.port != 8080 {
+			t.Errorf("port = %d, want 8080", c.port)
+		}
+	})
+
+	t.Run("returns error for non-numeric port", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		c := &workspaceOpenCmd{}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		err := c.preRun(cmd, []string{"my-workspace", "not-a-port"})
+		if err == nil {
+			t.Fatal("Expected error for non-numeric port, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid port") {
+			t.Errorf("Expected 'invalid port' error, got: %v", err)
+		}
+	})
+
+	t.Run("returns error when storage flag is not registered", func(t *testing.T) {
+		t.Parallel()
+
+		c := &workspaceOpenCmd{}
+		cmd := &cobra.Command{}
+
+		err := c.preRun(cmd, []string{"my-workspace"})
+		if err == nil {
+			t.Fatal("Expected error when storage flag is not registered, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to read --storage flag") {
+			t.Errorf("Expected 'failed to read --storage flag' error, got: %v", err)
+		}
+	})
+}
+
+func TestWorkspaceOpenCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails for nonexistent workspace", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		c := &workspaceOpenCmd{manager: manager, nameOrID: "nonexistent"}
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&bytes.Buffer{})
+
+		err := c.run(cobraCmd, nil)
+		if err == nil {
+			t.Fatal("Expected error for nonexistent workspace")
+		}
+		if !strings.Contains(err.Error(), "workspace not found") {
+			t.Errorf("Expected 'workspace not found', got: %v", err)
+		}
+	})
+
+	t.Run("fails when no ports are configured", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		id := setupWorkspaceWithForwards(t, storageDir, nil)
+
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		c := &workspaceOpenCmd{manager: manager, nameOrID: id}
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&bytes.Buffer{})
+
+		err := c.run(cobraCmd, nil)
+		if err == nil {
+			t.Fatal("Expected error when no forwards configured")
+		}
+		if !strings.Contains(err.Error(), "no port forwards configured") {
+			t.Errorf("Expected 'no port forwards configured', got: %v", err)
+		}
+	})
+
+	t.Run("opens single port without port argument", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		var openedURL string
+		c := &workspaceOpenCmd{
+			manager:  manager,
+			nameOrID: id,
+			openBrowser: func(_ context.Context, url string) error {
+				openedURL = url
+				return nil
+			},
+		}
+
+		var outBuf bytes.Buffer
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&outBuf)
+
+		if err := c.run(cobraCmd, nil); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		expected := "http://127.0.0.1:45678"
+		if output := strings.TrimSpace(outBuf.String()); output != expected {
+			t.Errorf("stdout = %q, want %q", output, expected)
+		}
+		if openedURL != expected {
+			t.Errorf("openBrowser url = %q, want %q", openedURL, expected)
+		}
+	})
+
+	t.Run("fails when multiple ports and no port argument", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+			{"bind": "127.0.0.1", "port": 45679, "target": 9090},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		c := &workspaceOpenCmd{manager: manager, nameOrID: id}
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&bytes.Buffer{})
+
+		err := c.run(cobraCmd, nil)
+		if err == nil {
+			t.Fatal("Expected error when multiple ports and no port argument")
+		}
+		if !strings.Contains(err.Error(), "multiple port forwards") {
+			t.Errorf("Expected 'multiple port forwards' error, got: %v", err)
+		}
+	})
+
+	t.Run("opens specific port when multiple ports configured", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+			{"bind": "127.0.0.1", "port": 45679, "target": 9090},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		c := &workspaceOpenCmd{manager: manager, nameOrID: id, port: 9090}
+		var outBuf bytes.Buffer
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&outBuf)
+
+		if err := c.run(cobraCmd, nil); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		expected := "http://127.0.0.1:45679"
+		if output := strings.TrimSpace(outBuf.String()); output != expected {
+			t.Errorf("stdout = %q, want %q", output, expected)
+		}
+	})
+
+	t.Run("fails when specified port not found", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		c := &workspaceOpenCmd{manager: manager, nameOrID: id, port: 9999}
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&bytes.Buffer{})
+
+		err := c.run(cobraCmd, nil)
+		if err == nil {
+			t.Fatal("Expected error for unknown port")
+		}
+		if !strings.Contains(err.Error(), "no port forward found for port 9999") {
+			t.Errorf("Expected 'no port forward found for port 9999', got: %v", err)
+		}
+	})
+}
+
+func TestWorkspaceOpenCmd_E2E(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails for nonexistent workspace", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "open", "nonexistent", "--storage", storageDir})
+
+		var outBuf bytes.Buffer
+		rootCmd.SetOut(&outBuf)
+		rootCmd.SetErr(&outBuf)
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error for nonexistent workspace")
+		}
+		if !strings.Contains(err.Error(), "workspace not found") {
+			t.Errorf("Expected 'workspace not found', got: %v", err)
+		}
+	})
+
+	t.Run("requires at least one argument", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "open", "--storage", storageDir})
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error when no argument provided")
+		}
+	})
+}
+
+func TestWorkspaceOpenCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewWorkspaceOpenCmd()
+
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("Failed to parse examples: %v", err)
+	}
+
+	expectedCount := 2
+	if len(commands) != expectedCount {
+		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	if err := testutil.ValidateCommandExamples(rootCmd, cmd.Example); err != nil {
+		t.Errorf("Example validation failed: %v", err)
+	}
+}


### PR DESCRIPTION
`kdn workspace open NAME|ID [PORT]` (alias: `kdn open`) opens a forwarded port of a running workspace in the default browser and prints the URL to stdout.

- 0 ports configured → error
- 1 port configured  → port argument is optional
- &gt;1 ports configured → port argument is required; tab-completion suggests the available target port numbers

Closes #415