### PR TITLE
feat(agent): pre-approve placeholder API key in Claude settings

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -49,4 +49,11 @@ type Agent interface {
 	// If mcp is nil, settings are returned unchanged.
 	// Returns the modified settings map, or an error if modification fails.
 	SetMCPServers(settings map[string][]byte, mcp *workspace.McpConfiguration) (map[string][]byte, error)
+	// ApprovePresetKey adds the given key values to the agent's approved preset API keys list.
+	// It takes the current agent settings map (path -> content) and a list of key values to approve,
+	// and returns the modified settings with the keys added to the approved list.
+	// If the agent does not support preset key approval, settings are returned unchanged.
+	// If approvedKeys is empty, settings are returned unchanged.
+	// Returns the modified settings map, or an error if modification fails.
+	ApprovePresetKey(settings map[string][]byte, approvedKeys []string) (map[string][]byte, error)
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -27,11 +27,11 @@ type Agent interface {
 	// Name returns the agent name (e.g., "claude", "goose").
 	Name() string
 	// SkipOnboarding modifies agent settings to skip onboarding prompts.
-	// It takes the current agent settings map (path -> content) and the workspace
-	// sources path inside the container, and returns the modified settings with
-	// onboarding flags set appropriately.
+	// It takes the current agent settings map (path -> content), the workspace
+	// sources path inside the container, and an optional list of API key values
+	// to pre-approve so the agent does not prompt the user about them.
 	// Returns the modified settings map, or an error if modification fails.
-	SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string) (map[string][]byte, error)
+	SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string, approvedKeys []string) (map[string][]byte, error)
 	// SetModel configures the model ID in the agent settings.
 	// It takes the current agent settings map (path -> content) and the model ID,
 	// and returns the modified settings with the model configured.
@@ -49,11 +49,4 @@ type Agent interface {
 	// If mcp is nil, settings are returned unchanged.
 	// Returns the modified settings map, or an error if modification fails.
 	SetMCPServers(settings map[string][]byte, mcp *workspace.McpConfiguration) (map[string][]byte, error)
-	// ApprovePresetKey adds the given key values to the agent's approved preset API keys list.
-	// It takes the current agent settings map (path -> content) and a list of key values to approve,
-	// and returns the modified settings with the keys added to the approved list.
-	// If the agent does not support preset key approval, settings are returned unchanged.
-	// If approvedKeys is empty, settings are returned unchanged.
-	// Returns the modified settings map, or an error if modification fails.
-	ApprovePresetKey(settings map[string][]byte, approvedKeys []string) (map[string][]byte, error)
 }

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -21,6 +21,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	kdnconfig "github.com/openkaiden/kdn/pkg/config"
@@ -185,6 +186,66 @@ func (c *claudeAgent) SetMCPServers(settings map[string][]byte, mcp *workspace.M
 	if len(mcpServers) > 0 {
 		config["mcpServers"] = mcpServers
 	}
+
+	modifiedContent, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal modified %s: %w", ClaudeJSONPath, err)
+	}
+
+	settings[ClaudeJSONPath] = modifiedContent
+	return settings, nil
+}
+
+// ApprovePresetKey adds the given key values to customApiKeyResponses.approved in .claude.json.
+// Existing approved entries are preserved; duplicates are removed.
+func (c *claudeAgent) ApprovePresetKey(settings map[string][]byte, approvedKeys []string) (map[string][]byte, error) {
+	if len(approvedKeys) == 0 {
+		return settings, nil
+	}
+	if settings == nil {
+		settings = make(map[string][]byte)
+	}
+
+	var existingContent []byte
+	var exists bool
+	if existingContent, exists = settings[ClaudeJSONPath]; !exists {
+		existingContent = []byte("{}")
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(existingContent, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing %s: %w", ClaudeJSONPath, err)
+	}
+
+	customApiKeyResponses := make(map[string]interface{})
+	if raw, ok := config["customApiKeyResponses"]; ok {
+		if m, ok := raw.(map[string]interface{}); ok {
+			customApiKeyResponses = m
+		}
+	}
+
+	seen := make(map[string]struct{})
+	if raw, ok := customApiKeyResponses["approved"]; ok {
+		if slice, ok := raw.([]interface{}); ok {
+			for _, v := range slice {
+				if s, ok := v.(string); ok {
+					seen[s] = struct{}{}
+				}
+			}
+		}
+	}
+	for _, k := range approvedKeys {
+		seen[k] = struct{}{}
+	}
+
+	approved := make([]string, 0, len(seen))
+	for k := range seen {
+		approved = append(approved, k)
+	}
+	sort.Strings(approved)
+
+	customApiKeyResponses["approved"] = approved
+	config["customApiKeyResponses"] = customApiKeyResponses
 
 	modifiedContent, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -51,9 +51,10 @@ func (c *claudeAgent) Name() string {
 }
 
 // SkipOnboarding modifies Claude settings to skip onboarding prompts.
-// It sets hasCompletedOnboarding to true and marks the workspace sources
-// directory as trusted. All other fields in the settings file are preserved.
-func (c *claudeAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string) (map[string][]byte, error) {
+// It sets hasCompletedOnboarding to true, marks the workspace sources
+// directory as trusted, and pre-approves any provided API key values
+// in customApiKeyResponses.approved. All other fields are preserved.
+func (c *claudeAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string, approvedKeys []string) (map[string][]byte, error) {
 	if settings == nil {
 		settings = make(map[string][]byte)
 	}
@@ -101,6 +102,39 @@ func (c *claudeAgent) SkipOnboarding(settings map[string][]byte, workspaceSource
 	// Set hasTrustDialogAccepted while preserving other fields
 	projectSettings["hasTrustDialogAccepted"] = true
 	projects[workspaceSourcesPath] = projectSettings
+
+	// Pre-approve API key values so Claude does not prompt the user about them
+	if len(approvedKeys) > 0 {
+		customApiKeyResponses := make(map[string]interface{})
+		if raw, ok := config["customApiKeyResponses"]; ok {
+			if m, ok := raw.(map[string]interface{}); ok {
+				customApiKeyResponses = m
+			}
+		}
+
+		seen := make(map[string]struct{})
+		if raw, ok := customApiKeyResponses["approved"]; ok {
+			if slice, ok := raw.([]interface{}); ok {
+				for _, v := range slice {
+					if s, ok := v.(string); ok {
+						seen[s] = struct{}{}
+					}
+				}
+			}
+		}
+		for _, k := range approvedKeys {
+			seen[k] = struct{}{}
+		}
+
+		approved := make([]string, 0, len(seen))
+		for k := range seen {
+			approved = append(approved, k)
+		}
+		sort.Strings(approved)
+
+		customApiKeyResponses["approved"] = approved
+		config["customApiKeyResponses"] = customApiKeyResponses
+	}
 
 	// Marshal final result
 	modifiedContent, err := json.MarshalIndent(config, "", "  ")
@@ -186,66 +220,6 @@ func (c *claudeAgent) SetMCPServers(settings map[string][]byte, mcp *workspace.M
 	if len(mcpServers) > 0 {
 		config["mcpServers"] = mcpServers
 	}
-
-	modifiedContent, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal modified %s: %w", ClaudeJSONPath, err)
-	}
-
-	settings[ClaudeJSONPath] = modifiedContent
-	return settings, nil
-}
-
-// ApprovePresetKey adds the given key values to customApiKeyResponses.approved in .claude.json.
-// Existing approved entries are preserved; duplicates are removed.
-func (c *claudeAgent) ApprovePresetKey(settings map[string][]byte, approvedKeys []string) (map[string][]byte, error) {
-	if len(approvedKeys) == 0 {
-		return settings, nil
-	}
-	if settings == nil {
-		settings = make(map[string][]byte)
-	}
-
-	var existingContent []byte
-	var exists bool
-	if existingContent, exists = settings[ClaudeJSONPath]; !exists {
-		existingContent = []byte("{}")
-	}
-
-	var config map[string]interface{}
-	if err := json.Unmarshal(existingContent, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse existing %s: %w", ClaudeJSONPath, err)
-	}
-
-	customApiKeyResponses := make(map[string]interface{})
-	if raw, ok := config["customApiKeyResponses"]; ok {
-		if m, ok := raw.(map[string]interface{}); ok {
-			customApiKeyResponses = m
-		}
-	}
-
-	seen := make(map[string]struct{})
-	if raw, ok := customApiKeyResponses["approved"]; ok {
-		if slice, ok := raw.([]interface{}); ok {
-			for _, v := range slice {
-				if s, ok := v.(string); ok {
-					seen[s] = struct{}{}
-				}
-			}
-		}
-	}
-	for _, k := range approvedKeys {
-		seen[k] = struct{}{}
-	}
-
-	approved := make([]string, 0, len(seen))
-	for k := range seen {
-		approved = append(approved, k)
-	}
-	sort.Strings(approved)
-
-	customApiKeyResponses["approved"] = approved
-	config["customApiKeyResponses"] = customApiKeyResponses
 
 	modifiedContent, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -893,3 +893,175 @@ func TestClaude_SetMCPServers_InvalidJSON(t *testing.T) {
 		t.Error("Expected error for invalid JSON, got nil")
 	}
 }
+
+func TestClaude_ApprovePresetKey_NoExistingSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	settings := make(map[string][]byte)
+
+	result, err := agent.ApprovePresetKey(settings, []string{"placeholder"})
+	if err != nil {
+		t.Fatalf("ApprovePresetKey() error = %v", err)
+	}
+
+	claudeJSON, exists := result[ClaudeJSONPath]
+	if !exists {
+		t.Fatalf("Expected %s to be created", ClaudeJSONPath)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(claudeJSON, &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	resp, ok := config["customApiKeyResponses"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("customApiKeyResponses missing or wrong type: %v", config["customApiKeyResponses"])
+	}
+	approved, ok := resp["approved"].([]interface{})
+	if !ok || len(approved) != 1 || approved[0] != "placeholder" {
+		t.Errorf("approved = %v, want [placeholder]", resp["approved"])
+	}
+}
+
+func TestClaude_ApprovePresetKey_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+
+	result, err := agent.ApprovePresetKey(nil, []string{"placeholder"})
+	if err != nil {
+		t.Fatalf("ApprovePresetKey() error = %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected non-nil result map")
+	}
+
+	if _, exists := result[ClaudeJSONPath]; !exists {
+		t.Errorf("Expected %s to be created", ClaudeJSONPath)
+	}
+}
+
+func TestClaude_ApprovePresetKey_EmptyKeys(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	settings := map[string][]byte{
+		ClaudeJSONPath: []byte(`{"existingField": "value"}`),
+	}
+
+	result, err := agent.ApprovePresetKey(settings, []string{})
+	if err != nil {
+		t.Fatalf("ApprovePresetKey() error = %v", err)
+	}
+
+	// settings returned unchanged — no customApiKeyResponses added
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+	if _, ok := config["customApiKeyResponses"]; ok {
+		t.Error("customApiKeyResponses should not be present when no keys provided")
+	}
+}
+
+func TestClaude_ApprovePresetKey_PreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	existing := map[string]interface{}{
+		"hasCompletedOnboarding": true,
+		"someOtherField":         "keep me",
+	}
+	existingJSON, _ := json.Marshal(existing)
+
+	result, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: existingJSON}, []string{"placeholder"})
+	if err != nil {
+		t.Fatalf("ApprovePresetKey() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	if v, ok := config["hasCompletedOnboarding"].(bool); !ok || !v {
+		t.Errorf("hasCompletedOnboarding = %v, want true", config["hasCompletedOnboarding"])
+	}
+	if v, ok := config["someOtherField"].(string); !ok || v != "keep me" {
+		t.Errorf("someOtherField = %v, want %q", config["someOtherField"], "keep me")
+	}
+}
+
+func TestClaude_ApprovePresetKey_MergesWithExisting(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	existing := map[string]interface{}{
+		"customApiKeyResponses": map[string]interface{}{
+			"approved": []interface{}{"existing-key"},
+		},
+	}
+	existingJSON, _ := json.Marshal(existing)
+
+	result, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: existingJSON}, []string{"placeholder"})
+	if err != nil {
+		t.Fatalf("ApprovePresetKey() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	resp := config["customApiKeyResponses"].(map[string]interface{})
+	approved := resp["approved"].([]interface{})
+	if len(approved) != 2 {
+		t.Fatalf("approved len = %d, want 2: %v", len(approved), approved)
+	}
+	// sorted: existing-key, placeholder
+	if approved[0] != "existing-key" || approved[1] != "placeholder" {
+		t.Errorf("approved = %v, want [existing-key placeholder]", approved)
+	}
+}
+
+func TestClaude_ApprovePresetKey_Deduplicates(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+	existing := map[string]interface{}{
+		"customApiKeyResponses": map[string]interface{}{
+			"approved": []interface{}{"placeholder"},
+		},
+	}
+	existingJSON, _ := json.Marshal(existing)
+
+	result, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: existingJSON}, []string{"placeholder", "placeholder"})
+	if err != nil {
+		t.Fatalf("ApprovePresetKey() error = %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
+		t.Fatalf("Failed to parse result JSON: %v", err)
+	}
+
+	resp := config["customApiKeyResponses"].(map[string]interface{})
+	approved := resp["approved"].([]interface{})
+	if len(approved) != 1 || approved[0] != "placeholder" {
+		t.Errorf("approved = %v, want [placeholder]", approved)
+	}
+}
+
+func TestClaude_ApprovePresetKey_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	agent := NewClaude()
+
+	_, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: []byte("invalid json {{{")}, []string{"placeholder"})
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -40,7 +40,7 @@ func TestClaude_SkipOnboarding_NoExistingSettings(t *testing.T) {
 	agent := NewClaude()
 	settings := make(map[string][]byte)
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -83,7 +83,7 @@ func TestClaude_SkipOnboarding_NilSettings(t *testing.T) {
 
 	agent := NewClaude()
 
-	result, err := agent.SkipOnboarding(nil, "/workspace/sources")
+	result, err := agent.SkipOnboarding(nil, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -128,7 +128,7 @@ func TestClaude_SkipOnboarding_PreservesUnknownFields(t *testing.T) {
 		ClaudeJSONPath: existingJSON,
 	}
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -222,7 +222,7 @@ func TestClaude_SkipOnboarding_DifferentWorkspacePaths(t *testing.T) {
 			agent := NewClaude()
 			settings := make(map[string][]byte)
 
-			result, err := agent.SkipOnboarding(settings, tc.workspacePath)
+			result, err := agent.SkipOnboarding(settings, tc.workspacePath, nil)
 			if err != nil {
 				t.Fatalf("SkipOnboarding() error = %v", err)
 			}
@@ -274,7 +274,7 @@ func TestClaude_SkipOnboarding_UpdatesExistingProject(t *testing.T) {
 		ClaudeJSONPath: existingJSON,
 	}
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -314,7 +314,7 @@ func TestClaude_SkipOnboarding_InvalidJSON(t *testing.T) {
 		ClaudeJSONPath: []byte("invalid json {{{"),
 	}
 
-	_, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	_, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got nil")
 	}
@@ -326,7 +326,7 @@ func TestClaude_SkipOnboarding_EmptyWorkspacePath(t *testing.T) {
 	agent := NewClaude()
 	settings := make(map[string][]byte)
 
-	result, err := agent.SkipOnboarding(settings, "")
+	result, err := agent.SkipOnboarding(settings, "", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -894,24 +894,18 @@ func TestClaude_SetMCPServers_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestClaude_ApprovePresetKey_NoExistingSettings(t *testing.T) {
+func TestClaude_SkipOnboarding_SetsApprovedKeys(t *testing.T) {
 	t.Parallel()
 
 	agent := NewClaude()
-	settings := make(map[string][]byte)
 
-	result, err := agent.ApprovePresetKey(settings, []string{"placeholder"})
+	result, err := agent.SkipOnboarding(make(map[string][]byte), "/workspace/sources", []string{"placeholder"})
 	if err != nil {
-		t.Fatalf("ApprovePresetKey() error = %v", err)
-	}
-
-	claudeJSON, exists := result[ClaudeJSONPath]
-	if !exists {
-		t.Fatalf("Expected %s to be created", ClaudeJSONPath)
+		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
 
 	var config map[string]interface{}
-	if err := json.Unmarshal(claudeJSON, &config); err != nil {
+	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
 		t.Fatalf("Failed to parse result JSON: %v", err)
 	}
 
@@ -925,39 +919,16 @@ func TestClaude_ApprovePresetKey_NoExistingSettings(t *testing.T) {
 	}
 }
 
-func TestClaude_ApprovePresetKey_NilSettings(t *testing.T) {
+func TestClaude_SkipOnboarding_NilApprovedKeys(t *testing.T) {
 	t.Parallel()
 
 	agent := NewClaude()
 
-	result, err := agent.ApprovePresetKey(nil, []string{"placeholder"})
+	result, err := agent.SkipOnboarding(nil, "/workspace/sources", nil)
 	if err != nil {
-		t.Fatalf("ApprovePresetKey() error = %v", err)
+		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
 
-	if result == nil {
-		t.Fatal("Expected non-nil result map")
-	}
-
-	if _, exists := result[ClaudeJSONPath]; !exists {
-		t.Errorf("Expected %s to be created", ClaudeJSONPath)
-	}
-}
-
-func TestClaude_ApprovePresetKey_EmptyKeys(t *testing.T) {
-	t.Parallel()
-
-	agent := NewClaude()
-	settings := map[string][]byte{
-		ClaudeJSONPath: []byte(`{"existingField": "value"}`),
-	}
-
-	result, err := agent.ApprovePresetKey(settings, []string{})
-	if err != nil {
-		t.Fatalf("ApprovePresetKey() error = %v", err)
-	}
-
-	// settings returned unchanged — no customApiKeyResponses added
 	var config map[string]interface{}
 	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
 		t.Fatalf("Failed to parse result JSON: %v", err)
@@ -967,35 +938,29 @@ func TestClaude_ApprovePresetKey_EmptyKeys(t *testing.T) {
 	}
 }
 
-func TestClaude_ApprovePresetKey_PreservesExistingFields(t *testing.T) {
+func TestClaude_SkipOnboarding_EmptyApprovedKeys(t *testing.T) {
 	t.Parallel()
 
 	agent := NewClaude()
-	existing := map[string]interface{}{
-		"hasCompletedOnboarding": true,
-		"someOtherField":         "keep me",
+	settings := map[string][]byte{
+		ClaudeJSONPath: []byte(`{"existingField": "value"}`),
 	}
-	existingJSON, _ := json.Marshal(existing)
 
-	result, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: existingJSON}, []string{"placeholder"})
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", []string{})
 	if err != nil {
-		t.Fatalf("ApprovePresetKey() error = %v", err)
+		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
 
 	var config map[string]interface{}
 	if err := json.Unmarshal(result[ClaudeJSONPath], &config); err != nil {
 		t.Fatalf("Failed to parse result JSON: %v", err)
 	}
-
-	if v, ok := config["hasCompletedOnboarding"].(bool); !ok || !v {
-		t.Errorf("hasCompletedOnboarding = %v, want true", config["hasCompletedOnboarding"])
-	}
-	if v, ok := config["someOtherField"].(string); !ok || v != "keep me" {
-		t.Errorf("someOtherField = %v, want %q", config["someOtherField"], "keep me")
+	if _, ok := config["customApiKeyResponses"]; ok {
+		t.Error("customApiKeyResponses should not be present when no keys provided")
 	}
 }
 
-func TestClaude_ApprovePresetKey_MergesWithExisting(t *testing.T) {
+func TestClaude_SkipOnboarding_ApprovedKeysMergesWithExisting(t *testing.T) {
 	t.Parallel()
 
 	agent := NewClaude()
@@ -1006,9 +971,9 @@ func TestClaude_ApprovePresetKey_MergesWithExisting(t *testing.T) {
 	}
 	existingJSON, _ := json.Marshal(existing)
 
-	result, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: existingJSON}, []string{"placeholder"})
+	result, err := agent.SkipOnboarding(map[string][]byte{ClaudeJSONPath: existingJSON}, "/workspace/sources", []string{"placeholder"})
 	if err != nil {
-		t.Fatalf("ApprovePresetKey() error = %v", err)
+		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
 
 	var config map[string]interface{}
@@ -1027,7 +992,7 @@ func TestClaude_ApprovePresetKey_MergesWithExisting(t *testing.T) {
 	}
 }
 
-func TestClaude_ApprovePresetKey_Deduplicates(t *testing.T) {
+func TestClaude_SkipOnboarding_ApprovedKeysDeduplicates(t *testing.T) {
 	t.Parallel()
 
 	agent := NewClaude()
@@ -1038,9 +1003,9 @@ func TestClaude_ApprovePresetKey_Deduplicates(t *testing.T) {
 	}
 	existingJSON, _ := json.Marshal(existing)
 
-	result, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: existingJSON}, []string{"placeholder", "placeholder"})
+	result, err := agent.SkipOnboarding(map[string][]byte{ClaudeJSONPath: existingJSON}, "/workspace/sources", []string{"placeholder", "placeholder"})
 	if err != nil {
-		t.Fatalf("ApprovePresetKey() error = %v", err)
+		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
 
 	var config map[string]interface{}
@@ -1052,16 +1017,5 @@ func TestClaude_ApprovePresetKey_Deduplicates(t *testing.T) {
 	approved := resp["approved"].([]interface{})
 	if len(approved) != 1 || approved[0] != "placeholder" {
 		t.Errorf("approved = %v, want [placeholder]", approved)
-	}
-}
-
-func TestClaude_ApprovePresetKey_InvalidJSON(t *testing.T) {
-	t.Parallel()
-
-	agent := NewClaude()
-
-	_, err := agent.ApprovePresetKey(map[string][]byte{ClaudeJSONPath: []byte("invalid json {{{")}, []string{"placeholder"})
-	if err == nil {
-		t.Error("Expected error for invalid JSON, got nil")
 	}
 }

--- a/pkg/agent/cursor.go
+++ b/pkg/agent/cursor.go
@@ -83,6 +83,12 @@ func (c *cursorAgent) SetMCPServers(settings map[string][]byte, _ *workspace.Mcp
 	return settings, nil
 }
 
+// ApprovePresetKey returns the settings unchanged, as Cursor does not support preset key approval
+// through agent settings files.
+func (c *cursorAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
+	return settings, nil
+}
+
 // SetModel configures the model ID in Cursor settings.
 // It sets the model object in cli-config.json with the specified model ID.
 // All other fields in the settings file are preserved.

--- a/pkg/agent/cursor.go
+++ b/pkg/agent/cursor.go
@@ -50,7 +50,7 @@ func (c *cursorAgent) Name() string {
 // SkipOnboarding modifies Cursor settings to skip onboarding prompts.
 // It creates a .workspace-trusted file in the Cursor projects directory
 // for the given workspace sources path.
-func (c *cursorAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string) (map[string][]byte, error) {
+func (c *cursorAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string, _ []string) (map[string][]byte, error) {
 	if settings == nil {
 		settings = make(map[string][]byte)
 	}
@@ -80,12 +80,6 @@ func (c *cursorAgent) SkillsDir() string {
 // SetMCPServers returns the settings unchanged, as Cursor does not support MCP configuration
 // through agent settings files.
 func (c *cursorAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
-	return settings, nil
-}
-
-// ApprovePresetKey returns the settings unchanged, as Cursor does not support preset key approval
-// through agent settings files.
-func (c *cursorAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 

--- a/pkg/agent/cursor_test.go
+++ b/pkg/agent/cursor_test.go
@@ -40,7 +40,7 @@ func TestCursor_SkipOnboarding_NoExistingSettings(t *testing.T) {
 	settings := make(map[string][]byte)
 
 	before := time.Now().UTC()
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	after := time.Now().UTC()
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
@@ -79,7 +79,7 @@ func TestCursor_SkipOnboarding_NilSettings(t *testing.T) {
 
 	agent := NewCursor()
 
-	result, err := agent.SkipOnboarding(nil, "/workspace/sources")
+	result, err := agent.SkipOnboarding(nil, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -126,7 +126,7 @@ func TestCursor_SkipOnboarding_DifferentWorkspacePaths(t *testing.T) {
 			agent := NewCursor()
 			settings := make(map[string][]byte)
 
-			result, err := agent.SkipOnboarding(settings, tc.workspacePath)
+			result, err := agent.SkipOnboarding(settings, tc.workspacePath, nil)
 			if err != nil {
 				t.Fatalf("SkipOnboarding() error = %v", err)
 			}
@@ -158,7 +158,7 @@ func TestCursor_SkipOnboarding_PreservesExistingSettings(t *testing.T) {
 		"some/other/file": []byte("existing content"),
 	}
 
-	result, err := agent.SkipOnboarding(existingSettings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(existingSettings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}

--- a/pkg/agent/goose.go
+++ b/pkg/agent/goose.go
@@ -94,6 +94,12 @@ func (g *gooseAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpC
 	return settings, nil
 }
 
+// ApprovePresetKey returns the settings unchanged, as Goose does not support preset key approval
+// through agent settings files.
+func (g *gooseAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
+	return settings, nil
+}
+
 // SetModel configures the model ID in Goose settings.
 // It sets the GOOSE_MODEL key in the config file.
 // All other fields in the settings file are preserved.

--- a/pkg/agent/goose.go
+++ b/pkg/agent/goose.go
@@ -54,7 +54,7 @@ func (g *gooseAgent) Name() string {
 // It sets GOOSE_TELEMETRY_ENABLED to false in the goose config file if the
 // value is not already defined. If the user has already set it in their own
 // config file, the existing value is preserved.
-func (g *gooseAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[string][]byte, error) {
+func (g *gooseAgent) SkipOnboarding(settings map[string][]byte, _ string, _ []string) (map[string][]byte, error) {
 	if settings == nil {
 		settings = make(map[string][]byte)
 	}
@@ -91,12 +91,6 @@ func (g *gooseAgent) SkillsDir() string {
 // SetMCPServers returns the settings unchanged, as Goose does not support MCP configuration
 // through agent settings files.
 func (g *gooseAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
-	return settings, nil
-}
-
-// ApprovePresetKey returns the settings unchanged, as Goose does not support preset key approval
-// through agent settings files.
-func (g *gooseAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 

--- a/pkg/agent/goose_test.go
+++ b/pkg/agent/goose_test.go
@@ -39,7 +39,7 @@ func TestGoose_SkipOnboarding_NoExistingSettings(t *testing.T) {
 	agent := NewGoose()
 	settings := make(map[string][]byte)
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -66,7 +66,7 @@ func TestGoose_SkipOnboarding_NilSettings(t *testing.T) {
 
 	agent := NewGoose()
 
-	result, err := agent.SkipOnboarding(nil, "/workspace/sources")
+	result, err := agent.SkipOnboarding(nil, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -90,7 +90,7 @@ func TestGoose_SkipOnboarding_PreservesExistingTelemetryTrue(t *testing.T) {
 		GooseConfigPath: existingContent,
 	}
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -117,7 +117,7 @@ func TestGoose_SkipOnboarding_PreservesExistingTelemetryFalse(t *testing.T) {
 		GooseConfigPath: existingContent,
 	}
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -144,7 +144,7 @@ func TestGoose_SkipOnboarding_PreservesOtherFields(t *testing.T) {
 		GooseConfigPath: existingContent,
 	}
 
-	result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err != nil {
 		t.Fatalf("SkipOnboarding() error = %v", err)
 	}
@@ -178,7 +178,7 @@ func TestGoose_SkipOnboarding_InvalidYAML(t *testing.T) {
 		GooseConfigPath: []byte("invalid: yaml: :::"),
 	}
 
-	_, err := agent.SkipOnboarding(settings, "/workspace/sources")
+	_, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 	if err == nil {
 		t.Error("Expected error for invalid YAML, got nil")
 	}

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -125,6 +125,12 @@ func (o *openCodeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.M
 	return settings, nil
 }
 
+// ApprovePresetKey returns the settings unchanged, as OpenCode does not support preset key approval
+// through agent settings files.
+func (o *openCodeAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
+	return settings, nil
+}
+
 // configureProvider adds a provider block with the given base URL and registers the model.
 func configureProvider(config map[string]interface{}, provider, modelName, baseURL string) error {
 	providers, _ := config["provider"].(map[string]interface{})

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -50,7 +50,7 @@ func (o *openCodeAgent) Name() string {
 
 // SkipOnboarding returns the settings unchanged since OpenCode does not
 // require onboarding configuration.
-func (o *openCodeAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[string][]byte, error) {
+func (o *openCodeAgent) SkipOnboarding(settings map[string][]byte, _ string, _ []string) (map[string][]byte, error) {
 	if settings == nil {
 		settings = make(map[string][]byte)
 	}
@@ -122,12 +122,6 @@ func (o *openCodeAgent) SkillsDir() string {
 // SetMCPServers returns the settings unchanged, as OpenCode does not support MCP configuration
 // through agent settings files.
 func (o *openCodeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
-	return settings, nil
-}
-
-// ApprovePresetKey returns the settings unchanged, as OpenCode does not support preset key approval
-// through agent settings files.
-func (o *openCodeAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -43,7 +43,7 @@ func TestOpenCode_SkipOnboarding(t *testing.T) {
 		agent := NewOpenCode()
 		settings := make(map[string][]byte)
 
-		result, err := agent.SkipOnboarding(settings, "/workspace/sources")
+		result, err := agent.SkipOnboarding(settings, "/workspace/sources", nil)
 		if err != nil {
 			t.Fatalf("SkipOnboarding() error = %v", err)
 		}
@@ -58,7 +58,7 @@ func TestOpenCode_SkipOnboarding(t *testing.T) {
 
 		agent := NewOpenCode()
 
-		result, err := agent.SkipOnboarding(nil, "/workspace/sources")
+		result, err := agent.SkipOnboarding(nil, "/workspace/sources", nil)
 		if err != nil {
 			t.Fatalf("SkipOnboarding() error = %v", err)
 		}
@@ -77,7 +77,7 @@ func TestOpenCode_SkipOnboarding(t *testing.T) {
 			"some/other/file": []byte("existing content"),
 		}
 
-		result, err := agent.SkipOnboarding(existingSettings, "/workspace/sources")
+		result, err := agent.SkipOnboarding(existingSettings, "/workspace/sources", nil)
 		if err != nil {
 			t.Fatalf("SkipOnboarding() error = %v", err)
 		}

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -50,6 +50,10 @@ func (f *fakeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpCo
 	return settings, nil
 }
 
+func (f *fakeAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
+	return settings, nil
+}
+
 func TestNewRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -34,7 +34,7 @@ func (f *fakeAgent) Name() string {
 	return f.name
 }
 
-func (f *fakeAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[string][]byte, error) {
+func (f *fakeAgent) SkipOnboarding(settings map[string][]byte, _ string, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 
@@ -47,10 +47,6 @@ func (f *fakeAgent) SkillsDir() string {
 }
 
 func (f *fakeAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
-	return settings, nil
-}
-
-func (f *fakeAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -362,6 +362,24 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		}
 	}
 
+	// Apply agent-specific preset key approvals based on collected secret env var values
+	if opts.Agent != "" && len(secretEnvVars) > 0 {
+		if agentImpl, agentErr := m.agentRegistry.Get(opts.Agent); agentErr == nil {
+			seen := make(map[string]struct{})
+			var approvedKeys []string
+			for _, v := range secretEnvVars {
+				if _, ok := seen[v]; !ok {
+					seen[v] = struct{}{}
+					approvedKeys = append(approvedKeys, v)
+				}
+			}
+			agentSettings, err = agentImpl.ApprovePresetKey(agentSettings, approvedKeys)
+			if err != nil {
+				return nil, fmt.Errorf("failed to apply agent preset key settings: %w", err)
+			}
+		}
+	}
+
 	// Create runtime instance with merged configuration
 	runtimeInfo, err := rt.Create(ctx, runtime.CreateParams{
 		Name:               name,

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -274,6 +274,46 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		}
 	}
 
+	// Map workspace secrets to OneCLI secret definitions and collect env vars
+	var onecliSecrets []onecli.CreateSecretInput
+	secretEnvVars := make(map[string]string)
+	if mergedConfig != nil && mergedConfig.Secrets != nil && len(*mergedConfig.Secrets) > 0 {
+		mapper := onecli.NewSecretMapper(m.secretServiceRegistry)
+		for i, name := range *mergedConfig.Secrets {
+			item, value, err := m.secretStore.Get(name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get secret %q at index %d: %w", name, i, err)
+			}
+			inputs, err := mapper.Map(item, value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map secret %q at index %d: %w", name, i, err)
+			}
+			onecliSecrets = append(onecliSecrets, inputs...)
+
+			if item.Type != secret.TypeOther {
+				if svc, svcErr := m.secretServiceRegistry.Get(item.Type); svcErr == nil {
+					for _, envVar := range svc.EnvVars() {
+						secretEnvVars[envVar] = "placeholder"
+					}
+				}
+			} else {
+				for _, envVar := range item.Envs {
+					secretEnvVars[envVar] = "placeholder"
+				}
+			}
+		}
+	}
+
+	// Collect unique placeholder values for pre-approving injected API keys
+	seen := make(map[string]struct{})
+	var approvedKeys []string
+	for _, v := range secretEnvVars {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			approvedKeys = append(approvedKeys, v)
+		}
+	}
+
 	// Read agent settings files from storage config directory
 	agentSettings, err := m.readAgentSettings(m.storageDir, opts.Agent)
 	if err != nil {
@@ -285,7 +325,7 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		if agentImpl, err := m.agentRegistry.Get(opts.Agent); err == nil {
 			// Get workspace sources path from runtime before creating instance
 			workspaceSourcesPath := rt.WorkspaceSourcesPath()
-			agentSettings, err = agentImpl.SkipOnboarding(agentSettings, workspaceSourcesPath)
+			agentSettings, err = agentImpl.SkipOnboarding(agentSettings, workspaceSourcesPath, approvedKeys)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply agent onboarding settings: %w", err)
 			}
@@ -330,54 +370,6 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 			}
 		}
 		// If agent not found in registry, use settings as-is (not all agents may be implemented)
-	}
-
-	// Map workspace secrets to OneCLI secret definitions and collect env vars
-	var onecliSecrets []onecli.CreateSecretInput
-	secretEnvVars := make(map[string]string)
-	if mergedConfig != nil && mergedConfig.Secrets != nil && len(*mergedConfig.Secrets) > 0 {
-		mapper := onecli.NewSecretMapper(m.secretServiceRegistry)
-		for i, name := range *mergedConfig.Secrets {
-			item, value, err := m.secretStore.Get(name)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get secret %q at index %d: %w", name, i, err)
-			}
-			inputs, err := mapper.Map(item, value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map secret %q at index %d: %w", name, i, err)
-			}
-			onecliSecrets = append(onecliSecrets, inputs...)
-
-			if item.Type != secret.TypeOther {
-				if svc, svcErr := m.secretServiceRegistry.Get(item.Type); svcErr == nil {
-					for _, envVar := range svc.EnvVars() {
-						secretEnvVars[envVar] = "placeholder"
-					}
-				}
-			} else {
-				for _, envVar := range item.Envs {
-					secretEnvVars[envVar] = "placeholder"
-				}
-			}
-		}
-	}
-
-	// Apply agent-specific preset key approvals based on collected secret env var values
-	if opts.Agent != "" && len(secretEnvVars) > 0 {
-		if agentImpl, agentErr := m.agentRegistry.Get(opts.Agent); agentErr == nil {
-			seen := make(map[string]struct{})
-			var approvedKeys []string
-			for _, v := range secretEnvVars {
-				if _, ok := seen[v]; !ok {
-					seen[v] = struct{}{}
-					approvedKeys = append(approvedKeys, v)
-				}
-			}
-			agentSettings, err = agentImpl.ApprovePresetKey(agentSettings, approvedKeys)
-			if err != nil {
-				return nil, fmt.Errorf("failed to apply agent preset key settings: %w", err)
-			}
-		}
 	}
 
 	// Create runtime instance with merged configuration

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -297,6 +297,10 @@ func (t *trackingAgent) SetMCPServers(settings map[string][]byte, _ *workspace.M
 	return settings, nil
 }
 
+func (t *trackingAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
+	return settings, nil
+}
+
 func (t *trackingAgent) WasSetMCPServersCalled() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -345,6 +349,10 @@ func (e *erroringSetModelAgent) SkillsDir() string {
 }
 
 func (e *erroringSetModelAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
+	return settings, nil
+}
+
+func (e *erroringSetModelAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -251,7 +251,7 @@ func (t *trackingAgent) Name() string {
 	return t.name
 }
 
-func (t *trackingAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string) (map[string][]byte, error) {
+func (t *trackingAgent) SkipOnboarding(settings map[string][]byte, workspaceSourcesPath string, _ []string) (map[string][]byte, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.skipOnboardingCalled = true
@@ -297,10 +297,6 @@ func (t *trackingAgent) SetMCPServers(settings map[string][]byte, _ *workspace.M
 	return settings, nil
 }
 
-func (t *trackingAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
-	return settings, nil
-}
-
 func (t *trackingAgent) WasSetMCPServersCalled() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -333,7 +329,7 @@ func (e *erroringSetModelAgent) Name() string {
 	return e.name
 }
 
-func (e *erroringSetModelAgent) SkipOnboarding(settings map[string][]byte, _ string) (map[string][]byte, error) {
+func (e *erroringSetModelAgent) SkipOnboarding(settings map[string][]byte, _ string, _ []string) (map[string][]byte, error) {
 	if settings == nil {
 		settings = make(map[string][]byte)
 	}
@@ -349,10 +345,6 @@ func (e *erroringSetModelAgent) SkillsDir() string {
 }
 
 func (e *erroringSetModelAgent) SetMCPServers(settings map[string][]byte, _ *workspace.McpConfiguration) (map[string][]byte, error) {
-	return settings, nil
-}
-
-func (e *erroringSetModelAgent) ApprovePresetKey(settings map[string][]byte, _ []string) (map[string][]byte, error) {
 	return settings, nil
 }
 


### PR DESCRIPTION
Claude prompts the user to approve an API key the first time it sees a
value it doesn't recognise. When kdn injects ANTHROPIC_API_KEY=placeholder
via secret env vars, Claude would halt and ask — this bakes the approval
into .claude.json at image-build time so the prompt never appears.

- Add ApprovePresetKey to the Agent interface
- Implement for Claude: writes customApiKeyResponses.approved to
  .claude.json, merging with any existing entries and deduplicating
- No-op stubs for Cursor, Goose, OpenCode
- Call site in manager.Add after secrets are collected, passing the
  unique set of placeholder values from secretEnvVars

fixes https://github.com/openkaiden/kaiden/issues/1682
