### PR TITLE
fix(podman): use native-host.internal for host-native services

### DIFF
--- a/pkg/containerurl/containerurl.go
+++ b/pkg/containerurl/containerurl.go
@@ -23,8 +23,13 @@ import (
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
-// ContainerHost is the hostname used to reach the host machine from inside a container.
+// ContainerHost is the hostname used to reach the podman VM from inside a container.
 const ContainerHost = "host.containers.internal"
+
+// NativeHost is the hostname injected into /etc/hosts to reach the native
+// host machine (e.g. the Windows host on WSL2). On non-WSL2 platforms this
+// is not injected — URLs fall back to ContainerHost.
+const NativeHost = "native-host.internal"
 
 // localhostAliases lists hostnames and IPs that refer to the local machine.
 var localhostAliases = []string{"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"}

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -287,7 +287,9 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 		// Only inject if neither the workspace config nor OneCLI already set NO_PROXY.
 		if !workspaceEnvNames["NO_PROXY"] && !workspaceEnvNames["no_proxy"] &&
 			!onecliEnvNames["NO_PROXY"] && !onecliEnvNames["no_proxy"] {
-			const noProxy = "localhost,127.0.0.1,host.containers.internal"
+			// native-host.internal is a no-op on linux/mac since the hostname
+			// is never injected into /etc/hosts on those platforms.
+			const noProxy = "localhost,127.0.0.1,host.containers.internal,native-host.internal"
 			args = append(args, "-e", "NO_PROXY="+noProxy, "-e", "no_proxy="+noProxy)
 		}
 		if ccArgs.caFilePath != "" && ccArgs.caContainerPath != "" {

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -625,10 +625,10 @@ func TestBuildContainerArgs(t *testing.T) {
 		}
 
 		// Verify NO_PROXY is injected so local addresses bypass the proxy
-		if !strings.Contains(argsStr, "-e NO_PROXY=localhost,127.0.0.1,host.containers.internal") {
+		if !strings.Contains(argsStr, "-e NO_PROXY=localhost,127.0.0.1,host.containers.internal,native-host.internal") {
 			t.Errorf("Expected NO_PROXY env var in args: %s", argsStr)
 		}
-		if !strings.Contains(argsStr, "-e no_proxy=localhost,127.0.0.1,host.containers.internal") {
+		if !strings.Contains(argsStr, "-e no_proxy=localhost,127.0.0.1,host.containers.internal,native-host.internal") {
 			t.Errorf("Expected no_proxy env var in args: %s", argsStr)
 		}
 

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -368,29 +368,32 @@ func (p *podmanRuntime) resolveWSLHostIP(ctx context.Context) string {
 	return ""
 }
 
-// injectWSLHostEntry adds or updates a host.containers.internal entry in
-// /etc/hosts inside the workspace container, mapping it to the Windows
-// host IP read from the podman machine's /etc/resolv.conf via SSH.
-// Filters out any existing entry before appending so repeated Start()
-// calls don't accumulate stale lines.
+// injectHostEntry adds or replaces an /etc/hosts entry inside the given
+// container, mapping hostname to ip. Existing lines for the hostname are
+// removed first so repeated Start() calls don't accumulate stale entries.
+func (p *podmanRuntime) injectHostEntry(ctx context.Context, containerID, hostname, ip string) error {
+	escaped := strings.ReplaceAll(hostname, ".", "\\.")
+	cmd := fmt.Sprintf(
+		"grep -v '%s' /etc/hosts > /tmp/hosts.tmp && cp /tmp/hosts.tmp /etc/hosts && rm /tmp/hosts.tmp && echo '%s %s' >> /etc/hosts",
+		escaped, ip, hostname,
+	)
+	if err := p.executor.Run(ctx, io.Discard, io.Discard,
+		"exec", "--user", "root", containerID, "sh", "-c", cmd,
+	); err != nil {
+		return fmt.Errorf("failed to inject %s entry: %w", hostname, err)
+	}
+	return nil
+}
+
+// injectWSLHostEntry adds a native-host.internal entry to /etc/hosts inside
+// the given container, mapping it to the Windows gateway IP so that host-native
+// services (e.g. Ollama) are reachable.
 func (p *podmanRuntime) injectWSLHostEntry(ctx context.Context, containerID string) error {
 	hostIP := p.resolveWSLHostIP(ctx)
 	if hostIP == "" {
 		return fmt.Errorf("failed to resolve Windows host IP from podman machine")
 	}
-
-	// /etc/hosts is a mount in containers — sed -i fails because it tries to
-	// rename a temp file over the mount. Use grep + tee to modify in-place.
-	cmd := fmt.Sprintf(
-		"grep -v 'host\\.containers\\.internal' /etc/hosts > /tmp/hosts.tmp && cp /tmp/hosts.tmp /etc/hosts && rm /tmp/hosts.tmp && echo '%s host.containers.internal' >> /etc/hosts",
-		hostIP,
-	)
-	if err := p.executor.Run(ctx, io.Discard, io.Discard,
-		"exec", "--user", "root", containerID, "sh", "-c", cmd,
-	); err != nil {
-		return fmt.Errorf("failed to update /etc/hosts entry: %w", err)
-	}
-	return nil
+	return p.injectHostEntry(ctx, containerID, "native-host.internal", hostIP)
 }
 
 // buildNftScript generates the shell script that sets up nftables OUTPUT rules.

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -885,14 +885,14 @@ func TestInjectWSLHostEntry(t *testing.T) {
 		for _, call := range fakeExec.RunCalls {
 			if len(call) >= 7 && call[0] == "exec" && call[1] == "--user" && call[2] == "root" && call[3] == "test-container" && call[4] == "sh" && call[5] == "-c" {
 				script := call[6]
-				if strings.Contains(script, "grep -v") && strings.Contains(script, "10.255.0.1 host.containers.internal") {
+				if strings.Contains(script, "grep -v") && strings.Contains(script, "10.255.0.1 native-host.internal") {
 					found = true
 					break
 				}
 			}
 		}
 		if !found {
-			t.Error("expected exec call with sed + echo writing host.containers.internal to /etc/hosts")
+			t.Error("expected exec call writing native-host.internal to /etc/hosts")
 		}
 	})
 

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -137,9 +137,8 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start network-guard container: %w", err)
 	}
 
-	// On WSL2, host.containers.internal does not resolve because the WSL2
-	// provider does not update /etc/hosts like macOS/Hyper-V VMs do. Patch
-	// the network-guard container so resolveHostGateway's getent succeeds.
+	// On WSL2, inject native-host.internal so host-native services
+	// (e.g. Ollama on Windows) are reachable.
 	isWSL := p.isPodmanWSL(ctx)
 	if isWSL {
 		if err := p.injectWSLHostEntry(ctx, networkGuardContainer); err != nil {


### PR DESCRIPTION
## Summary
- Rename `windows.host.containers` to `native-host.internal` as a platform-agnostic hostname for reaching the native host machine (e.g. Windows host on WSL2) from inside containers
- Remove the port-11434 Ollama hardcode from `RewriteURL` — Kaiden controls intent by choosing the hostname (`localhost` vs `native-host.internal`), not kdn by sniffing ports
- Extract `injectHostEntry` as a reusable helper for `/etc/hosts` injection

## Test plan
- [x] `go test ./pkg/containerurl/...` passes
- [x] `go test ./pkg/runtime/podman/...` passes (pre-existing pod YAML test failures unrelated)
- [ ] Manual test on WSL2: verify `native-host.internal` resolves to Windows host IP inside container
- [ ] Manual test on Mac/Linux: verify `host.containers.internal` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)