### PR TITLE
feat(podman): configure Vertex AI via declared gcloud mount

### DIFF
--- a/pkg/googleauth/googleauth.go
+++ b/pkg/googleauth/googleauth.go
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package googleauth provides utilities for detecting and using Google
+// Application Default Credentials (ADC) when configuring workspaces.
+package googleauth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+// ADCCredentials holds the fields from application_default_credentials.json
+// that are needed to configure the Vertex AI app in OneCLI.
+type ADCCredentials struct {
+	RefreshToken   string `json:"refresh_token"`
+	ClientID       string `json:"client_id"`
+	ClientSecret   string `json:"client_secret"`
+	QuotaProjectID string `json:"quota_project_id"`
+}
+
+// VertexAIFields returns the credential fields for the OneCLI vertex-ai connect API.
+// If QuotaProjectID is empty in the ADC file, falls back to the
+// ANTHROPIC_VERTEX_PROJECT_ID or GOOGLE_CLOUD_PROJECT env vars.
+func (c *ADCCredentials) VertexAIFields() map[string]string {
+	quotaProject := c.QuotaProjectID
+	if quotaProject == "" {
+		if p := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"); p != "" {
+			quotaProject = p
+		} else {
+			quotaProject = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		}
+	}
+	return map[string]string{
+		"refreshToken":   c.RefreshToken,
+		"clientId":       c.ClientID,
+		"clientSecret":   c.ClientSecret,
+		"quotaProjectId": quotaProject,
+	}
+}
+
+const (
+	containerHomeDir   = "/home/agent"
+	containerGcloudDir = containerHomeDir + "/.config/gcloud"
+	containerADCPath   = containerGcloudDir + "/application_default_credentials.json"
+)
+
+// GcloudMount records a workspace mount that targets the gcloud config directory
+// or the ADC file directly, along with the resolved host path for the ADC file.
+type GcloudMount struct {
+	// Mount is the original workspace mount declaration.
+	Mount workspace.Mount
+	// ADCFilePath is the resolved host path to application_default_credentials.json.
+	ADCFilePath string
+}
+
+// FindGcloudMount scans workspace mounts for one targeting the gcloud config
+// directory ($HOME/.config/gcloud) or the ADC file directly. Returns nil if
+// none found. Detection is based on the resolved container-side target path.
+func FindGcloudMount(mounts []workspace.Mount, homeDir string) *GcloudMount {
+	for _, m := range mounts {
+		target := resolveGcloudTarget(m.Target)
+		switch target {
+		case containerGcloudDir:
+			hostDir := resolveGcloudHost(m.Host, homeDir)
+			return &GcloudMount{
+				Mount:       m,
+				ADCFilePath: filepath.Join(hostDir, "application_default_credentials.json"),
+			}
+		case containerADCPath:
+			return &GcloudMount{
+				Mount:       m,
+				ADCFilePath: resolveGcloudHost(m.Host, homeDir),
+			}
+		}
+	}
+	return nil
+}
+
+// resolveGcloudHost expands $HOME in a mount host path and returns the absolute path.
+// $SOURCES is not handled since gcloud config dirs are never under the source tree.
+func resolveGcloudHost(host, homeDir string) string {
+	if strings.HasPrefix(host, "$HOME") {
+		rest := filepath.FromSlash(host[len("$HOME"):])
+		return filepath.Join(homeDir, rest)
+	}
+	return filepath.Clean(host)
+}
+
+// resolveGcloudTarget expands $HOME in a mount target path and returns the
+// absolute container-side path. Mirrors the logic in mounts.go:resolveTargetPath.
+func resolveGcloudTarget(target string) string {
+	if strings.HasPrefix(target, "$HOME") {
+		return path.Join(containerHomeDir, target[len("$HOME"):])
+	}
+	return path.Clean(target)
+}
+
+// DefaultPath returns the standard host path for application default credentials.
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"), nil
+}
+
+// LoadFrom reads application_default_credentials.json from the given path.
+// Returns nil (no error) if the file does not exist.
+func LoadFrom(adcPath string) (*ADCCredentials, error) {
+	data, err := os.ReadFile(adcPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ADC file: %w", err)
+	}
+	var creds ADCCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("failed to parse ADC file: %w", err)
+	}
+	return &creds, nil
+}
+
+// Load reads application_default_credentials.json from the default location.
+// Returns nil (no error) if the file does not exist.
+func Load() (*ADCCredentials, error) {
+	p, err := DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	return LoadFrom(p)
+}
+
+// fakeADCJSON is written into the workspace container at the standard gcloud
+// credentials path. It has synthetic values so that gcloud-aware tools see a
+// credentials file without exposing real secrets; actual auth goes through the
+// OneCLI proxy which holds the real refresh token.
+var fakeADCJSON = []byte(`{
+  "account": "",
+  "client_id": "FAKE_CLIENT_ID",
+  "client_secret": "FAKE_CLIENT_SECRET",
+  "quota_project_id": "FAKE_QUOTA_PROJECT_ID",
+  "refresh_token": "FAKE_REFRESH_TOKEN",
+  "type": "authorized_user",
+  "universe_domain": "googleapis.com"
+}
+`)
+
+// FakeADCJSON returns the bytes of a synthetic ADC file for use inside containers.
+func FakeADCJSON() []byte {
+	return fakeADCJSON
+}
+
+// VertexAIHosts lists the host patterns that must be excluded from network
+// filtering when Vertex AI is configured. The approval handler uses glob
+// syntax, so "*-aiplatform.googleapis.com" covers regional endpoints such as
+// "us-central1-aiplatform.googleapis.com".
+var VertexAIHosts = []string{
+	"oauth2.googleapis.com",
+	"aiplatform.googleapis.com",
+	"*-aiplatform.googleapis.com",
+}
+
+// HostEnvVars reads Google-related env vars from the host and returns the
+// workspace env vars that should be injected into the container.
+//
+// Mappings:
+//   - CLOUD_ML_REGION      → CLOUD_ML_REGION, VERTEX_LOCATION
+//   - ANTHROPIC_VERTEX_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) → both vars
+func HostEnvVars() map[string]string {
+	vars := make(map[string]string)
+
+	if region := os.Getenv("CLOUD_ML_REGION"); region != "" {
+		vars["CLOUD_ML_REGION"] = region
+		vars["VERTEX_LOCATION"] = region
+	}
+
+	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
+	if projectID == "" {
+		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+	}
+	if projectID != "" {
+		vars["ANTHROPIC_VERTEX_PROJECT_ID"] = projectID
+		vars["GOOGLE_CLOUD_PROJECT"] = projectID
+	}
+
+	return vars
+}

--- a/pkg/googleauth/googleauth_test.go
+++ b/pkg/googleauth/googleauth_test.go
@@ -1,0 +1,197 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package googleauth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+func TestFindGcloudMount(t *testing.T) {
+	t.Parallel()
+
+	homeDir := "/home/testuser"
+
+	tests := []struct {
+		name            string
+		mounts          []workspace.Mount
+		wantNil         bool
+		wantADCFilePath string
+		wantMountHost   string
+	}{
+		{
+			name:    "no mounts",
+			mounts:  nil,
+			wantNil: true,
+		},
+		{
+			name: "unrelated mount",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/projects", Target: "$HOME/projects"},
+			},
+			wantNil: true,
+		},
+		{
+			name: "gcloud directory mount via $HOME",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud", Target: "$HOME/.config/gcloud"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud",
+		},
+		{
+			name: "gcloud directory mount via absolute host path",
+			mounts: []workspace.Mount{
+				{Host: "/home/testuser/.config/gcloud", Target: "$HOME/.config/gcloud"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join("/home/testuser/.config/gcloud", "application_default_credentials.json"),
+			wantMountHost:   "/home/testuser/.config/gcloud",
+		},
+		{
+			name: "gcloud ADC file mount via $HOME",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud/application_default_credentials.json", Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud/application_default_credentials.json",
+		},
+		{
+			name: "gcloud ADC file mount via absolute target",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud/application_default_credentials.json", Target: "/home/agent/.config/gcloud/application_default_credentials.json"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud/application_default_credentials.json",
+		},
+		{
+			name: "gcloud directory mount via absolute target",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud", Target: "/home/agent/.config/gcloud"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud",
+		},
+		{
+			name: "first matching mount wins",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/other", Target: "$HOME/other"},
+				{Host: "$HOME/.config/gcloud", Target: "$HOME/.config/gcloud"},
+				{Host: "$HOME/.config/gcloud/application_default_credentials.json", Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FindGcloudMount(tt.mounts, homeDir)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("FindGcloudMount() = %+v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("FindGcloudMount() = nil, want non-nil")
+			}
+			if got.ADCFilePath != tt.wantADCFilePath {
+				t.Errorf("ADCFilePath = %q, want %q", got.ADCFilePath, tt.wantADCFilePath)
+			}
+			if got.Mount.Host != tt.wantMountHost {
+				t.Errorf("Mount.Host = %q, want %q", got.Mount.Host, tt.wantMountHost)
+			}
+		})
+	}
+}
+
+func TestLoadFrom(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for missing file", func(t *testing.T) {
+		t.Parallel()
+
+		creds, err := LoadFrom("/nonexistent/path/adc.json")
+		if err != nil {
+			t.Fatalf("LoadFrom() error = %v, want nil", err)
+		}
+		if creds != nil {
+			t.Errorf("LoadFrom() = %+v, want nil", creds)
+		}
+	})
+
+	t.Run("parses valid ADC file", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := filepath.Join(t.TempDir(), "adc.json")
+		content := []byte(`{
+			"refresh_token": "test-token",
+			"client_id": "test-client-id",
+			"client_secret": "test-secret",
+			"quota_project_id": "test-project"
+		}`)
+		if err := os.WriteFile(adcPath, content, 0644); err != nil {
+			t.Fatalf("failed to write test ADC file: %v", err)
+		}
+
+		creds, err := LoadFrom(adcPath)
+		if err != nil {
+			t.Fatalf("LoadFrom() error = %v", err)
+		}
+		if creds == nil {
+			t.Fatal("LoadFrom() = nil, want non-nil")
+		}
+		if creds.RefreshToken != "test-token" {
+			t.Errorf("RefreshToken = %q, want %q", creds.RefreshToken, "test-token")
+		}
+		if creds.ClientID != "test-client-id" {
+			t.Errorf("ClientID = %q, want %q", creds.ClientID, "test-client-id")
+		}
+		if creds.QuotaProjectID != "test-project" {
+			t.Errorf("QuotaProjectID = %q, want %q", creds.QuotaProjectID, "test-project")
+		}
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(adcPath, []byte("not json"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		_, err := LoadFrom(adcPath)
+		if err == nil {
+			t.Fatal("LoadFrom() error = nil, want error for invalid JSON")
+		}
+	})
+}

--- a/pkg/onecli/client.go
+++ b/pkg/onecli/client.go
@@ -40,6 +40,8 @@ type Client interface {
 	CreateRule(ctx context.Context, input CreateRuleInput) (*Rule, error)
 	ListRules(ctx context.Context) ([]Rule, error)
 	DeleteRule(ctx context.Context, id string) error
+	// ConnectApp connects an app provider using the given credential fields.
+	ConnectApp(ctx context.Context, provider string, fields map[string]string) error
 }
 
 // UpdateSecretInput is the request body for updating a secret.
@@ -201,6 +203,17 @@ func (c *client) ListRules(ctx context.Context) ([]Rule, error) {
 func (c *client) DeleteRule(ctx context.Context, id string) error {
 	if err := c.do(ctx, http.MethodDelete, "/api/rules/"+id, nil, nil); err != nil {
 		return fmt.Errorf("deleting rule: %w", err)
+	}
+	return nil
+}
+
+// ConnectApp connects an app provider using the given credential fields.
+func (c *client) ConnectApp(ctx context.Context, provider string, fields map[string]string) error {
+	body := struct {
+		Fields map[string]string `json:"fields"`
+	}{Fields: fields}
+	if err := c.do(ctx, http.MethodPost, "/api/apps/"+provider+"/connect", body, nil); err != nil {
+		return fmt.Errorf("connecting %s: %w", provider, err)
 	}
 	return nil
 }

--- a/pkg/onecli/provisioner_test.go
+++ b/pkg/onecli/provisioner_test.go
@@ -74,6 +74,10 @@ func (f *fakeClient) DeleteRule(_ context.Context, _ string) error {
 	return nil
 }
 
+func (f *fakeClient) ConnectApp(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+
 func TestProvisioner_AllSecretsCreated(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -27,6 +27,7 @@ import (
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/devcontainers/features"
+	"github.com/openkaiden/kdn/pkg/googleauth"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
@@ -37,7 +38,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-const defaultOnecliVersion = "1.17"
+const defaultOnecliVersion = "1.20.0"
 
 // podTemplateData holds the values used to render the pod YAML template
 // and is also persisted as per-pod metadata (pod-template-data.json) so
@@ -216,13 +217,20 @@ func (p *podmanRuntime) buildImage(ctx context.Context, imageName, instanceDir s
 
 // containerConfigArgs holds optional OneCLI container configuration to inject into the workspace.
 type containerConfigArgs struct {
-	envVars         map[string]string
-	caFilePath      string
-	caContainerPath string
+	envVars             map[string]string
+	caFilePath          string
+	caContainerPath     string
+	googleCredsHostPath string            // host path to fake ADC JSON file
+	googleEnvVars       map[string]string // Google-auth env vars derived from host
 }
 
+// gcloudContainerADCPath is the standard path for application default credentials inside the container.
+const gcloudContainerADCPath = "/home/agent/.config/gcloud/application_default_credentials.json"
+
 // buildContainerArgs builds the arguments for creating the workspace container inside the pod.
-func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string, ccArgs *containerConfigArgs) ([]string, error) {
+// gm, if non-nil, identifies a gcloud config mount that has been intercepted and should be
+// skipped — the fake ADC file is mounted instead via ccArgs.googleCredsHostPath.
+func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string, ccArgs *containerConfigArgs, gm *googleauth.GcloudMount) ([]string, error) {
 	args := []string{"create", "--pod", params.Name, "--name", params.Name, "--device", "/dev/fuse"}
 
 	// Collect workspace env var names for collision detection
@@ -262,6 +270,12 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 		if ccArgs.caFilePath != "" && ccArgs.caContainerPath != "" {
 			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", ccArgs.caFilePath, ccArgs.caContainerPath))
 		}
+		if ccArgs.googleCredsHostPath != "" {
+			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", ccArgs.googleCredsHostPath, gcloudContainerADCPath))
+		}
+		for k, v := range ccArgs.googleEnvVars {
+			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+		}
 	}
 
 	// Add secret service env vars with placeholder values so CLI tools detect a configured credential.
@@ -281,6 +295,9 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 			return nil, fmt.Errorf("failed to get home directory: %w", err)
 		}
 		for _, m := range *params.WorkspaceConfig.Mounts {
+			if gm != nil && m.Host == gm.Mount.Host && m.Target == gm.Mount.Target {
+				continue // intercepted — fake ADC mounted via ccArgs.googleCredsHostPath
+			}
 			args = append(args, "-v", mountVolumeArg(m, params.SourcePath, homeDir))
 		}
 	}
@@ -457,11 +474,36 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		}
 	}()
 
+	// Detect a gcloud config mount declared in the workspace config. When present,
+	// kdn intercepts the mount (substituting a fake ADC file) and configures
+	// OneCLI Vertex AI using the real credentials from the host ADC file.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	var gm *googleauth.GcloudMount
+	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Mounts != nil {
+		gm = googleauth.FindGcloudMount(*params.WorkspaceConfig.Mounts, homeDir)
+	}
+
+	var adc *googleauth.ADCCredentials
+	if gm != nil {
+		var adcErr error
+		adc, adcErr = googleauth.LoadFrom(gm.ADCFilePath)
+		if adcErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to load ADC from %s: %v\n", gm.ADCFilePath, adcErr)
+		}
+		if adc == nil {
+			fmt.Fprintf(os.Stderr, "warning: gcloud mount declared but %s not found; skipping Vertex AI setup\n", gm.ADCFilePath)
+			gm = nil // don't intercept the mount if we can't read credentials
+		}
+	}
+
 	// Always start OneCLI to inject proxy env vars and the CA cert into the workspace container.
 	// Without HTTP_PROXY/HTTPS_PROXY pointing at the OneCLI gateway, deny-mode networking rules
 	// have no effect because workspace traffic bypasses the proxy entirely.
-	// Secrets are provisioned if any were provided.
-	containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets)
+	// Secrets are provisioned if any were provided; ADC credentials configure Vertex AI if present.
+	containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets, adc)
 	if setupErr != nil {
 		return runtime.RuntimeInfo{}, setupErr
 	}
@@ -485,10 +527,26 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 			ccArgs.caContainerPath = containerConfig.CACertificateContainerPath
 		}
 	}
+	// Write fake ADC file and inject Google env vars when host credentials exist
+	if adc != nil {
+		if ccArgs == nil {
+			ccArgs = &containerConfigArgs{}
+		}
+		certsDir := filepath.Join(p.storageDir, "certs", params.Name)
+		if mkErr := os.MkdirAll(certsDir, 0755); mkErr != nil {
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to create certs directory: %w", mkErr)
+		}
+		fakecredsPath := filepath.Join(certsDir, "gcloud-adc.json")
+		if writeErr := os.WriteFile(fakecredsPath, googleauth.FakeADCJSON(), 0644); writeErr != nil {
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to write fake ADC credentials: %w", writeErr)
+		}
+		ccArgs.googleCredsHostPath = fakecredsPath
+		ccArgs.googleEnvVars = googleauth.HostEnvVars()
+	}
 
 	// Build workspace container args with proxy env vars and CA cert mount from OneCLI
 	stepLogger.Start(fmt.Sprintf("Creating workspace container: %s", params.Name), "Workspace container created")
-	createArgs, err := p.buildContainerArgs(params, imageName, ccArgs)
+	createArgs, err := p.buildContainerArgs(params, imageName, ccArgs, gm)
 	if err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, err
@@ -561,7 +619,7 @@ func (p *podmanRuntime) buildForwards(params runtime.CreateParams) ([]api.Worksp
 
 // setupOnecli starts postgres, waits for it, then starts onecli to avoid migration race conditions.
 // After provisioning secrets and retrieving container config, it stops the pod.
-func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.StepLogger, l logger.Logger, podName string, tmplData podTemplateData, secrets []onecli.CreateSecretInput) (*onecli.ContainerConfig, error) {
+func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.StepLogger, l logger.Logger, podName string, tmplData podTemplateData, secrets []onecli.CreateSecretInput, adc *googleauth.ADCCredentials) (*onecli.ContainerConfig, error) {
 	postgresContainer := podName + "-postgres"
 	onecliContainer := podName + "-onecli"
 
@@ -610,6 +668,15 @@ func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.S
 		if err := provisioner.ProvisionSecrets(ctx, secrets); err != nil {
 			stepLogger.Fail(err)
 			return nil, fmt.Errorf("failed to provision OneCLI secrets: %w", err)
+		}
+	}
+
+	// Configure Vertex AI if application default credentials are available on the host
+	if adc != nil {
+		stepLogger.Start("Configuring OneCLI Vertex AI app", "Vertex AI configured")
+		if err := client.ConnectApp(ctx, "vertex-ai", adc.VertexAIFields()); err != nil {
+			stepLogger.Fail(err)
+			return nil, fmt.Errorf("failed to configure Vertex AI: %w", err)
 		}
 	}
 

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -414,7 +414,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -469,7 +469,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -518,7 +518,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -555,7 +555,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -606,7 +606,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			caContainerPath: "/etc/ssl/certs/onecli-ca.pem",
 		}
 
-		args, err := p.buildContainerArgs(params, imageName, ccArgs)
+		args, err := p.buildContainerArgs(params, imageName, ccArgs, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -656,7 +656,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			},
 		}
 
-		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs)
+		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -693,7 +693,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			envVars: map[string]string{"HTTP_PROXY": "http://proxy:8080"},
 		}
 
-		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs)
+		args, err := p.buildContainerArgs(params, "kdn-test", ccArgs, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -719,7 +719,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			Agent:      "test_agent",
 		}
 
-		args, err := p.buildContainerArgs(params, "kdn-test", nil)
+		args, err := p.buildContainerArgs(params, "kdn-test", nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -755,7 +755,7 @@ func TestBuildContainerArgs(t *testing.T) {
 			},
 		}
 
-		args, err := p.buildContainerArgs(params, imageName, ccArgs)
+		args, err := p.buildContainerArgs(params, imageName, ccArgs, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -818,7 +818,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -877,7 +877,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}
@@ -914,7 +914,7 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 		imageName := "kdn-test-workspace"
 
-		args, err := p.buildContainerArgs(params, imageName, nil)
+		args, err := p.buildContainerArgs(params, imageName, nil, nil)
 		if err != nil {
 			t.Fatalf("buildContainerArgs() failed: %v", err)
 		}

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -19,9 +19,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/googleauth"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/steplogger"
@@ -147,6 +150,14 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	}
 
 	if shouldConfigureNetworking {
+		// When Vertex AI was configured at Create time (indicated by the fake ADC
+		// file), allow the Google auth and Vertex AI endpoints through the proxy
+		// without manual approval so the workspace can reach them transparently.
+		fakeADCPath := filepath.Join(p.storageDir, "certs", tmplData.Name, "gcloud-adc.json")
+		if _, err := os.Stat(fakeADCPath); err == nil {
+			allHosts = append(allHosts, googleauth.VertexAIHosts...)
+		}
+
 		stepLogger.Start("Configuring network rules", "Network rules configured")
 		if err := p.configureNetworking(ctx, onecliBaseURL, allHosts, tmplData.ApprovalHandlerDir); err != nil {
 			stepLogger.Fail(err)


### PR DESCRIPTION
When the workspace config declares a mount targeting
\$HOME/.config/gcloud (directory) or
\$HOME/.config/gcloud/application_default_credentials.json (file),
kdn now:
- intercepts the mount and substitutes a fake ADC file so
  gcloud-aware tools see a credentials file without exposing real
  secrets (real auth goes through the OneCLI proxy)
- reads the real ADC from the resolved host path and calls
  OneCLI /api/apps/vertex-ai/connect with the credentials
- injects CLOUD_ML_REGION/VERTEX_LOCATION and
  ANTHROPIC_VERTEX_PROJECT_ID/GOOGLE_CLOUD_PROJECT from host env
- auto-allows Google auth and Vertex AI endpoints in deny-mode
  network filtering

Activation is explicit (mount declaration) rather than implicit
host file detection. If the ADC file is missing the mount passes
through unchanged and Vertex AI setup is skipped with a warning.


To test this, in your workspace `.kaiden/workspace.json`, add the following :
```json
{
 ...
"environment": [
    { "name": "CLAUDE_CODE_USE_VERTEX", "value": "1" },
    { "name": "ANTHROPIC_VERTEX_PROJECT_ID", "value": "your real ANTHROPIC_VERTEX_PROJECT_ID" },
    { "name": "CLOUD_ML_REGION", "value": "global" }
  ],
  "network": {
    "mode": "allow" // For convenience
  },
  "mounts": [
    {
      "host": "$HOME/.config/gcloud",
      "target": "$HOME/.config/gcloud"
    }
  ]
}
```

Alternatively, you should be able to target a non default auth file like :
```
  "mounts": [
    {
      "host": "/path/to/auth.json",
      "target": "$HOME/.config/gcloud/application_default_credentials"
    }
  ]
```

see https://github.com/openkaiden/kdn/issues/411
