### PR TITLE
feat(credential): add pluggable credential interception system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,43 @@ The secret service system provides a pluggable architecture for managing secret 
 
 **For detailed guidance on the full secrets abstraction (Store, registry, adding new types), use:** `/working-with-secrets`
 
+### Credential System
+
+The credential system provides a pluggable architecture for intercepting sensitive credential files that users mount into workspace containers. When a declared mount targets a known credential file (e.g., `$HOME/.config/gcloud/application_default_credentials.json`), kdn replaces the real file with a placeholder and configures OneCLI to inject the real credential at request time.
+
+**Key Components:**
+- **`Credential` interface** (`pkg/credential/credential.go`): Contract all credentials must implement:
+  - `Name() string` — unique identifier
+  - `ContainerFilePath() string` — absolute path inside the container where the credential file lives
+  - `Detect(mounts []workspace.Mount, homeDir string) (hostFilePath string, intercepted *workspace.Mount)` — returns the real host path and the mount to intercept, or `("", nil)` if not applicable
+  - `FakeFile(hostFilePath string) ([]byte, error)` — returns placeholder file content (no real credentials)
+  - `Configure(ctx, client onecli.Client, hostFilePath string) error` — reads the real file and registers the credential with OneCLI
+  - `HostPatterns(hostFilePath string) []string` — hostnames OneCLI must be allowed to reach for this credential
+  - `EnvVars(hostFilePath string) map[string]string` — extra environment variables to inject into the container
+- **Registry** (`pkg/credential/registry.go`): Thread-safe ordered list; `NewRegistry() Registry`; `Register()` rejects nil, empty name, and duplicates
+- **Centralized Registration** (`pkg/credentialsetup/register.go`): `RegisterAll(registrar)` registers all built-in credentials (currently `gcloud`)
+- **`CredentialRegistryAware`** optional runtime interface (`pkg/runtime/runtime.go`): Runtimes that implement `SetCredentialRegistry(credential.Registry)` receive the registry automatically when `manager.RegisterRuntime()` is called
+
+**Podman runtime integration:**
+- `detectCredentials()` in `create.go` iterates the registry at `Create` time, writes fake files to `<storageDir>/credentials/<workspaceName>/<credName>/credential` (mode `0600`), and returns `[]activeCredential`
+- Fake credential mounts are added to the container; intercepted original mounts are suppressed via an `interceptedMounts map[mountKey]bool`
+- `setupOnecli` calls `cred.Configure()` for each active credential to register it with OneCLI
+- `collectCredentialHosts()` in `start.go` merges credential host patterns into the network allow-list
+- Credential directories are cleaned up on workspace removal via the `"credentials"` entry in `workspaceTempDirs` (`pkg/runtime/podman/remove.go`)
+
+**Per-workspace credential directory layout:**
+
+```text
+<storageDir>/
+  credentials/
+    <workspaceName>/
+      <credName>/
+        credential    ← fake placeholder file (mode 0600)
+```
+
+**Implementations:**
+- `pkg/credential/gcloud/` — Google Cloud ADC (`application_default_credentials.json`); configures OneCLI Vertex AI via `ConnectApp`
+
 ### Dev Container Features
 
 The `pkg/devcontainers/features` package models, downloads, and orders Dev Container Features (OCI registry artifacts or local file trees) prior to container image generation.

--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ To reuse your host Claude Code settings (preferences, custom instructions, etc.)
 **Notes:**
 
 - Run `gcloud auth application-default login` on your host machine before starting the workspace to ensure valid credentials are available
-- The `$HOME/.config/gcloud` mount is read-only to prevent the workspace from modifying your host credentials
+- kdn automatically intercepts the gcloud mount: a placeholder credential file is written into the container and OneCLI injects the real Application Default Credentials transparently at request time — the actual credential file never touches the container filesystem
 - No `ANTHROPIC_API_KEY` is needed when using Vertex AI — credentials are provided via the mounted gcloud configuration
+- When `network.mode` is `"deny"`, the Google OAuth and Vertex AI endpoints (`oauth2.googleapis.com`, `aiplatform.googleapis.com`) are automatically added to the allow-list — no explicit `hosts` entry is needed
 - To pin a specific Claude model, use `--model` flag during `init` (e.g., `--model claude-sonnet-4-20250514`), which takes precedence over any model in default settings, or add an `ANTHROPIC_MODEL` environment variable (e.g., `"claude-opus-4-5"`)
 
 ### Starting Claude with Default Settings
@@ -301,7 +302,7 @@ Create or edit `~/.kdn/config/agents.json`:
 }
 ```
 
-The `~/.config/gcloud` directory contains your Application Default Credentials and active account configuration. It is mounted read-only so that credentials are available inside the workspace while the host configuration remains unmodified.
+The `~/.config/gcloud` directory contains your Application Default Credentials and active account configuration. kdn automatically intercepts this mount: a placeholder credential file is written into the container and OneCLI injects the real Application Default Credentials transparently at request time — the actual credential file never touches the container filesystem.
 
 Then register and start the workspace:
 
@@ -1925,7 +1926,10 @@ Control network access for the workspace. By default, network access is denied (
   - Each entry must be a non-empty string
   - Omitting `hosts` (or leaving it empty) is valid: the workspace is fully isolated, with no outbound access permitted unless secrets contribute hosts
 
-**Automatic secret host injection:** When `mode` is `"deny"` and secrets are configured, kdn automatically adds the hosts associated with those secrets to the allowed list. You do not need to list them explicitly under `hosts`. For example, a `github` secret automatically allows `api.github.com` without any `hosts` entry.
+**Automatic host injection:** When `mode` is `"deny"`, kdn automatically adds the required hosts to the allowed list from two sources — no explicit `hosts` entry is needed for either:
+
+- **Secrets:** The hosts associated with each configured secret are added automatically. For example, a `github` secret automatically allows `api.github.com`.
+- **Credentials:** The hosts required by each intercepted credential mount are added automatically. For example, mounting `$HOME/.config/gcloud` automatically allows `oauth2.googleapis.com` and `aiplatform.googleapis.com`.
 
 **Validation Rules:**
 - If `mode` is set, it must be either `"allow"` or `"deny"`

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -28,6 +28,7 @@ import (
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/agentsetup"
 	"github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/credentialsetup"
 	"github.com/openkaiden/kdn/pkg/envvars"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/logger"
@@ -106,6 +107,11 @@ func (i *initCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Register all available secret services
 	if err := secretservicesetup.RegisterAll(manager); err != nil {
 		return outputErrorIfJSON(cmd, i.output, fmt.Errorf("failed to register secret services: %w", err))
+	}
+
+	// Register all available credentials
+	if err := credentialsetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, i.output, fmt.Errorf("failed to register credentials: %w", err))
 	}
 
 	i.manager = manager

--- a/pkg/credential/credential.go
+++ b/pkg/credential/credential.go
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package credential provides a pluggable abstraction for file-based credentials
+// that kdn intercepts when declared as workspace mounts. A placeholder file is
+// substituted so the real secret never lands inside the container; actual auth
+// flows through the OneCLI proxy.
+package credential
+
+import (
+	"context"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/onecli"
+)
+
+// Credential describes how a particular file-based credential is intercepted
+// when declared as a workspace mount.
+type Credential interface {
+	// Name returns the unique identifier for this credential type (e.g. "gcloud", "openshift").
+	Name() string
+
+	// ContainerFilePath returns the absolute path inside the container at which
+	// the placeholder file must be mounted.
+	ContainerFilePath() string
+
+	// Detect scans workspace mounts and returns the resolved host-side path to
+	// the real credential file and the mount entry to intercept.
+	// Returns ("", nil) when this credential is not declared or not applicable.
+	Detect(mounts []workspace.Mount, homeDir string) (hostFilePath string, intercepted *workspace.Mount)
+
+	// FakeFile returns the bytes to write as the placeholder credential file
+	// that will be mounted into the container instead of the real one.
+	// hostFilePath is the path to the real credential on the host.
+	FakeFile(hostFilePath string) ([]byte, error)
+
+	// Configure performs any OneCLI setup needed when this credential is active
+	// (e.g. calling ConnectApp or creating secrets with the real credential).
+	// hostFilePath is the path to the real credential on the host.
+	Configure(ctx context.Context, client onecli.Client, hostFilePath string) error
+
+	// HostPatterns returns host globs to add to the allow list in deny-mode
+	// networking when this credential is active. hostFilePath lets dynamic
+	// implementations extract the server URL from the real credential file.
+	HostPatterns(hostFilePath string) []string
+
+	// EnvVars returns environment variables to inject into the workspace container.
+	// hostFilePath is the path to the real credential on the host.
+	EnvVars(hostFilePath string) map[string]string
+}
+
+// Registry manages Credential implementations.
+type Registry interface {
+	// Register adds a credential implementation to the registry.
+	// Returns an error if a credential with the same name is already registered.
+	Register(c Credential) error
+
+	// List returns all registered credentials.
+	List() []Credential
+}

--- a/pkg/credential/gcloud/gcloud.go
+++ b/pkg/credential/gcloud/gcloud.go
@@ -1,0 +1,227 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package gcloud implements the credential.Credential interface for Google Cloud
+// Application Default Credentials (ADC). When a workspace mount targets the
+// gcloud config directory or the ADC file directly, this credential intercepts
+// the mount and substitutes a placeholder file. Real authentication is forwarded
+// through the OneCLI proxy via the Vertex AI app connection.
+package gcloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/credential"
+	"github.com/openkaiden/kdn/pkg/onecli"
+)
+
+const (
+	containerHomeDir   = "/home/agent"
+	containerGcloudDir = containerHomeDir + "/.config/gcloud"
+	containerADCPath   = containerGcloudDir + "/application_default_credentials.json"
+)
+
+// adcCredentials holds the fields from application_default_credentials.json
+// needed to configure the Vertex AI app in OneCLI.
+type adcCredentials struct {
+	RefreshToken   string `json:"refresh_token"`
+	ClientID       string `json:"client_id"`
+	ClientSecret   string `json:"client_secret"`
+	QuotaProjectID string `json:"quota_project_id"`
+}
+
+// vertexAIFields returns the credential fields for the OneCLI vertex-ai connect API.
+// When QuotaProjectID is empty in the ADC file, falls back to host env vars.
+func (c *adcCredentials) vertexAIFields() map[string]string {
+	quotaProject := c.QuotaProjectID
+	if quotaProject == "" {
+		if p := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"); p != "" {
+			quotaProject = p
+		} else {
+			quotaProject = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		}
+	}
+	return map[string]string{
+		"refreshToken":   c.RefreshToken,
+		"clientId":       c.ClientID,
+		"clientSecret":   c.ClientSecret,
+		"quotaProjectId": quotaProject,
+	}
+}
+
+// vertexAIHosts lists the host patterns that must be allowed in deny-mode
+// networking when Vertex AI is configured.
+var vertexAIHosts = []string{
+	"oauth2.googleapis.com",
+	"aiplatform.googleapis.com",
+	"*-aiplatform.googleapis.com",
+}
+
+// fakeADCJSON is written into the workspace container at the standard gcloud
+// credentials path. It has synthetic values so that gcloud-aware tools see a
+// credentials file without exposing real secrets; actual auth goes through the
+// OneCLI proxy which holds the real refresh token.
+var fakeADCJSON = []byte(`{
+  "account": "",
+  "client_id": "FAKE_CLIENT_ID",
+  "client_secret": "FAKE_CLIENT_SECRET",
+  "quota_project_id": "FAKE_QUOTA_PROJECT_ID",
+  "refresh_token": "FAKE_REFRESH_TOKEN",
+  "type": "authorized_user",
+  "universe_domain": "googleapis.com"
+}
+`)
+
+// gcloudCredential implements credential.Credential for Google Cloud ADC.
+type gcloudCredential struct{}
+
+// Compile-time check that gcloudCredential implements the Credential interface.
+var _ credential.Credential = (*gcloudCredential)(nil)
+
+// New returns a new gcloud Credential implementation.
+func New() credential.Credential {
+	return &gcloudCredential{}
+}
+
+// Name returns the credential identifier.
+func (g *gcloudCredential) Name() string {
+	return "gcloud"
+}
+
+// ContainerFilePath returns the ADC file path inside the container.
+func (g *gcloudCredential) ContainerFilePath() string {
+	return containerADCPath
+}
+
+// Detect scans workspace mounts for one targeting the gcloud config directory
+// or the ADC file directly. The target path is checked after resolving $HOME.
+// Returns the host path to the real ADC file and the intercepted mount, or
+// ("", nil) when no matching mount is found.
+func (g *gcloudCredential) Detect(mounts []workspace.Mount, homeDir string) (string, *workspace.Mount) {
+	for i := range mounts {
+		m := mounts[i]
+		target := resolveTarget(m.Target)
+		switch target {
+		case containerGcloudDir:
+			hostDir := resolveHost(m.Host, homeDir)
+			return filepath.Join(hostDir, "application_default_credentials.json"), &mounts[i]
+		case containerADCPath:
+			return resolveHost(m.Host, homeDir), &mounts[i]
+		}
+	}
+	return "", nil
+}
+
+// FakeFile returns the static placeholder ADC JSON. The real hostFilePath is
+// not needed because the fake file is always the same regardless of credentials.
+func (g *gcloudCredential) FakeFile(_ string) ([]byte, error) {
+	return fakeADCJSON, nil
+}
+
+// Configure reads the real ADC file from hostFilePath and calls the OneCLI
+// vertex-ai connect API with the parsed credentials.
+func (g *gcloudCredential) Configure(ctx context.Context, client onecli.Client, hostFilePath string) error {
+	adc, err := loadADC(hostFilePath)
+	if err != nil {
+		return fmt.Errorf("reading ADC from %s: %w", hostFilePath, err)
+	}
+	if adc == nil {
+		return fmt.Errorf("ADC file not found at %s", hostFilePath)
+	}
+	if err := client.ConnectApp(ctx, "vertex-ai", adc.vertexAIFields()); err != nil {
+		return fmt.Errorf("configuring Vertex AI: %w", err)
+	}
+	return nil
+}
+
+// HostPatterns returns the static list of Google auth and Vertex AI endpoints
+// that must be allowed in deny-mode networking when this credential is active.
+func (g *gcloudCredential) HostPatterns(_ string) []string {
+	result := make([]string, len(vertexAIHosts))
+	copy(result, vertexAIHosts)
+	return result
+}
+
+// EnvVars reads Google-related env vars from the host and returns the workspace
+// env vars to inject into the container.
+//
+// Mappings:
+//   - CLOUD_ML_REGION      → CLOUD_ML_REGION, VERTEX_LOCATION
+//   - ANTHROPIC_VERTEX_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) → both vars
+func (g *gcloudCredential) EnvVars(_ string) map[string]string {
+	vars := make(map[string]string)
+
+	if region := os.Getenv("CLOUD_ML_REGION"); region != "" {
+		vars["CLOUD_ML_REGION"] = region
+		vars["VERTEX_LOCATION"] = region
+	}
+
+	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
+	if projectID == "" {
+		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+	}
+	if projectID != "" {
+		vars["ANTHROPIC_VERTEX_PROJECT_ID"] = projectID
+		vars["GOOGLE_CLOUD_PROJECT"] = projectID
+	}
+
+	return vars
+}
+
+// loadADC reads application_default_credentials.json from adcPath.
+// Returns (nil, nil) if the file does not exist.
+func loadADC(adcPath string) (*adcCredentials, error) {
+	data, err := os.ReadFile(adcPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	var creds adcCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parsing ADC JSON: %w", err)
+	}
+	return &creds, nil
+}
+
+// resolveHost expands $HOME in a mount host path and returns the absolute path.
+func resolveHost(host, homeDir string) string {
+	if strings.HasPrefix(host, "$HOME") {
+		rest := filepath.FromSlash(host[len("$HOME"):])
+		return filepath.Join(homeDir, rest)
+	}
+	return filepath.Clean(host)
+}
+
+// resolveTarget expands $HOME in a mount target path and returns the absolute
+// container-side path.
+func resolveTarget(target string) string {
+	if strings.HasPrefix(target, "$HOME") {
+		return path.Join(containerHomeDir, target[len("$HOME"):])
+	}
+	return path.Clean(target)
+}

--- a/pkg/credential/gcloud/gcloud_test.go
+++ b/pkg/credential/gcloud/gcloud_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -289,6 +290,9 @@ func TestLoadADC(t *testing.T) {
 	t.Run("returns error for unreadable file", func(t *testing.T) {
 		t.Parallel()
 
+		if runtime.GOOS == "windows" {
+			t.Skip("file permission bits are not enforced on Windows")
+		}
 		if os.Getuid() == 0 {
 			t.Skip("running as root: permission checks do not apply")
 		}

--- a/pkg/credential/gcloud/gcloud_test.go
+++ b/pkg/credential/gcloud/gcloud_test.go
@@ -1,0 +1,254 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package gcloud
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+func TestGcloudCredential_Name(t *testing.T) {
+	t.Parallel()
+	if got := New().Name(); got != "gcloud" {
+		t.Errorf("Name() = %q, want %q", got, "gcloud")
+	}
+}
+
+func TestGcloudCredential_ContainerFilePath(t *testing.T) {
+	t.Parallel()
+	want := "/home/agent/.config/gcloud/application_default_credentials.json"
+	if got := New().ContainerFilePath(); got != want {
+		t.Errorf("ContainerFilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestGcloudCredential_Detect(t *testing.T) {
+	t.Parallel()
+
+	homeDir := "/home/testuser"
+
+	tests := []struct {
+		name            string
+		mounts          []workspace.Mount
+		wantNil         bool
+		wantADCFilePath string
+		wantMountHost   string
+	}{
+		{
+			name:    "no mounts",
+			mounts:  nil,
+			wantNil: true,
+		},
+		{
+			name: "unrelated mount",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/projects", Target: "$HOME/projects"},
+			},
+			wantNil: true,
+		},
+		{
+			name: "gcloud directory mount via $HOME",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud", Target: "$HOME/.config/gcloud"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud",
+		},
+		{
+			name: "gcloud directory mount via absolute host path",
+			mounts: []workspace.Mount{
+				{Host: "/home/testuser/.config/gcloud", Target: "$HOME/.config/gcloud"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join("/home/testuser/.config/gcloud", "application_default_credentials.json"),
+			wantMountHost:   "/home/testuser/.config/gcloud",
+		},
+		{
+			name: "gcloud ADC file mount via $HOME",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud/application_default_credentials.json", Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud/application_default_credentials.json",
+		},
+		{
+			name: "gcloud ADC file mount via absolute container target",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud/application_default_credentials.json", Target: "/home/agent/.config/gcloud/application_default_credentials.json"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud/application_default_credentials.json",
+		},
+		{
+			name: "gcloud directory mount via absolute container target",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/.config/gcloud", Target: "/home/agent/.config/gcloud"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud",
+		},
+		{
+			name: "first matching mount wins",
+			mounts: []workspace.Mount{
+				{Host: "$HOME/other", Target: "$HOME/other"},
+				{Host: "$HOME/.config/gcloud", Target: "$HOME/.config/gcloud"},
+				{Host: "$HOME/.config/gcloud/application_default_credentials.json", Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+			},
+			wantNil:         false,
+			wantADCFilePath: filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json"),
+			wantMountHost:   "$HOME/.config/gcloud",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cred := New()
+			gotPath, gotMount := cred.Detect(tt.mounts, homeDir)
+
+			if tt.wantNil {
+				if gotPath != "" || gotMount != nil {
+					t.Errorf("Detect() = (%q, %+v), want (\"\", nil)", gotPath, gotMount)
+				}
+				return
+			}
+
+			if gotPath == "" || gotMount == nil {
+				t.Fatal("Detect() returned empty result, want non-nil match")
+			}
+			if gotPath != tt.wantADCFilePath {
+				t.Errorf("Detect() hostFilePath = %q, want %q", gotPath, tt.wantADCFilePath)
+			}
+			if gotMount.Host != tt.wantMountHost {
+				t.Errorf("Detect() intercepted.Host = %q, want %q", gotMount.Host, tt.wantMountHost)
+			}
+		})
+	}
+}
+
+func TestGcloudCredential_FakeFile(t *testing.T) {
+	t.Parallel()
+
+	cred := New()
+	content, err := cred.FakeFile("")
+	if err != nil {
+		t.Fatalf("FakeFile() error = %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("FakeFile() returned empty content")
+	}
+	// Must contain placeholder values, not real credentials.
+	s := string(content)
+	for _, placeholder := range []string{"FAKE_CLIENT_ID", "FAKE_CLIENT_SECRET", "FAKE_REFRESH_TOKEN"} {
+		if !strings.Contains(s, placeholder) {
+			t.Errorf("FakeFile() content does not contain %q", placeholder)
+		}
+	}
+}
+
+func TestGcloudCredential_HostPatterns(t *testing.T) {
+	t.Parallel()
+
+	cred := New()
+	patterns := cred.HostPatterns("")
+	if len(patterns) == 0 {
+		t.Fatal("HostPatterns() returned empty slice")
+	}
+	// Must include Google OAuth and Vertex AI endpoints.
+	found := make(map[string]bool)
+	for _, p := range patterns {
+		found[p] = true
+	}
+	for _, want := range []string{"oauth2.googleapis.com", "aiplatform.googleapis.com"} {
+		if !found[want] {
+			t.Errorf("HostPatterns() missing %q", want)
+		}
+	}
+}
+
+func TestLoadADC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for missing file", func(t *testing.T) {
+		t.Parallel()
+
+		creds, err := loadADC("/nonexistent/path/adc.json")
+		if err != nil {
+			t.Fatalf("loadADC() error = %v, want nil", err)
+		}
+		if creds != nil {
+			t.Errorf("loadADC() = %+v, want nil", creds)
+		}
+	})
+
+	t.Run("parses valid ADC file", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := filepath.Join(t.TempDir(), "adc.json")
+		content := []byte(`{
+			"refresh_token": "test-token",
+			"client_id": "test-client-id",
+			"client_secret": "test-secret",
+			"quota_project_id": "test-project"
+		}`)
+		if err := os.WriteFile(adcPath, content, 0644); err != nil {
+			t.Fatalf("failed to write test ADC file: %v", err)
+		}
+
+		creds, err := loadADC(adcPath)
+		if err != nil {
+			t.Fatalf("loadADC() error = %v", err)
+		}
+		if creds == nil {
+			t.Fatal("loadADC() = nil, want non-nil")
+		}
+		if creds.RefreshToken != "test-token" {
+			t.Errorf("RefreshToken = %q, want %q", creds.RefreshToken, "test-token")
+		}
+		if creds.ClientID != "test-client-id" {
+			t.Errorf("ClientID = %q, want %q", creds.ClientID, "test-client-id")
+		}
+		if creds.QuotaProjectID != "test-project" {
+			t.Errorf("QuotaProjectID = %q, want %q", creds.QuotaProjectID, "test-project")
+		}
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(adcPath, []byte("not json"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		_, err := loadADC(adcPath)
+		if err == nil {
+			t.Fatal("loadADC() error = nil, want error for invalid JSON")
+		}
+	})
+}

--- a/pkg/credential/gcloud/gcloud_test.go
+++ b/pkg/credential/gcloud/gcloud_test.go
@@ -19,13 +19,47 @@
 package gcloud
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/onecli"
 )
+
+// fakeOnecliClient is a test double for onecli.Client that records ConnectApp calls.
+type fakeOnecliClient struct {
+	connectAppErr      error
+	connectAppProvider string
+	connectAppFields   map[string]string
+}
+
+var _ onecli.Client = (*fakeOnecliClient)(nil)
+
+func (f *fakeOnecliClient) CreateSecret(_ context.Context, _ onecli.CreateSecretInput) (*onecli.Secret, error) {
+	return nil, nil
+}
+func (f *fakeOnecliClient) UpdateSecret(_ context.Context, _ string, _ onecli.UpdateSecretInput) error {
+	return nil
+}
+func (f *fakeOnecliClient) ListSecrets(_ context.Context) ([]onecli.Secret, error) { return nil, nil }
+func (f *fakeOnecliClient) DeleteSecret(_ context.Context, _ string) error         { return nil }
+func (f *fakeOnecliClient) GetContainerConfig(_ context.Context) (*onecli.ContainerConfig, error) {
+	return nil, nil
+}
+func (f *fakeOnecliClient) CreateRule(_ context.Context, _ onecli.CreateRuleInput) (*onecli.Rule, error) {
+	return nil, nil
+}
+func (f *fakeOnecliClient) ListRules(_ context.Context) ([]onecli.Rule, error) { return nil, nil }
+func (f *fakeOnecliClient) DeleteRule(_ context.Context, _ string) error       { return nil }
+func (f *fakeOnecliClient) ConnectApp(_ context.Context, provider string, fields map[string]string) error {
+	f.connectAppProvider = provider
+	f.connectAppFields = fields
+	return f.connectAppErr
+}
 
 func TestGcloudCredential_Name(t *testing.T) {
 	t.Parallel()
@@ -249,6 +283,239 @@ func TestLoadADC(t *testing.T) {
 		_, err := loadADC(adcPath)
 		if err == nil {
 			t.Fatal("loadADC() error = nil, want error for invalid JSON")
+		}
+	})
+
+	t.Run("returns error for unreadable file", func(t *testing.T) {
+		t.Parallel()
+
+		if os.Getuid() == 0 {
+			t.Skip("running as root: permission checks do not apply")
+		}
+
+		adcPath := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(adcPath, []byte(`{}`), 0000); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		_, err := loadADC(adcPath)
+		if err == nil {
+			t.Fatal("loadADC() error = nil, want error for unreadable file")
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			t.Errorf("loadADC() returned ErrNotExist, want a permission error")
+		}
+	})
+}
+
+func TestVertexAIFields(t *testing.T) {
+	t.Run("uses quota_project_id from ADC when present", func(t *testing.T) {
+		t.Parallel()
+
+		creds := &adcCredentials{
+			RefreshToken:   "tok",
+			ClientID:       "id",
+			ClientSecret:   "sec",
+			QuotaProjectID: "adc-project",
+		}
+		fields := creds.vertexAIFields()
+		if fields["quotaProjectId"] != "adc-project" {
+			t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "adc-project")
+		}
+		if fields["refreshToken"] != "tok" {
+			t.Errorf("refreshToken = %q, want %q", fields["refreshToken"], "tok")
+		}
+	})
+
+	t.Run("falls back to ANTHROPIC_VERTEX_PROJECT_ID when quota_project_id empty", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "env-vertex-project")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "should-not-be-used")
+
+		creds := &adcCredentials{RefreshToken: "tok"}
+		fields := creds.vertexAIFields()
+		if fields["quotaProjectId"] != "env-vertex-project" {
+			t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "env-vertex-project")
+		}
+	})
+
+	t.Run("falls back to GOOGLE_CLOUD_PROJECT when ANTHROPIC_VERTEX_PROJECT_ID unset", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "gcp-project")
+
+		creds := &adcCredentials{RefreshToken: "tok"}
+		fields := creds.vertexAIFields()
+		if fields["quotaProjectId"] != "gcp-project" {
+			t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "gcp-project")
+		}
+	})
+
+	t.Run("empty quotaProjectId when no env vars set", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+		creds := &adcCredentials{RefreshToken: "tok"}
+		fields := creds.vertexAIFields()
+		if fields["quotaProjectId"] != "" {
+			t.Errorf("quotaProjectId = %q, want empty string", fields["quotaProjectId"])
+		}
+	})
+}
+
+func TestGcloudCredential_Configure(t *testing.T) {
+	t.Parallel()
+
+	writeADC := func(t *testing.T, content string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write ADC file: %v", err)
+		}
+		return p
+	}
+
+	validADC := `{
+		"refresh_token": "real-token",
+		"client_id": "real-client-id",
+		"client_secret": "real-secret",
+		"quota_project_id": "real-project"
+	}`
+
+	t.Run("success: calls ConnectApp with parsed fields", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := writeADC(t, validADC)
+		client := &fakeOnecliClient{}
+		cred := New()
+
+		if err := cred.Configure(context.Background(), client, adcPath); err != nil {
+			t.Fatalf("Configure() error = %v", err)
+		}
+		if client.connectAppProvider != "vertex-ai" {
+			t.Errorf("ConnectApp provider = %q, want %q", client.connectAppProvider, "vertex-ai")
+		}
+		if client.connectAppFields["refreshToken"] != "real-token" {
+			t.Errorf("refreshToken = %q, want %q", client.connectAppFields["refreshToken"], "real-token")
+		}
+		if client.connectAppFields["quotaProjectId"] != "real-project" {
+			t.Errorf("quotaProjectId = %q, want %q", client.connectAppFields["quotaProjectId"], "real-project")
+		}
+	})
+
+	t.Run("error: ADC file not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := &fakeOnecliClient{}
+		cred := New()
+
+		err := cred.Configure(context.Background(), client, "/nonexistent/adc.json")
+		if err == nil {
+			t.Fatal("Configure() error = nil, want error for missing file")
+		}
+		if !strings.Contains(err.Error(), "ADC file not found") {
+			t.Errorf("error %q does not mention 'ADC file not found'", err.Error())
+		}
+	})
+
+	t.Run("error: invalid JSON in ADC file", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := writeADC(t, "not valid json")
+		client := &fakeOnecliClient{}
+		cred := New()
+
+		err := cred.Configure(context.Background(), client, adcPath)
+		if err == nil {
+			t.Fatal("Configure() error = nil, want error for invalid JSON")
+		}
+	})
+
+	t.Run("error: ConnectApp returns error", func(t *testing.T) {
+		t.Parallel()
+
+		adcPath := writeADC(t, validADC)
+		client := &fakeOnecliClient{connectAppErr: errors.New("vertex-ai unavailable")}
+		cred := New()
+
+		err := cred.Configure(context.Background(), client, adcPath)
+		if err == nil {
+			t.Fatal("Configure() error = nil, want error from ConnectApp")
+		}
+		if !strings.Contains(err.Error(), "vertex-ai unavailable") {
+			t.Errorf("error %q does not mention 'vertex-ai unavailable'", err.Error())
+		}
+	})
+}
+
+func TestGcloudCredential_EnvVars(t *testing.T) {
+	t.Run("empty map when no env vars set", func(t *testing.T) {
+		t.Setenv("CLOUD_ML_REGION", "")
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+		vars := New().EnvVars("")
+		if len(vars) != 0 {
+			t.Errorf("EnvVars() = %v, want empty map", vars)
+		}
+	})
+
+	t.Run("CLOUD_ML_REGION propagates to CLOUD_ML_REGION and VERTEX_LOCATION", func(t *testing.T) {
+		t.Setenv("CLOUD_ML_REGION", "us-central1")
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+		vars := New().EnvVars("")
+		if vars["CLOUD_ML_REGION"] != "us-central1" {
+			t.Errorf("CLOUD_ML_REGION = %q, want %q", vars["CLOUD_ML_REGION"], "us-central1")
+		}
+		if vars["VERTEX_LOCATION"] != "us-central1" {
+			t.Errorf("VERTEX_LOCATION = %q, want %q", vars["VERTEX_LOCATION"], "us-central1")
+		}
+	})
+
+	t.Run("ANTHROPIC_VERTEX_PROJECT_ID propagates to both project vars", func(t *testing.T) {
+		t.Setenv("CLOUD_ML_REGION", "")
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-vertex-project")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+		vars := New().EnvVars("")
+		if vars["ANTHROPIC_VERTEX_PROJECT_ID"] != "my-vertex-project" {
+			t.Errorf("ANTHROPIC_VERTEX_PROJECT_ID = %q, want %q", vars["ANTHROPIC_VERTEX_PROJECT_ID"], "my-vertex-project")
+		}
+		if vars["GOOGLE_CLOUD_PROJECT"] != "my-vertex-project" {
+			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", vars["GOOGLE_CLOUD_PROJECT"], "my-vertex-project")
+		}
+	})
+
+	t.Run("GOOGLE_CLOUD_PROJECT used when ANTHROPIC_VERTEX_PROJECT_ID unset", func(t *testing.T) {
+		t.Setenv("CLOUD_ML_REGION", "")
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "gcp-fallback")
+
+		vars := New().EnvVars("")
+		if vars["ANTHROPIC_VERTEX_PROJECT_ID"] != "gcp-fallback" {
+			t.Errorf("ANTHROPIC_VERTEX_PROJECT_ID = %q, want %q", vars["ANTHROPIC_VERTEX_PROJECT_ID"], "gcp-fallback")
+		}
+		if vars["GOOGLE_CLOUD_PROJECT"] != "gcp-fallback" {
+			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", vars["GOOGLE_CLOUD_PROJECT"], "gcp-fallback")
+		}
+	})
+
+	t.Run("all env vars set produces all four output vars", func(t *testing.T) {
+		t.Setenv("CLOUD_ML_REGION", "europe-west4")
+		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "full-project")
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+		vars := New().EnvVars("")
+		for _, key := range []string{"CLOUD_ML_REGION", "VERTEX_LOCATION", "ANTHROPIC_VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"} {
+			if vars[key] == "" {
+				t.Errorf("EnvVars() missing or empty key %q", key)
+			}
+		}
+		if vars["CLOUD_ML_REGION"] != "europe-west4" {
+			t.Errorf("CLOUD_ML_REGION = %q, want %q", vars["CLOUD_ML_REGION"], "europe-west4")
+		}
+		if vars["GOOGLE_CLOUD_PROJECT"] != "full-project" {
+			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", vars["GOOGLE_CLOUD_PROJECT"], "full-project")
 		}
 	})
 }

--- a/pkg/credential/registry.go
+++ b/pkg/credential/registry.go
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package credential
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// registry is the internal implementation of Registry.
+type registry struct {
+	mu          sync.RWMutex
+	credentials []Credential
+	names       map[string]struct{}
+}
+
+// Compile-time check to ensure registry implements Registry.
+var _ Registry = (*registry)(nil)
+
+// NewRegistry creates a new credential registry.
+func NewRegistry() Registry {
+	return &registry{
+		names: make(map[string]struct{}),
+	}
+}
+
+// Register adds a credential to the registry.
+func (r *registry) Register(c Credential) error {
+	if c == nil {
+		return errors.New("credential cannot be nil")
+	}
+
+	name := c.Name()
+	if name == "" {
+		return errors.New("credential name cannot be empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.names[name]; exists {
+		return fmt.Errorf("credential %q is already registered", name)
+	}
+
+	r.names[name] = struct{}{}
+	r.credentials = append(r.credentials, c)
+	return nil
+}
+
+// List returns all registered credentials in registration order.
+func (r *registry) List() []Credential {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Credential, len(r.credentials))
+	copy(result, r.credentials)
+	return result
+}

--- a/pkg/credential/registry_test.go
+++ b/pkg/credential/registry_test.go
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package credential
+
+import (
+	"context"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/onecli"
+)
+
+// fakeCredential is a test implementation of Credential.
+type fakeCredential struct {
+	name string
+}
+
+func (f *fakeCredential) Name() string              { return f.name }
+func (f *fakeCredential) ContainerFilePath() string { return "/fake/path" }
+func (f *fakeCredential) Detect(_ []workspace.Mount, _ string) (string, *workspace.Mount) {
+	return "", nil
+}
+func (f *fakeCredential) FakeFile(_ string) ([]byte, error)                            { return nil, nil }
+func (f *fakeCredential) Configure(_ context.Context, _ onecli.Client, _ string) error { return nil }
+func (f *fakeCredential) HostPatterns(_ string) []string                               { return nil }
+func (f *fakeCredential) EnvVars(_ string) map[string]string                           { return nil }
+
+func TestRegistry_Register(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registers a credential", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		if err := r.Register(&fakeCredential{name: "test"}); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+	})
+
+	t.Run("rejects nil", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		if err := r.Register(nil); err == nil {
+			t.Fatal("Register(nil) expected error, got nil")
+		}
+	})
+
+	t.Run("rejects empty name", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		if err := r.Register(&fakeCredential{name: ""}); err == nil {
+			t.Fatal("Register(empty name) expected error, got nil")
+		}
+	})
+
+	t.Run("rejects duplicate name", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		if err := r.Register(&fakeCredential{name: "dup"}); err != nil {
+			t.Fatalf("first Register() error = %v", err)
+		}
+		if err := r.Register(&fakeCredential{name: "dup"}); err == nil {
+			t.Fatal("second Register() expected error for duplicate name, got nil")
+		}
+	})
+}
+
+func TestRegistry_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty registry returns empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		if got := r.List(); len(got) != 0 {
+			t.Errorf("List() = %v, want empty", got)
+		}
+	})
+
+	t.Run("preserves registration order", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		_ = r.Register(&fakeCredential{name: "a"})
+		_ = r.Register(&fakeCredential{name: "b"})
+		_ = r.Register(&fakeCredential{name: "c"})
+
+		got := r.List()
+		if len(got) != 3 {
+			t.Fatalf("List() len = %d, want 3", len(got))
+		}
+		names := []string{got[0].Name(), got[1].Name(), got[2].Name()}
+		want := []string{"a", "b", "c"}
+		for i, n := range names {
+			if n != want[i] {
+				t.Errorf("List()[%d].Name() = %q, want %q", i, n, want[i])
+			}
+		}
+	})
+}

--- a/pkg/credentialsetup/register.go
+++ b/pkg/credentialsetup/register.go
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package credentialsetup provides centralized registration of all available
+// credential implementations.
+package credentialsetup
+
+import (
+	"fmt"
+
+	"github.com/openkaiden/kdn/pkg/credential"
+	"github.com/openkaiden/kdn/pkg/credential/gcloud"
+)
+
+// CredentialRegistrar is an interface for types that can register credentials.
+// This is implemented by instances.Manager.
+type CredentialRegistrar interface {
+	RegisterCredential(c credential.Credential) error
+}
+
+// credentialFactory is a function that creates a new credential instance.
+type credentialFactory func() credential.Credential
+
+// availableCredentials lists all credential implementations to register.
+var availableCredentials = []credentialFactory{
+	gcloud.New,
+}
+
+// RegisterAll registers all available credential implementations to the given registrar.
+// Returns an error if any credential fails to register.
+func RegisterAll(registrar CredentialRegistrar) error {
+	return registerAllWithFactories(registrar, availableCredentials)
+}
+
+// registerAllWithFactories registers the given credentials to the registrar.
+// This function is internal and used for testing with custom credential lists.
+func registerAllWithFactories(registrar CredentialRegistrar, factories []credentialFactory) error {
+	for _, factory := range factories {
+		c := factory()
+		if c == nil {
+			return fmt.Errorf("credential factory returned nil")
+		}
+		if err := registrar.RegisterCredential(c); err != nil {
+			return fmt.Errorf("failed to register credential %q: %w", c.Name(), err)
+		}
+	}
+	return nil
+}

--- a/pkg/credentialsetup/register_test.go
+++ b/pkg/credentialsetup/register_test.go
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package credentialsetup
+
+import (
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/credential"
+)
+
+type fakeRegistrar struct {
+	registered []string
+}
+
+func (f *fakeRegistrar) RegisterCredential(c credential.Credential) error {
+	f.registered = append(f.registered, c.Name())
+	return nil
+}
+
+func TestRegisterAll(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeRegistrar{}
+	if err := RegisterAll(r); err != nil {
+		t.Fatalf("RegisterAll() error = %v", err)
+	}
+
+	if len(r.registered) == 0 {
+		t.Fatal("RegisterAll() registered no credentials")
+	}
+
+	// gcloud must be registered.
+	found := false
+	for _, name := range r.registered {
+		if name == "gcloud" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("RegisterAll() did not register %q; got %v", "gcloud", r.registered)
+	}
+}

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -33,6 +33,7 @@ import (
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/agent"
 	"github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/generator"
 	"github.com/openkaiden/kdn/pkg/git"
 	"github.com/openkaiden/kdn/pkg/onecli"
@@ -99,6 +100,8 @@ type Manager interface {
 	RegisterAgent(name string, agent agent.Agent) error
 	// RegisterSecretService registers a secret service with the manager's registry
 	RegisterSecretService(service secretservice.SecretService) error
+	// RegisterCredential registers a credential with the manager's registry
+	RegisterCredential(c credential.Credential) error
 }
 
 // manager is the internal implementation of Manager
@@ -111,6 +114,7 @@ type manager struct {
 	runtimeRegistry       runtime.Registry
 	agentRegistry         agent.Registry
 	secretServiceRegistry secretservice.Registry
+	credentialRegistry    credential.Registry
 	secretStore           secret.Store
 	projectDetector       project.Detector
 	now                   func() time.Time
@@ -128,13 +132,14 @@ func NewManager(storageDir string) (Manager, error) {
 	}
 	agentReg := agent.NewRegistry()
 	secretServiceReg := secretservice.NewRegistry()
+	credReg := credential.NewRegistry()
 	secretStore := secret.NewStore(storageDir)
-	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, agentReg, secretServiceReg, secretStore, project.NewDetector(git.NewDetector()), time.Now)
+	return newManagerWithFactory(storageDir, NewInstanceFromData, generator.New(), reg, agentReg, secretServiceReg, credReg, secretStore, project.NewDetector(git.NewDetector()), time.Now)
 }
 
 // newManagerWithFactory creates a new instance manager with a custom instance factory, generator, registry, and project detector.
 // This is unexported and primarily useful for testing with fake instances, generators, runtimes, and project detectors.
-func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, agentReg agent.Registry, secretServiceReg secretservice.Registry, secretStore secret.Store, detector project.Detector, clock func() time.Time) (Manager, error) {
+func newManagerWithFactory(storageDir string, factory InstanceFactory, gen generator.Generator, reg runtime.Registry, agentReg agent.Registry, secretServiceReg secretservice.Registry, credReg credential.Registry, secretStore secret.Store, detector project.Detector, clock func() time.Time) (Manager, error) {
 	if storageDir == "" {
 		return nil, errors.New("storage directory cannot be empty")
 	}
@@ -152,6 +157,9 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 	}
 	if secretServiceReg == nil {
 		return nil, errors.New("secret service registry cannot be nil")
+	}
+	if credReg == nil {
+		return nil, errors.New("credential registry cannot be nil")
 	}
 	if secretStore == nil {
 		return nil, errors.New("secret store cannot be nil")
@@ -177,6 +185,7 @@ func newManagerWithFactory(storageDir string, factory InstanceFactory, gen gener
 		runtimeRegistry:       reg,
 		agentRegistry:         agentReg,
 		secretServiceRegistry: secretServiceReg,
+		credentialRegistry:    credReg,
 		secretStore:           secretStore,
 		projectDetector:       detector,
 		now:                   clock,
@@ -791,6 +800,9 @@ func (m *manager) RegisterRuntime(rt runtime.Runtime) error {
 	if aware, ok := rt.(runtime.SecretServiceRegistryAware); ok {
 		aware.SetSecretServiceRegistry(m.secretServiceRegistry)
 	}
+	if aware, ok := rt.(runtime.CredentialRegistryAware); ok {
+		aware.SetCredentialRegistry(m.credentialRegistry)
+	}
 	return nil
 }
 
@@ -802,6 +814,11 @@ func (m *manager) RegisterAgent(name string, agent agent.Agent) error {
 // RegisterSecretService registers a secret service with the manager's registry.
 func (m *manager) RegisterSecretService(service secretservice.SecretService) error {
 	return m.secretServiceRegistry.Register(service)
+}
+
+// RegisterCredential registers a credential with the manager's registry.
+func (m *manager) RegisterCredential(c credential.Credential) error {
+	return m.credentialRegistry.Register(c)
 }
 
 var invalidNameChars = regexp.MustCompile(`[^a-z0-9._-]+`)

--- a/pkg/instances/manager_terminal_test.go
+++ b/pkg/instances/manager_terminal_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/openkaiden/kdn/pkg/agent"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -84,7 +85,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -133,7 +134,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -161,7 +162,7 @@ func TestManager_Terminal(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistryWithTerminal(tmpDir, nil), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistryWithTerminal(tmpDir, nil), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		err := manager.Terminal(context.Background(), "nonexistent-id", []string{"bash"})
 		if !errors.Is(err, ErrInstanceNotFound) {
@@ -179,7 +180,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -224,7 +225,7 @@ func TestManager_Terminal(t *testing.T) {
 		regularFakeRT := fake.New()
 		_ = reg.Register(regularFakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -258,7 +259,7 @@ func TestManager_Terminal(t *testing.T) {
 		reg, _ := runtime.NewRegistry(filepath.Join(tmpDir, "runtimes"))
 		_ = reg.Register(fakeRT)
 
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -29,6 +29,7 @@ import (
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/agent"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -432,7 +433,7 @@ func TestNewManager(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() unexpected error = %v", err)
 		}
@@ -464,7 +465,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -494,7 +495,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		_, err := manager.Add(context.Background(), AddOptions{Instance: nil, RuntimeType: "fake"})
 		if err == nil {
@@ -516,7 +517,7 @@ func TestManager_Add(t *testing.T) {
 			"duplicate-id-0000000000000000000000000000000000000000000000000000000a",
 			"unique-id-1-0000000000000000000000000000000000000000000000000000000b",
 		})
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, gen, newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		// Create instances without IDs (empty ID)
@@ -567,7 +568,7 @@ func TestManager_Add(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -593,7 +594,7 @@ func TestManager_Add(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -630,7 +631,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instances, err := manager.List()
 		if err != nil {
@@ -646,7 +647,7 @@ func TestManager_List(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst1 := newFakeInstance(newFakeInstanceParams{
@@ -676,7 +677,7 @@ func TestManager_List(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		// Create empty storage file
 		storageFile := filepath.Join(tmpDir, DefaultStorageFileName)
@@ -699,7 +700,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -732,7 +733,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		_, err := manager.Get("nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -744,7 +745,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -780,7 +781,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		_, err := manager.Get("nonexistent-name")
 		if err != ErrInstanceNotFound {
@@ -792,7 +793,7 @@ func TestManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		// Create first instance
@@ -836,7 +837,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -866,7 +867,7 @@ func TestManager_Delete(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		err := manager.Delete(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -879,7 +880,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		source1 := filepath.Join(instanceTmpDir, "source1")
@@ -922,7 +923,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -936,7 +937,7 @@ func TestManager_Delete(t *testing.T) {
 		manager1.Delete(ctx, generatedID)
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		_, err := manager2.Get(generatedID)
 		if err != ErrInstanceNotFound {
 			t.Errorf("Get() from new manager error = %v, want %v", err, ErrInstanceNotFound)
@@ -948,7 +949,7 @@ func TestManager_Delete(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		sourceDir := filepath.Join(instanceTmpDir, "source")
@@ -990,7 +991,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1022,7 +1023,7 @@ func TestManager_Start(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		err := manager.Start(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -1052,7 +1053,7 @@ func TestManager_Start(t *testing.T) {
 				runtime:    RuntimeData{}, // Empty runtime
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, noRuntimeFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1092,7 +1093,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1103,7 +1104,7 @@ func TestManager_Start(t *testing.T) {
 		manager1.Start(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "running" {
@@ -1116,7 +1117,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1141,7 +1142,7 @@ func TestManager_Start(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1180,7 +1181,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1214,7 +1215,7 @@ func TestManager_Stop(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		err := manager.Stop(context.Background(), "nonexistent-id")
 		if err != ErrInstanceNotFound {
@@ -1227,7 +1228,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1267,7 +1268,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  filepath.Join(string(filepath.Separator), "tmp", "source"),
@@ -1279,7 +1280,7 @@ func TestManager_Stop(t *testing.T) {
 		manager1.Stop(ctx, added.GetID())
 
 		// Create new manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		retrieved, _ := manager2.Get(added.GetID())
 
 		if retrieved.GetRuntimeData().State != "stopped" {
@@ -1292,7 +1293,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1316,7 +1317,7 @@ func TestManager_Stop(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		projectDetector := &fakeProjectDetector{result: "https://github.com/openkaiden/kdn/"}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), projectDetector, time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), projectDetector, time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1353,7 +1354,7 @@ func TestManager_Stop(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		projectDetector := &fakeProjectDetector{result: "https://github.com/openkaiden/kdn/"}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), projectDetector, time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), projectDetector, time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1390,7 +1391,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1418,7 +1419,7 @@ func TestManager_Stop(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1476,7 +1477,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1520,7 +1521,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		// Add instance that is inaccessible
 		instanceTmpDir := t.TempDir()
@@ -1564,7 +1565,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: false, // Always inaccessible for this test
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, inaccessibleFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inaccessibleSource := filepath.Join(instanceTmpDir, "nonexistent-source")
@@ -1613,7 +1614,7 @@ func TestManager_Reconcile(t *testing.T) {
 				accessible: accessible,
 			}, nil
 		}
-		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, mixedFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		accessibleConfig := filepath.Join(instanceTmpDir, "accessible-config")
 
@@ -1656,7 +1657,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1680,7 +1681,7 @@ func TestManager_Reconcile(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		removed, err := manager.Reconcile()
 		if err != nil {
@@ -1703,7 +1704,7 @@ func TestManager_Persistence(t *testing.T) {
 		instanceTmpDir := t.TempDir()
 
 		// Create first manager and add instance
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		expectedSource := filepath.Join(instanceTmpDir, "source")
 		expectedConfig := filepath.Join(instanceTmpDir, "config")
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -1716,7 +1717,7 @@ func TestManager_Persistence(t *testing.T) {
 		generatedID := added.GetID()
 
 		// Create second manager with same storage
-		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager2, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		instances, err := manager2.List()
 		if err != nil {
 			t.Fatalf("List() from second manager unexpected error = %v", err)
@@ -1737,7 +1738,7 @@ func TestManager_Persistence(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		expectedSource := filepath.Join(instanceTmpDir, "source")
@@ -1817,7 +1818,7 @@ func TestManager_MigrateTimestamps(t *testing.T) {
 		fixedClock := func() time.Time { return fixedNow }
 
 		// Creating the manager triggers migrateTimestamps
-		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), fixedClock)
+		manager, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), fixedClock)
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
 		}
@@ -1857,7 +1858,7 @@ func TestManager_MigrateTimestamps(t *testing.T) {
 
 		// Add an instance through the manager (it will have CreatedAt set)
 		existingNow := time.Date(2026, 1, 10, 8, 0, 0, 0, time.UTC)
-		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), func() time.Time { return existingNow })
+		manager1, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), func() time.Time { return existingNow })
 
 		inst := newFakeInstance(newFakeInstanceParams{
 			SourceDir:  t.TempDir(),
@@ -1870,7 +1871,7 @@ func TestManager_MigrateTimestamps(t *testing.T) {
 
 		// Reload with a different clock — migration must not overwrite the existing timestamp
 		laterNow := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-		manager2, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), func() time.Time { return laterNow })
+		manager2, err := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), func() time.Time { return laterNow })
 		if err != nil {
 			t.Fatalf("newManagerWithFactory() error = %v", err)
 		}
@@ -1895,7 +1896,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		var wg sync.WaitGroup
@@ -1928,7 +1929,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		// Add some instances first
@@ -2009,7 +2010,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		// Cast to concrete type to access unexported methods
 		mgr := m.(*manager)
@@ -2042,7 +2043,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2067,7 +2068,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2106,7 +2107,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2142,7 +2143,7 @@ func TestManager_ensureUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2163,7 +2164,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2180,7 +2181,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2205,7 +2206,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2223,7 +2224,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2244,7 +2245,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2262,7 +2263,7 @@ func TestManager_generateUniqueName(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		mgr := m.(*manager)
 
@@ -2284,7 +2285,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2334,7 +2335,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2395,7 +2396,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2471,7 +2472,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2570,7 +2571,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		// Create workspace config
@@ -2624,7 +2625,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		result, err := mgr.mergeConfigurations("github.com/user/repo", nil, "")
@@ -2652,7 +2653,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -2682,7 +2683,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write agents.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -2722,7 +2723,7 @@ func TestManager_mergeConfigurations(t *testing.T) {
 			t.Fatalf("Failed to write projects.json: %v", err)
 		}
 
-		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		m, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 		mgr := m.(*manager)
 
 		workspaceValue := "workspace-value"
@@ -4262,6 +4263,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRegistry(tmpDir),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(),
+			credential.NewRegistry(),
 			store,
 			newFakeProjectDetector(),
 			time.Now,
@@ -4306,6 +4308,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRegistry(tmpDir),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(), // empty registry — mapper.Map will fail
+			credential.NewRegistry(),
 			store,
 			newFakeProjectDetector(),
 			time.Now,
@@ -4348,6 +4351,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRuntimeRegistry(t, tmpDir, spy),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(),
+			credential.NewRegistry(),
 			store,
 			newFakeProjectDetector(),
 			time.Now,
@@ -4424,6 +4428,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRuntimeRegistry(t, tmpDir, spy),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(),
+			credential.NewRegistry(),
 			store,
 			newFakeProjectDetector(),
 			time.Now,
@@ -4479,6 +4484,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRuntimeRegistry(t, tmpDir, spy),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(),
+			credential.NewRegistry(),
 			newFakeSecretStore(),
 			newFakeProjectDetector(),
 			time.Now,
@@ -4516,6 +4522,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRuntimeRegistry(t, tmpDir, spy),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(),
+			credential.NewRegistry(),
 			newFakeSecretStore(),
 			newFakeProjectDetector(),
 			time.Now,
@@ -4566,6 +4573,7 @@ func TestManager_Add_Secrets(t *testing.T) {
 			newTestRuntimeRegistry(t, tmpDir, spy),
 			agent.NewRegistry(),
 			secretservice.NewRegistry(),
+			credential.NewRegistry(),
 			store,
 			newFakeProjectDetector(),
 			time.Now,
@@ -4648,7 +4656,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
 			t.Fatalf("Register() error = %v", err)
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4687,7 +4695,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
 			t.Fatalf("Register() error = %v", err)
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4714,7 +4722,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4741,7 +4749,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		_, err := manager.GetDashboardURL(ctx, "nonexistent-id")
 		if !errors.Is(err, ErrInstanceNotFound) {
@@ -4763,7 +4771,7 @@ func TestManager_GetDashboardURL(t *testing.T) {
 		if err := reg.Register(fake.NewWithDashboard(dashboardURL)); err != nil {
 			t.Fatalf("Register() error = %v", err)
 		}
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		instanceTmpDir := t.TempDir()
 		inst := newFakeInstance(newFakeInstanceParams{
@@ -4797,7 +4805,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		svc := &fakeSecretServiceImpl{name: "github", hostsPatterns: []string{"github.com"}, headerName: "Authorization"}
 
@@ -4811,7 +4819,7 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
 
 		svc1 := &fakeSecretServiceImpl{name: "github", headerName: "Authorization"}
 		svc2 := &fakeSecretServiceImpl{name: "github", headerName: "X-Token"}

--- a/pkg/onecli/client.go
+++ b/pkg/onecli/client.go
@@ -40,6 +40,8 @@ type Client interface {
 	CreateRule(ctx context.Context, input CreateRuleInput) (*Rule, error)
 	ListRules(ctx context.Context) ([]Rule, error)
 	DeleteRule(ctx context.Context, id string) error
+	// ConnectApp connects an app provider using the given credential fields.
+	ConnectApp(ctx context.Context, provider string, fields map[string]string) error
 }
 
 // UpdateSecretInput is the request body for updating a secret.
@@ -201,6 +203,17 @@ func (c *client) ListRules(ctx context.Context) ([]Rule, error) {
 func (c *client) DeleteRule(ctx context.Context, id string) error {
 	if err := c.do(ctx, http.MethodDelete, "/api/rules/"+id, nil, nil); err != nil {
 		return fmt.Errorf("deleting rule: %w", err)
+	}
+	return nil
+}
+
+// ConnectApp connects an app provider using the given credential fields.
+func (c *client) ConnectApp(ctx context.Context, provider string, fields map[string]string) error {
+	body := struct {
+		Fields map[string]string `json:"fields"`
+	}{Fields: fields}
+	if err := c.do(ctx, http.MethodPost, "/api/apps/"+provider+"/connect", body, nil); err != nil {
+		return fmt.Errorf("connecting %s: %w", provider, err)
 	}
 	return nil
 }

--- a/pkg/onecli/provisioner_test.go
+++ b/pkg/onecli/provisioner_test.go
@@ -74,6 +74,10 @@ func (f *fakeClient) DeleteRule(_ context.Context, _ string) error {
 	return nil
 }
 
+func (f *fakeClient) ConnectApp(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+
 func TestProvisioner_AllSecretsCreated(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -370,10 +370,9 @@ func renderPodYAML(data podTemplateData) ([]byte, error) {
 }
 
 // detectCredentials scans the workspace config mounts against each registered
-// credential. For each credential that is detected, the real credential file
-// is read, a fake placeholder is written to the durable credentials directory,
-// and an activeCredential entry is returned. Mounts whose credential file is
-// missing on the host are skipped with a warning.
+// credential. For each credential that is detected, a fake placeholder is written
+// to the durable credentials directory and an activeCredential entry is returned.
+// Credentials whose host file is missing or unreadable are skipped with a warning.
 func (p *podmanRuntime) detectCredentials(params runtime.CreateParams, homeDir string) []activeCredential {
 	if p.credentialRegistry == nil {
 		return nil
@@ -386,6 +385,11 @@ func (p *podmanRuntime) detectCredentials(params runtime.CreateParams, homeDir s
 	for _, cred := range p.credentialRegistry.List() {
 		hostPath, intercepted := cred.Detect(*params.WorkspaceConfig.Mounts, homeDir)
 		if hostPath == "" {
+			continue
+		}
+
+		if _, err := os.Stat(hostPath); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: credential %q: %s missing on host: %v; skipping\n", cred.Name(), hostPath, err)
 			continue
 		}
 

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -26,6 +26,8 @@ import (
 	"text/template"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/devcontainers/features"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/onecli"
@@ -37,7 +39,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/steplogger"
 )
 
-const defaultOnecliVersion = "1.17"
+const defaultOnecliVersion = "1.20.0"
 
 // podTemplateData holds the values used to render the pod YAML template
 // and is also persisted as per-pod metadata (pod-template-data.json) so
@@ -214,12 +216,34 @@ func (p *podmanRuntime) buildImage(ctx context.Context, imageName, instanceDir s
 	return nil
 }
 
+// credentialMount represents a fake credential file to mount into the workspace container
+// in place of the real credential file declared in the workspace config.
+type credentialMount struct {
+	// hostPath is the path to the fake credential file on the host.
+	hostPath string
+	// containerPath is the absolute path inside the container where the file must appear.
+	containerPath string
+}
+
+// activeCredential holds the detected state of a credential at Create time.
+type activeCredential struct {
+	cred        credential.Credential
+	hostPath    string           // path to the real credential on the host
+	intercepted *workspace.Mount // the mount entry to skip (replaced by the fake file)
+}
+
 // containerConfigArgs holds optional OneCLI container configuration to inject into the workspace.
 type containerConfigArgs struct {
-	envVars         map[string]string
-	caFilePath      string
-	caContainerPath string
+	envVars           map[string]string
+	caFilePath        string
+	caContainerPath   string
+	credMounts        []credentialMount // fake credential files to mount
+	credEnvVars       map[string]string // env vars contributed by active credentials
+	interceptedMounts map[mountKey]bool // original mounts replaced by credentials (must be skipped)
 }
+
+// mountKey uniquely identifies a workspace mount by its host+target pair.
+type mountKey struct{ host, target string }
 
 // buildContainerArgs builds the arguments for creating the workspace container inside the pod.
 func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageName string, ccArgs *containerConfigArgs) ([]string, error) {
@@ -262,6 +286,12 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 		if ccArgs.caFilePath != "" && ccArgs.caContainerPath != "" {
 			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", ccArgs.caFilePath, ccArgs.caContainerPath))
 		}
+		for _, cm := range ccArgs.credMounts {
+			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", cm.hostPath, cm.containerPath))
+		}
+		for k, v := range ccArgs.credEnvVars {
+			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+		}
 	}
 
 	// Add secret service env vars with placeholder values so CLI tools detect a configured credential.
@@ -274,13 +304,16 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 	// Mount the source directory at /workspace/sources
 	args = append(args, "-v", fmt.Sprintf("%s:/workspace/sources:Z", params.SourcePath))
 
-	// Mount additional directories if specified
+	// Mount additional directories if specified, skipping mounts intercepted by active credentials.
 	if params.WorkspaceConfig != nil && params.WorkspaceConfig.Mounts != nil {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get home directory: %w", err)
 		}
 		for _, m := range *params.WorkspaceConfig.Mounts {
+			if ccArgs != nil && ccArgs.interceptedMounts[mountKey{host: m.Host, target: m.Target}] {
+				continue // replaced by a fake credential file
+			}
 			args = append(args, "-v", mountVolumeArg(m, params.SourcePath, homeDir))
 		}
 	}
@@ -334,6 +367,53 @@ func renderPodYAML(data podTemplateData) ([]byte, error) {
 		return nil, fmt.Errorf("failed to render pod template: %w", err)
 	}
 	return buf.Bytes(), nil
+}
+
+// detectCredentials scans the workspace config mounts against each registered
+// credential. For each credential that is detected, the real credential file
+// is read, a fake placeholder is written to the durable credentials directory,
+// and an activeCredential entry is returned. Mounts whose credential file is
+// missing on the host are skipped with a warning.
+func (p *podmanRuntime) detectCredentials(params runtime.CreateParams, homeDir string) []activeCredential {
+	if p.credentialRegistry == nil {
+		return nil
+	}
+	if params.WorkspaceConfig == nil || params.WorkspaceConfig.Mounts == nil {
+		return nil
+	}
+
+	var active []activeCredential
+	for _, cred := range p.credentialRegistry.List() {
+		hostPath, intercepted := cred.Detect(*params.WorkspaceConfig.Mounts, homeDir)
+		if hostPath == "" {
+			continue
+		}
+
+		fakeContent, err := cred.FakeFile(hostPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: credential %q: failed to generate placeholder file: %v; skipping\n", cred.Name(), err)
+			continue
+		}
+
+		credDir := filepath.Join(p.storageDir, "credentials", params.Name, cred.Name())
+		if err := os.MkdirAll(credDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: credential %q: failed to create directory %s: %v; skipping\n", cred.Name(), credDir, err)
+			continue
+		}
+
+		fakePath := filepath.Join(credDir, "credential")
+		if err := os.WriteFile(fakePath, fakeContent, 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: credential %q: failed to write placeholder file: %v; skipping\n", cred.Name(), err)
+			continue
+		}
+
+		active = append(active, activeCredential{
+			cred:        cred,
+			hostPath:    hostPath,
+			intercepted: intercepted,
+		})
+	}
+	return active
 }
 
 // Create creates a new Podman runtime instance.
@@ -457,11 +537,21 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		}
 	}()
 
+	// Detect active credentials from the workspace config mounts. When a credential
+	// is detected, its real file is read for OneCLI configuration and a fake
+	// placeholder file is written to a durable directory under storageDir so it
+	// can be mounted into the container instead of the real file.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	activeCredentials := p.detectCredentials(params, homeDir)
+
 	// Always start OneCLI to inject proxy env vars and the CA cert into the workspace container.
 	// Without HTTP_PROXY/HTTPS_PROXY pointing at the OneCLI gateway, deny-mode networking rules
 	// have no effect because workspace traffic bypasses the proxy entirely.
-	// Secrets are provisioned if any were provided.
-	containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets)
+	// Secrets are provisioned if any were provided; active credentials are configured.
+	containerConfig, setupErr := p.setupOnecli(ctx, stepLogger, l, params.Name, tmplData, params.OnecliSecrets, activeCredentials)
 	if setupErr != nil {
 		return runtime.RuntimeInfo{}, setupErr
 	}
@@ -484,6 +574,32 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 			ccArgs.caFilePath = caPath
 			ccArgs.caContainerPath = containerConfig.CACertificateContainerPath
 		}
+	}
+
+	// Populate credential mounts and env vars from active credentials.
+	if len(activeCredentials) > 0 {
+		if ccArgs == nil {
+			ccArgs = &containerConfigArgs{}
+		}
+		intercepted := make(map[mountKey]bool, len(activeCredentials))
+		for _, ac := range activeCredentials {
+			if ac.intercepted != nil {
+				intercepted[mountKey{host: ac.intercepted.Host, target: ac.intercepted.Target}] = true
+			}
+			credDir := filepath.Join(p.storageDir, "credentials", params.Name, ac.cred.Name())
+			fakePath := filepath.Join(credDir, "credential")
+			ccArgs.credMounts = append(ccArgs.credMounts, credentialMount{
+				hostPath:      fakePath,
+				containerPath: ac.cred.ContainerFilePath(),
+			})
+			for k, v := range ac.cred.EnvVars(ac.hostPath) {
+				if ccArgs.credEnvVars == nil {
+					ccArgs.credEnvVars = make(map[string]string)
+				}
+				ccArgs.credEnvVars[k] = v
+			}
+		}
+		ccArgs.interceptedMounts = intercepted
 	}
 
 	// Build workspace container args with proxy env vars and CA cert mount from OneCLI
@@ -560,8 +676,8 @@ func (p *podmanRuntime) buildForwards(params runtime.CreateParams) ([]api.Worksp
 }
 
 // setupOnecli starts postgres, waits for it, then starts onecli to avoid migration race conditions.
-// After provisioning secrets and retrieving container config, it stops the pod.
-func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.StepLogger, l logger.Logger, podName string, tmplData podTemplateData, secrets []onecli.CreateSecretInput) (*onecli.ContainerConfig, error) {
+// After provisioning secrets and configuring active credentials, it stops the pod.
+func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.StepLogger, l logger.Logger, podName string, tmplData podTemplateData, secrets []onecli.CreateSecretInput, activeCredentials []activeCredential) (*onecli.ContainerConfig, error) {
 	postgresContainer := podName + "-postgres"
 	onecliContainer := podName + "-onecli"
 
@@ -610,6 +726,18 @@ func (p *podmanRuntime) setupOnecli(ctx context.Context, stepLogger steplogger.S
 		if err := provisioner.ProvisionSecrets(ctx, secrets); err != nil {
 			stepLogger.Fail(err)
 			return nil, fmt.Errorf("failed to provision OneCLI secrets: %w", err)
+		}
+	}
+
+	// Configure each active credential (e.g. connect Vertex AI app, create secret).
+	for _, ac := range activeCredentials {
+		stepLogger.Start(
+			fmt.Sprintf("Configuring credential: %s", ac.cred.Name()),
+			fmt.Sprintf("Credential configured: %s", ac.cred.Name()),
+		)
+		if err := ac.cred.Configure(ctx, client, ac.hostPath); err != nil {
+			stepLogger.Fail(err)
+			return nil, fmt.Errorf("configuring credential %q: %w", ac.cred.Name(), err)
 		}
 	}
 

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -30,6 +30,8 @@ import (
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/credential"
+	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
@@ -1715,6 +1717,238 @@ func TestPrepareFeatures(t *testing.T) {
 		// Verify containerEnv was returned.
 		if info.envVars["MY_FEATURE_HOME"] != "/opt/my-feature" {
 			t.Errorf("Expected MY_FEATURE_HOME=/opt/my-feature, got %q", info.envVars["MY_FEATURE_HOME"])
+		}
+	})
+}
+
+// fakeCredentialForDetect is a configurable test double for credential.Credential.
+// Only Detect and FakeFile behaviour can be controlled; Configure is a no-op.
+type fakeCredentialForDetect struct {
+	name        string
+	detectPath  string // returned as hostFilePath by Detect; "" means not detected
+	intercepted *workspace.Mount
+	fakeContent []byte
+	fakeFileErr error
+}
+
+var _ credential.Credential = (*fakeCredentialForDetect)(nil)
+
+func (f *fakeCredentialForDetect) Name() string              { return f.name }
+func (f *fakeCredentialForDetect) ContainerFilePath() string { return "/fake/" + f.name }
+func (f *fakeCredentialForDetect) Detect(_ []workspace.Mount, _ string) (string, *workspace.Mount) {
+	return f.detectPath, f.intercepted
+}
+func (f *fakeCredentialForDetect) FakeFile(_ string) ([]byte, error) {
+	return f.fakeContent, f.fakeFileErr
+}
+func (f *fakeCredentialForDetect) Configure(_ context.Context, _ onecli.Client, _ string) error {
+	return nil
+}
+func (f *fakeCredentialForDetect) HostPatterns(_ string) []string     { return nil }
+func (f *fakeCredentialForDetect) EnvVars(_ string) map[string]string { return nil }
+
+func TestDetectCredentials(t *testing.T) {
+	t.Parallel()
+
+	emptyMounts := []workspace.Mount{}
+	configWithMounts := func(mounts []workspace.Mount) *workspace.WorkspaceConfiguration {
+		return &workspace.WorkspaceConfiguration{Mounts: &mounts}
+	}
+
+	t.Run("nil registry returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{}
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("nil WorkspaceConfig returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		reg := credential.NewRegistry()
+		p := &podmanRuntime{credentialRegistry: reg}
+		result := p.detectCredentials(runtime.CreateParams{Name: "ws"}, "/home/user")
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("nil Mounts returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		reg := credential.NewRegistry()
+		p := &podmanRuntime{credentialRegistry: reg}
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{},
+		}, "/home/user")
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("credential not detected is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{name: "unmatched", detectPath: ""})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: t.TempDir()}
+
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+		if len(result) != 0 {
+			t.Errorf("Expected empty result for undetected credential, got %v", result)
+		}
+	})
+
+	t.Run("FakeFile error skips credential", func(t *testing.T) {
+		t.Parallel()
+
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{
+			name:        "broken",
+			detectPath:  "/some/path",
+			fakeFileErr: errors.New("cannot generate placeholder"),
+		})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: t.TempDir()}
+
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+		if len(result) != 0 {
+			t.Errorf("Expected empty result when FakeFile fails, got %v", result)
+		}
+	})
+
+	t.Run("MkdirAll error skips credential", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		// Block MkdirAll by placing a regular file where the credentials dir would be.
+		if err := os.WriteFile(filepath.Join(storageDir, "credentials"), []byte("not a dir"), 0644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{
+			name:        "test",
+			detectPath:  "/some/path",
+			fakeContent: []byte("fake"),
+		})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+		if len(result) != 0 {
+			t.Errorf("Expected empty result when MkdirAll fails, got %v", result)
+		}
+	})
+
+	t.Run("WriteFile error skips credential", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		// Pre-create the credential dir but make the "credential" leaf a directory
+		// so os.WriteFile cannot overwrite it.
+		credDir := filepath.Join(storageDir, "credentials", "ws", "test")
+		if err := os.MkdirAll(filepath.Join(credDir, "credential"), 0755); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{
+			name:        "test",
+			detectPath:  "/some/path",
+			fakeContent: []byte("fake"),
+		})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+		if len(result) != 0 {
+			t.Errorf("Expected empty result when WriteFile fails, got %v", result)
+		}
+	})
+
+	t.Run("successful detection returns active credential", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		interceptedMount := &workspace.Mount{Host: "/real/path", Target: "/container/cred"}
+
+		reg := credential.NewRegistry()
+		cred := &fakeCredentialForDetect{
+			name:        "mycred",
+			detectPath:  "/real/credential/path",
+			intercepted: interceptedMount,
+			fakeContent: []byte(`{"token":"placeholder"}`),
+		}
+		_ = reg.Register(cred)
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+
+		mounts := []workspace.Mount{{Host: "/real/path", Target: "/container/cred"}}
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(mounts),
+		}, "/home/user")
+
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 active credential, got %d", len(result))
+		}
+		if result[0].hostPath != "/real/credential/path" {
+			t.Errorf("hostPath = %q, want %q", result[0].hostPath, "/real/credential/path")
+		}
+		if result[0].intercepted != interceptedMount {
+			t.Errorf("intercepted mount not set correctly")
+		}
+
+		fakePath := filepath.Join(storageDir, "credentials", "ws", "mycred", "credential")
+		content, err := os.ReadFile(fakePath)
+		if err != nil {
+			t.Fatalf("Expected fake credential file at %s: %v", fakePath, err)
+		}
+		if string(content) != `{"token":"placeholder"}` {
+			t.Errorf("fake file content = %q, want %q", string(content), `{"token":"placeholder"}`)
+		}
+	})
+
+	t.Run("only detected credentials are returned", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{name: "missing", detectPath: ""})
+		_ = reg.Register(&fakeCredentialForDetect{
+			name:        "present",
+			detectPath:  "/host/cred",
+			fakeContent: []byte("ok"),
+		})
+		_ = reg.Register(&fakeCredentialForDetect{name: "also-missing", detectPath: ""})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 active credential, got %d", len(result))
+		}
+		if result[0].cred.Name() != "present" {
+			t.Errorf("Expected 'present' credential, got %q", result[0].cred.Name())
 		}
 	})
 }

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1765,9 +1765,15 @@ func TestCreate_WithActiveCredentials(t *testing.T) {
 		}
 		mounts := []workspace.Mount{interceptedMount}
 
+		// Create a real credential file so os.Stat in detectCredentials succeeds.
+		realCredFile := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(realCredFile, []byte(`{"type":"authorized_user"}`), 0600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
 		cred := &fakeCredentialForDetect{
 			name:        "mycred",
-			detectPath:  "/host/real/credential",
+			detectPath:  realCredFile,
 			intercepted: &mounts[0],
 			fakeContent: []byte(`{"fake":true}`),
 			envVars:     map[string]string{"CRED_TOKEN": "placeholder"},
@@ -1846,10 +1852,16 @@ func TestCreate_WithActiveCredentials(t *testing.T) {
 		sourcePath := t.TempDir()
 		onecliServer := newOnecliTestServer(t)
 
+		// Create a real credential file so os.Stat in detectCredentials succeeds.
+		realCredFile2 := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(realCredFile2, []byte(`{"type":"authorized_user"}`), 0600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
 		mounts := []workspace.Mount{{Host: "/host/cred", Target: "/host/cred"}}
 		cred := &fakeCredentialForDetect{
 			name:        "cred2",
-			detectPath:  "/host/cred",
+			detectPath:  realCredFile2,
 			intercepted: &mounts[0],
 			fakeContent: []byte("placeholder"),
 		}
@@ -1967,13 +1979,39 @@ func TestDetectCredentials(t *testing.T) {
 		}
 	})
 
-	t.Run("FakeFile error skips credential", func(t *testing.T) {
+	t.Run("host file missing on host skips credential", func(t *testing.T) {
 		t.Parallel()
 
 		reg := credential.NewRegistry()
 		_ = reg.Register(&fakeCredentialForDetect{
+			name:        "gcloud",
+			detectPath:  "/nonexistent/path/adc.json",
+			fakeContent: []byte(`{"fake":true}`),
+		})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: t.TempDir()}
+
+		result := p.detectCredentials(runtime.CreateParams{
+			Name:            "ws",
+			WorkspaceConfig: configWithMounts(emptyMounts),
+		}, "/home/user")
+		if len(result) != 0 {
+			t.Errorf("Expected empty result when host file is missing, got %v", result)
+		}
+	})
+
+	t.Run("FakeFile error skips credential", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a real file so os.Stat succeeds; FakeFile error is still exercised.
+		realFile := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(realFile, []byte("{}"), 0644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{
 			name:        "broken",
-			detectPath:  "/some/path",
+			detectPath:  realFile,
 			fakeFileErr: errors.New("cannot generate placeholder"),
 		})
 		p := &podmanRuntime{credentialRegistry: reg, storageDir: t.TempDir()}
@@ -1996,10 +2034,16 @@ func TestDetectCredentials(t *testing.T) {
 			t.Fatalf("setup: %v", err)
 		}
 
+		// Create a real file so os.Stat succeeds; MkdirAll error is still exercised.
+		realFile := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(realFile, []byte("{}"), 0644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
 		reg := credential.NewRegistry()
 		_ = reg.Register(&fakeCredentialForDetect{
 			name:        "test",
-			detectPath:  "/some/path",
+			detectPath:  realFile,
 			fakeContent: []byte("fake"),
 		})
 		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
@@ -2024,10 +2068,16 @@ func TestDetectCredentials(t *testing.T) {
 			t.Fatalf("setup: %v", err)
 		}
 
+		// Create a real file so os.Stat succeeds; WriteFile error is still exercised.
+		realFile := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(realFile, []byte("{}"), 0644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
 		reg := credential.NewRegistry()
 		_ = reg.Register(&fakeCredentialForDetect{
 			name:        "test",
-			detectPath:  "/some/path",
+			detectPath:  realFile,
 			fakeContent: []byte("fake"),
 		})
 		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
@@ -2047,10 +2097,16 @@ func TestDetectCredentials(t *testing.T) {
 		storageDir := t.TempDir()
 		interceptedMount := &workspace.Mount{Host: "/real/path", Target: "/container/cred"}
 
+		// Create a real credential file so os.Stat succeeds.
+		realCredFile := filepath.Join(t.TempDir(), "adc.json")
+		if err := os.WriteFile(realCredFile, []byte(`{"type":"authorized_user"}`), 0600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
 		reg := credential.NewRegistry()
 		cred := &fakeCredentialForDetect{
 			name:        "mycred",
-			detectPath:  "/real/credential/path",
+			detectPath:  realCredFile,
 			intercepted: interceptedMount,
 			fakeContent: []byte(`{"token":"placeholder"}`),
 		}
@@ -2066,8 +2122,8 @@ func TestDetectCredentials(t *testing.T) {
 		if len(result) != 1 {
 			t.Fatalf("Expected 1 active credential, got %d", len(result))
 		}
-		if result[0].hostPath != "/real/credential/path" {
-			t.Errorf("hostPath = %q, want %q", result[0].hostPath, "/real/credential/path")
+		if result[0].hostPath != realCredFile {
+			t.Errorf("hostPath = %q, want %q", result[0].hostPath, realCredFile)
 		}
 		if result[0].intercepted != interceptedMount {
 			t.Errorf("intercepted mount not set correctly")
@@ -2087,11 +2143,18 @@ func TestDetectCredentials(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
+
+		// Create a real file for the credential that should be detected.
+		realCredFile := filepath.Join(t.TempDir(), "cred.json")
+		if err := os.WriteFile(realCredFile, []byte(`{}`), 0600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
 		reg := credential.NewRegistry()
 		_ = reg.Register(&fakeCredentialForDetect{name: "missing", detectPath: ""})
 		_ = reg.Register(&fakeCredentialForDetect{
 			name:        "present",
-			detectPath:  "/host/cred",
+			detectPath:  realCredFile,
 			fakeContent: []byte("ok"),
 		})
 		_ = reg.Register(&fakeCredentialForDetect{name: "also-missing", detectPath: ""})

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1729,6 +1729,7 @@ type fakeCredentialForDetect struct {
 	intercepted *workspace.Mount
 	fakeContent []byte
 	fakeFileErr error
+	envVars     map[string]string
 }
 
 var _ credential.Credential = (*fakeCredentialForDetect)(nil)
@@ -1745,7 +1746,164 @@ func (f *fakeCredentialForDetect) Configure(_ context.Context, _ onecli.Client, 
 	return nil
 }
 func (f *fakeCredentialForDetect) HostPatterns(_ string) []string     { return nil }
-func (f *fakeCredentialForDetect) EnvVars(_ string) map[string]string { return nil }
+func (f *fakeCredentialForDetect) EnvVars(_ string) map[string]string { return f.envVars }
+
+func TestCreate_WithActiveCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fake credential file mounted and intercepted mount suppressed", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcePath := t.TempDir()
+		onecliServer := newOnecliTestServer(t)
+
+		// Mount the gcloud directory; the credential will intercept it.
+		interceptedMount := workspace.Mount{
+			Host:   "$HOME/.config/gcloud",
+			Target: "$HOME/.config/gcloud",
+		}
+		mounts := []workspace.Mount{interceptedMount}
+
+		cred := &fakeCredentialForDetect{
+			name:        "mycred",
+			detectPath:  "/host/real/credential",
+			intercepted: &mounts[0],
+			fakeContent: []byte(`{"fake":true}`),
+			envVars:     map[string]string{"CRED_TOKEN": "placeholder"},
+		}
+		reg := credential.NewRegistry()
+		_ = reg.Register(cred)
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(_ context.Context, args ...string) error { return nil }
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("container-id-123"), nil
+		}
+
+		p := &podmanRuntime{
+			system:             &fakeSystem{},
+			executor:           fakeExec,
+			storageDir:         storageDir,
+			config:             &fakeConfig{},
+			onecliBaseURLFn:    func(_ int) string { return onecliServer.URL },
+			credentialRegistry: reg,
+		}
+
+		params := runtime.CreateParams{
+			Name:       "test-workspace",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Mounts: &mounts,
+			},
+		}
+
+		ctx := steplogger.WithLogger(context.Background(), &fakeStepLogger{})
+		_, err := p.Create(ctx, params)
+		if err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		// Find the podman "create" call to inspect the container args.
+		var createArgs []string
+		for _, call := range fakeExec.OutputCalls {
+			if len(call) > 0 && call[0] == "create" {
+				createArgs = call
+				break
+			}
+		}
+		if createArgs == nil {
+			t.Fatal("Expected 'create' command to be called")
+		}
+		argsStr := strings.Join(createArgs, " ")
+
+		// Fake credential file must be mounted at the credential's container path.
+		fakePath := filepath.Join(storageDir, "credentials", "test-workspace", "mycred", "credential")
+		expectedCredMount := fmt.Sprintf("-v %s:/fake/mycred:ro,Z", fakePath)
+		if !strings.Contains(argsStr, expectedCredMount) {
+			t.Errorf("Expected credential mount %q in args:\n%s", expectedCredMount, argsStr)
+		}
+
+		// Credential env vars must be injected.
+		if !strings.Contains(argsStr, "-e CRED_TOKEN=placeholder") {
+			t.Errorf("Expected credential env var in args:\n%s", argsStr)
+		}
+
+		// The intercepted mount's container path must NOT appear (mount was suppressed).
+		if strings.Contains(argsStr, "/home/agent/.config/gcloud") {
+			t.Errorf("Intercepted mount container path should be absent from args:\n%s", argsStr)
+		}
+	})
+
+	t.Run("ccArgs initialised when OneCLI returns no container config", func(t *testing.T) {
+		t.Parallel()
+
+		// When the OneCLI server returns an empty container config (no env, no CA cert),
+		// containerConfig is non-nil but ccArgs starts with only envVars set (to an
+		// empty map). The credential block must still populate credMounts correctly.
+		storageDir := t.TempDir()
+		sourcePath := t.TempDir()
+		onecliServer := newOnecliTestServer(t)
+
+		mounts := []workspace.Mount{{Host: "/host/cred", Target: "/host/cred"}}
+		cred := &fakeCredentialForDetect{
+			name:        "cred2",
+			detectPath:  "/host/cred",
+			intercepted: &mounts[0],
+			fakeContent: []byte("placeholder"),
+		}
+		reg := credential.NewRegistry()
+		_ = reg.Register(cred)
+
+		fakeExec := exec.NewFake()
+		fakeExec.RunFunc = func(_ context.Context, args ...string) error { return nil }
+		fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte("container-id-456"), nil
+		}
+
+		p := &podmanRuntime{
+			system:             &fakeSystem{},
+			executor:           fakeExec,
+			storageDir:         storageDir,
+			config:             &fakeConfig{},
+			onecliBaseURLFn:    func(_ int) string { return onecliServer.URL },
+			credentialRegistry: reg,
+		}
+
+		params := runtime.CreateParams{
+			Name:       "ws2",
+			SourcePath: sourcePath,
+			Agent:      "test_agent",
+			WorkspaceConfig: &workspace.WorkspaceConfiguration{
+				Mounts: &mounts,
+			},
+		}
+
+		ctx := steplogger.WithLogger(context.Background(), &fakeStepLogger{})
+		_, err := p.Create(ctx, params)
+		if err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		var createArgs []string
+		for _, call := range fakeExec.OutputCalls {
+			if len(call) > 0 && call[0] == "create" {
+				createArgs = call
+				break
+			}
+		}
+		if createArgs == nil {
+			t.Fatal("Expected 'create' command to be called")
+		}
+
+		fakePath := filepath.Join(storageDir, "credentials", "ws2", "cred2", "credential")
+		expectedMount := fmt.Sprintf("-v %s:/fake/cred2:ro,Z", fakePath)
+		if !strings.Contains(strings.Join(createArgs, " "), expectedMount) {
+			t.Errorf("Expected credential mount %q in args: %v", expectedMount, createArgs)
+		}
+	})
+}
 
 func TestDetectCredentials(t *testing.T) {
 	t.Parallel()

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -24,6 +24,7 @@ import (
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/containerurl"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/config"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
@@ -44,6 +45,7 @@ type podmanRuntime struct {
 	onecliBaseURLFn       func(port int) string // overridable in tests; nil uses default http://localhost:<port>
 	secretStore           secret.Store
 	secretServiceRegistry secretservice.Registry
+	credentialRegistry    credential.Registry
 }
 
 // onecliURL returns the base URL for the OneCLI service on the given port.
@@ -65,6 +67,9 @@ var _ runtime.AgentLister = (*podmanRuntime)(nil)
 
 // Ensure podmanRuntime implements runtime.SecretServiceRegistryAware at compile time.
 var _ runtime.SecretServiceRegistryAware = (*podmanRuntime)(nil)
+
+// Ensure podmanRuntime implements runtime.CredentialRegistryAware at compile time.
+var _ runtime.CredentialRegistryAware = (*podmanRuntime)(nil)
 
 // Ensure podmanRuntime implements runtime.ConfigTransformer at compile time.
 var _ runtime.ConfigTransformer = (*podmanRuntime)(nil)
@@ -101,6 +106,12 @@ func (p *podmanRuntime) Available() bool {
 // can resolve host patterns for secrets when configuring deny-mode networking.
 func (p *podmanRuntime) SetSecretServiceRegistry(reg secretservice.Registry) {
 	p.secretServiceRegistry = reg
+}
+
+// SetCredentialRegistry injects the credential registry so that Create() can
+// intercept file-based credential mounts and configure OneCLI accordingly.
+func (p *podmanRuntime) SetCredentialRegistry(reg credential.Registry) {
+	p.credentialRegistry = reg
 }
 
 // TransformConfig implements runtime.ConfigTransformer.

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -80,7 +80,7 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 
 // workspaceTempDirs lists the subdirectories under storageDir that hold
 // per-workspace temporary files and must be cleaned up on removal.
-var workspaceTempDirs = []string{"approval-handler", "certs"}
+var workspaceTempDirs = []string{"approval-handler", "certs", "credentials"}
 
 // cleanupWorkspaceTempDirs removes per-workspace subdirectories from every
 // directory listed in workspaceTempDirs.

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
@@ -106,7 +108,11 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	if err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to collect secret hosts: %w", err)
 	}
-	allHosts := mergeHosts(explicitHosts, secretHosts)
+
+	// Automatically add host patterns from credentials that were configured at Create time.
+	// The credential directory acts as a signal that the credential was successfully set up.
+	credentialHosts := p.collectCredentialHosts(tmplData.Name, wsCfg)
+	allHosts := mergeHosts(explicitHosts, mergeHosts(secretHosts, credentialHosts))
 
 	// Networking rules are configured whenever mode is explicitly deny, regardless
 	// of whether any hosts are allowed. An empty host list causes the
@@ -256,6 +262,38 @@ func (p *podmanRuntime) waitForPostgres(ctx context.Context, podName string) err
 		}
 	}
 	return fmt.Errorf("postgres not ready after %d retries: %w", postgresMaxRetries, lastErr)
+}
+
+// collectCredentialHosts returns the host patterns contributed by credentials
+// that were successfully configured at Create time (indicated by the presence of
+// their per-workspace credential directory). For credentials with dynamic host
+// patterns (e.g. OpenShift cluster URL), the workspace mounts are re-read to
+// reconstruct the host path passed to HostPatterns.
+func (p *podmanRuntime) collectCredentialHosts(workspaceName string, wsCfg *workspace.WorkspaceConfiguration) []string {
+	if p.credentialRegistry == nil {
+		return nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	var hosts []string
+	for _, cred := range p.credentialRegistry.List() {
+		credDir := filepath.Join(p.storageDir, "credentials", workspaceName, cred.Name())
+		if _, err := os.Stat(credDir); err != nil {
+			continue // credential was not configured at Create time
+		}
+
+		// Re-detect to obtain the host file path for dynamic HostPatterns implementations.
+		hostPath := ""
+		if wsCfg != nil && wsCfg.Mounts != nil {
+			hostPath, _ = cred.Detect(*wsCfg.Mounts, homeDir)
+		}
+		hosts = append(hosts, cred.HostPatterns(hostPath)...)
+	}
+	return hosts
 }
 
 const (

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -855,6 +855,10 @@ func TestCollectCredentialHosts(t *testing.T) {
 		if result[0] != "api.example.com" || result[1] != "*.example.com" {
 			t.Errorf("host patterns = %v, want [api.example.com *.example.com]", result)
 		}
+		// Verify that the detected host path is forwarded to HostPatterns.
+		if cred.lastHostPath != "/real/credential" {
+			t.Errorf("HostPatterns received hostPath = %q, want %q", cred.lastHostPath, "/real/credential")
+		}
 	})
 
 	t.Run("only credentials with existing dirs contribute hosts", func(t *testing.T) {
@@ -918,9 +922,11 @@ func TestCollectCredentialHosts(t *testing.T) {
 type fakeCredentialWithHosts struct {
 	fakeCredentialForDetect
 	hostPatterns []string
+	lastHostPath string
 }
 
-func (f *fakeCredentialWithHosts) HostPatterns(_ string) []string {
+func (f *fakeCredentialWithHosts) HostPatterns(hostPath string) []string {
+	f.lastHostPath = hostPath
 	return f.hostPatterns
 }
 

--- a/pkg/runtime/podman/start_test.go
+++ b/pkg/runtime/podman/start_test.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/podman/exec"
 	"github.com/openkaiden/kdn/pkg/steplogger"
@@ -735,6 +737,191 @@ func TestStart_DenyMode_NoHosts_ConfiguresNetworking(t *testing.T) {
 	// Approval-handler must be started before pod start so it has config.json.
 	fakeExec.AssertRunCalledWith(t, "start", podName+"-approval-handler")
 	fakeExec.AssertRunCalledWith(t, "pod", "start", podName)
+}
+
+func TestCollectCredentialHosts(t *testing.T) {
+	t.Parallel()
+
+	makeCredDir := func(t *testing.T, storageDir, workspaceName, credName string) {
+		t.Helper()
+		dir := filepath.Join(storageDir, "credentials", workspaceName, credName)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create credential dir: %v", err)
+		}
+	}
+
+	t.Run("nil registry returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		p := &podmanRuntime{storageDir: t.TempDir()}
+		result := p.collectCredentialHosts("ws", nil)
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("empty registry returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		reg := credential.NewRegistry()
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: t.TempDir()}
+		result := p.collectCredentialHosts("ws", nil)
+		if len(result) != 0 {
+			t.Errorf("Expected empty result, got %v", result)
+		}
+	})
+
+	t.Run("credential dir absent skips credential", func(t *testing.T) {
+		t.Parallel()
+
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{
+			name:        "mycred",
+			detectPath:  "/host/path",
+			fakeContent: []byte("ok"),
+		})
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: t.TempDir()}
+
+		// No credential dir created → stat fails → credential skipped.
+		result := p.collectCredentialHosts("ws", nil)
+		if len(result) != 0 {
+			t.Errorf("Expected empty result when credential dir absent, got %v", result)
+		}
+	})
+
+	t.Run("credential dir present, nil wsCfg: HostPatterns called with empty hostPath", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		reg := credential.NewRegistry()
+		cred := &fakeCredentialForDetect{
+			name:        "mycred",
+			detectPath:  "/host/path",
+			fakeContent: []byte("ok"),
+		}
+		_ = reg.Register(cred)
+		makeCredDir(t, storageDir, "ws", "mycred")
+
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+		result := p.collectCredentialHosts("ws", nil)
+
+		// fakeCredentialForDetect.HostPatterns returns nil, so result is empty.
+		if len(result) != 0 {
+			t.Errorf("Expected empty hosts (fake returns nil), got %v", result)
+		}
+	})
+
+	t.Run("credential dir present, nil Mounts: HostPatterns called with empty hostPath", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		reg := credential.NewRegistry()
+		_ = reg.Register(&fakeCredentialForDetect{name: "mycred", detectPath: "/host/path"})
+		makeCredDir(t, storageDir, "ws", "mycred")
+
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+		result := p.collectCredentialHosts("ws", &workspace.WorkspaceConfiguration{})
+		if len(result) != 0 {
+			t.Errorf("Expected empty hosts, got %v", result)
+		}
+	})
+
+	t.Run("credential dir present, Mounts set: Detect called and hostPath forwarded", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		// Use a credential that returns host patterns so we can verify the output.
+		cred := &fakeCredentialWithHosts{
+			fakeCredentialForDetect: fakeCredentialForDetect{
+				name:       "mycred",
+				detectPath: "/real/credential",
+			},
+			hostPatterns: []string{"api.example.com", "*.example.com"},
+		}
+		reg := credential.NewRegistry()
+		_ = reg.Register(cred)
+		makeCredDir(t, storageDir, "ws", "mycred")
+
+		mounts := []workspace.Mount{{Host: "/real/path", Target: "/container/path"}}
+		wsCfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+
+		result := p.collectCredentialHosts("ws", wsCfg)
+
+		if len(result) != 2 {
+			t.Fatalf("Expected 2 host patterns, got %d: %v", len(result), result)
+		}
+		if result[0] != "api.example.com" || result[1] != "*.example.com" {
+			t.Errorf("host patterns = %v, want [api.example.com *.example.com]", result)
+		}
+	})
+
+	t.Run("only credentials with existing dirs contribute hosts", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		present := &fakeCredentialWithHosts{
+			fakeCredentialForDetect: fakeCredentialForDetect{name: "present"},
+			hostPatterns:            []string{"present.example.com"},
+		}
+		absent := &fakeCredentialWithHosts{
+			fakeCredentialForDetect: fakeCredentialForDetect{name: "absent"},
+			hostPatterns:            []string{"absent.example.com"},
+		}
+		reg := credential.NewRegistry()
+		_ = reg.Register(present)
+		_ = reg.Register(absent)
+
+		// Only create the dir for "present".
+		makeCredDir(t, storageDir, "ws", "present")
+
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+		result := p.collectCredentialHosts("ws", nil)
+
+		if len(result) != 1 || result[0] != "present.example.com" {
+			t.Errorf("host patterns = %v, want [present.example.com]", result)
+		}
+	})
+
+	t.Run("multiple credentials with dirs: all host patterns collected", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+
+		credA := &fakeCredentialWithHosts{
+			fakeCredentialForDetect: fakeCredentialForDetect{name: "cred-a"},
+			hostPatterns:            []string{"a1.example.com", "a2.example.com"},
+		}
+		credB := &fakeCredentialWithHosts{
+			fakeCredentialForDetect: fakeCredentialForDetect{name: "cred-b"},
+			hostPatterns:            []string{"b.example.com"},
+		}
+		reg := credential.NewRegistry()
+		_ = reg.Register(credA)
+		_ = reg.Register(credB)
+
+		makeCredDir(t, storageDir, "ws", "cred-a")
+		makeCredDir(t, storageDir, "ws", "cred-b")
+
+		p := &podmanRuntime{credentialRegistry: reg, storageDir: storageDir}
+		result := p.collectCredentialHosts("ws", nil)
+
+		if len(result) != 3 {
+			t.Fatalf("Expected 3 host patterns, got %d: %v", len(result), result)
+		}
+	})
+}
+
+// fakeCredentialWithHosts extends fakeCredentialForDetect with configurable HostPatterns.
+type fakeCredentialWithHosts struct {
+	fakeCredentialForDetect
+	hostPatterns []string
+}
+
+func (f *fakeCredentialWithHosts) HostPatterns(_ string) []string {
+	return f.hostPatterns
 }
 
 func TestStart_DenyMode_StepLogger(t *testing.T) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 
 	api "github.com/openkaiden/kdn-api/cli/go"
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/secretservice"
 )
@@ -196,6 +197,15 @@ type Terminal interface {
 // during registration, enabling them to look up host patterns for secret-derived hosts.
 type SecretServiceRegistryAware interface {
 	SetSecretServiceRegistry(secretservice.Registry)
+}
+
+// CredentialRegistryAware is an optional interface for runtimes that need the
+// credential registry to intercept file-based credential mounts and configure
+// OneCLI when those credentials are declared in workspace config.
+// Runtimes implementing this interface receive the registry via SetCredentialRegistry
+// during registration.
+type CredentialRegistryAware interface {
+	SetCredentialRegistry(credential.Registry)
 }
 
 // FlagDef describes a CLI flag that a runtime wants to expose on the init command.


### PR DESCRIPTION
Introduces a credential abstraction that intercepts sensitive credential files (e.g. gcloud ADC) declared as workspace mounts. The real file is replaced with a placeholder inside the container; OneCLI is configured to inject the real credential transparently at request time.

- pkg/credential: Credential interface and thread-safe Registry
- pkg/credential/gcloud: gcloud ADC implementation (ConnectApp → Vertex AI)
- pkg/credentialsetup: centralized registration (mirrors secretservicesetup)
- pkg/runtime/runtime.go: CredentialRegistryAware optional interface
- pkg/runtime/podman: detectCredentials, fake-file writes, intercepted-mount suppression, credential host collection for deny-mode networking, credentials/ cleanup on workspace removal
- pkg/instances/manager: RegisterCredential + CredentialRegistryAware wiring
- pkg/onecli/client.go: ConnectApp method for app provider configuration
- defaultOnecliVersion bumped to 1.20.0 (required for ConnectApp support)
- AGENTS.md and README.md updated to document the new system


To test this, in your workspace `.kaiden/workspace.json`, add the following :
```json
{
 ...
"environment": [
    { "name": "CLAUDE_CODE_USE_VERTEX", "value": "1" },
    { "name": "ANTHROPIC_VERTEX_PROJECT_ID", "value": "your real ANTHROPIC_VERTEX_PROJECT_ID" },
    { "name": "CLOUD_ML_REGION", "value": "global" }
  ],
  "network": {
    "mode": "deny"
  },
  "mounts": [
    {
      "host": "$HOME/.config/gcloud",
      "target": "$HOME/.config/gcloud"
    }
  ]
}
```

- Check that hosts have been automatically added in the file ~/config.json of the approval-handler container.
- Check that the file `~/.config/gcloud/application_default_credentials.json` contains placeholders
- check that claude can work correctly

Alternatively, you should be able to target a non default auth file like :
```
  "mounts": [
    {
      "host": "/path/to/auth.json",
      "target": "$HOME/.config/gcloud/application_default_credentials.json"
    }
  ]
```

Fixes #411
Fixes #424 