### PR TITLE
fix(credential): remove EnvVars from Credential interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,6 @@ The credential system provides a pluggable architecture for intercepting sensiti
   - `FakeFile(hostFilePath string) ([]byte, error)` — returns placeholder file content (no real credentials)
   - `Configure(ctx, client onecli.Client, hostFilePath string) error` — reads the real file and registers the credential with OneCLI
   - `HostPatterns(hostFilePath string) []string` — hostnames OneCLI must be allowed to reach for this credential
-  - `EnvVars(hostFilePath string) map[string]string` — extra environment variables to inject into the container
 - **Registry** (`pkg/credential/registry.go`): Thread-safe ordered list; `NewRegistry() Registry`; `Register()` rejects nil, empty name, and duplicates
 - **Centralized Registration** (`pkg/credentialsetup/register.go`): `RegisterAll(registrar)` registers all built-in credentials (currently `gcloud`)
 - **`CredentialRegistryAware`** optional runtime interface (`pkg/runtime/runtime.go`): Runtimes that implement `SetCredentialRegistry(credential.Registry)` receive the registry automatically when `manager.RegisterRuntime()` is called

--- a/pkg/credential/credential.go
+++ b/pkg/credential/credential.go
@@ -58,10 +58,6 @@ type Credential interface {
 	// networking when this credential is active. hostFilePath lets dynamic
 	// implementations extract the server URL from the real credential file.
 	HostPatterns(hostFilePath string) []string
-
-	// EnvVars returns environment variables to inject into the workspace container.
-	// hostFilePath is the path to the real credential on the host.
-	EnvVars(hostFilePath string) map[string]string
 }
 
 // Registry manages Credential implementations.

--- a/pkg/credential/gcloud/gcloud.go
+++ b/pkg/credential/gcloud/gcloud.go
@@ -54,21 +54,12 @@ type adcCredentials struct {
 }
 
 // vertexAIFields returns the credential fields for the OneCLI vertex-ai connect API.
-// When QuotaProjectID is empty in the ADC file, falls back to host env vars.
 func (c *adcCredentials) vertexAIFields() map[string]string {
-	quotaProject := c.QuotaProjectID
-	if quotaProject == "" {
-		if p := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"); p != "" {
-			quotaProject = p
-		} else {
-			quotaProject = os.Getenv("GOOGLE_CLOUD_PROJECT")
-		}
-	}
 	return map[string]string{
 		"refreshToken":   c.RefreshToken,
 		"clientId":       c.ClientID,
 		"clientSecret":   c.ClientSecret,
-		"quotaProjectId": quotaProject,
+		"quotaProjectId": c.QuotaProjectID,
 	}
 }
 
@@ -163,32 +154,6 @@ func (g *gcloudCredential) HostPatterns(_ string) []string {
 	result := make([]string, len(vertexAIHosts))
 	copy(result, vertexAIHosts)
 	return result
-}
-
-// EnvVars reads Google-related env vars from the host and returns the workspace
-// env vars to inject into the container.
-//
-// Mappings:
-//   - CLOUD_ML_REGION      → CLOUD_ML_REGION, VERTEX_LOCATION
-//   - ANTHROPIC_VERTEX_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) → both vars
-func (g *gcloudCredential) EnvVars(_ string) map[string]string {
-	vars := make(map[string]string)
-
-	if region := os.Getenv("CLOUD_ML_REGION"); region != "" {
-		vars["CLOUD_ML_REGION"] = region
-		vars["VERTEX_LOCATION"] = region
-	}
-
-	projectID := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID")
-	if projectID == "" {
-		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-	}
-	if projectID != "" {
-		vars["ANTHROPIC_VERTEX_PROJECT_ID"] = projectID
-		vars["GOOGLE_CLOUD_PROJECT"] = projectID
-	}
-
-	return vars
 }
 
 // loadADC reads application_default_credentials.json from adcPath.

--- a/pkg/credential/gcloud/gcloud_test.go
+++ b/pkg/credential/gcloud/gcloud_test.go
@@ -313,56 +313,21 @@ func TestLoadADC(t *testing.T) {
 }
 
 func TestVertexAIFields(t *testing.T) {
-	t.Run("uses quota_project_id from ADC when present", func(t *testing.T) {
-		t.Parallel()
+	t.Parallel()
 
-		creds := &adcCredentials{
-			RefreshToken:   "tok",
-			ClientID:       "id",
-			ClientSecret:   "sec",
-			QuotaProjectID: "adc-project",
-		}
-		fields := creds.vertexAIFields()
-		if fields["quotaProjectId"] != "adc-project" {
-			t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "adc-project")
-		}
-		if fields["refreshToken"] != "tok" {
-			t.Errorf("refreshToken = %q, want %q", fields["refreshToken"], "tok")
-		}
-	})
-
-	t.Run("falls back to ANTHROPIC_VERTEX_PROJECT_ID when quota_project_id empty", func(t *testing.T) {
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "env-vertex-project")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "should-not-be-used")
-
-		creds := &adcCredentials{RefreshToken: "tok"}
-		fields := creds.vertexAIFields()
-		if fields["quotaProjectId"] != "env-vertex-project" {
-			t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "env-vertex-project")
-		}
-	})
-
-	t.Run("falls back to GOOGLE_CLOUD_PROJECT when ANTHROPIC_VERTEX_PROJECT_ID unset", func(t *testing.T) {
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "gcp-project")
-
-		creds := &adcCredentials{RefreshToken: "tok"}
-		fields := creds.vertexAIFields()
-		if fields["quotaProjectId"] != "gcp-project" {
-			t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "gcp-project")
-		}
-	})
-
-	t.Run("empty quotaProjectId when no env vars set", func(t *testing.T) {
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
-
-		creds := &adcCredentials{RefreshToken: "tok"}
-		fields := creds.vertexAIFields()
-		if fields["quotaProjectId"] != "" {
-			t.Errorf("quotaProjectId = %q, want empty string", fields["quotaProjectId"])
-		}
-	})
+	creds := &adcCredentials{
+		RefreshToken:   "tok",
+		ClientID:       "id",
+		ClientSecret:   "sec",
+		QuotaProjectID: "adc-project",
+	}
+	fields := creds.vertexAIFields()
+	if fields["quotaProjectId"] != "adc-project" {
+		t.Errorf("quotaProjectId = %q, want %q", fields["quotaProjectId"], "adc-project")
+	}
+	if fields["refreshToken"] != "tok" {
+		t.Errorf("refreshToken = %q, want %q", fields["refreshToken"], "tok")
+	}
 }
 
 func TestGcloudCredential_Configure(t *testing.T) {
@@ -446,80 +411,6 @@ func TestGcloudCredential_Configure(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "vertex-ai unavailable") {
 			t.Errorf("error %q does not mention 'vertex-ai unavailable'", err.Error())
-		}
-	})
-}
-
-func TestGcloudCredential_EnvVars(t *testing.T) {
-	t.Run("empty map when no env vars set", func(t *testing.T) {
-		t.Setenv("CLOUD_ML_REGION", "")
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
-
-		vars := New().EnvVars("")
-		if len(vars) != 0 {
-			t.Errorf("EnvVars() = %v, want empty map", vars)
-		}
-	})
-
-	t.Run("CLOUD_ML_REGION propagates to CLOUD_ML_REGION and VERTEX_LOCATION", func(t *testing.T) {
-		t.Setenv("CLOUD_ML_REGION", "us-central1")
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
-
-		vars := New().EnvVars("")
-		if vars["CLOUD_ML_REGION"] != "us-central1" {
-			t.Errorf("CLOUD_ML_REGION = %q, want %q", vars["CLOUD_ML_REGION"], "us-central1")
-		}
-		if vars["VERTEX_LOCATION"] != "us-central1" {
-			t.Errorf("VERTEX_LOCATION = %q, want %q", vars["VERTEX_LOCATION"], "us-central1")
-		}
-	})
-
-	t.Run("ANTHROPIC_VERTEX_PROJECT_ID propagates to both project vars", func(t *testing.T) {
-		t.Setenv("CLOUD_ML_REGION", "")
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-vertex-project")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
-
-		vars := New().EnvVars("")
-		if vars["ANTHROPIC_VERTEX_PROJECT_ID"] != "my-vertex-project" {
-			t.Errorf("ANTHROPIC_VERTEX_PROJECT_ID = %q, want %q", vars["ANTHROPIC_VERTEX_PROJECT_ID"], "my-vertex-project")
-		}
-		if vars["GOOGLE_CLOUD_PROJECT"] != "my-vertex-project" {
-			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", vars["GOOGLE_CLOUD_PROJECT"], "my-vertex-project")
-		}
-	})
-
-	t.Run("GOOGLE_CLOUD_PROJECT used when ANTHROPIC_VERTEX_PROJECT_ID unset", func(t *testing.T) {
-		t.Setenv("CLOUD_ML_REGION", "")
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "gcp-fallback")
-
-		vars := New().EnvVars("")
-		if vars["ANTHROPIC_VERTEX_PROJECT_ID"] != "gcp-fallback" {
-			t.Errorf("ANTHROPIC_VERTEX_PROJECT_ID = %q, want %q", vars["ANTHROPIC_VERTEX_PROJECT_ID"], "gcp-fallback")
-		}
-		if vars["GOOGLE_CLOUD_PROJECT"] != "gcp-fallback" {
-			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", vars["GOOGLE_CLOUD_PROJECT"], "gcp-fallback")
-		}
-	})
-
-	t.Run("all env vars set produces all four output vars", func(t *testing.T) {
-		t.Setenv("CLOUD_ML_REGION", "europe-west4")
-		t.Setenv("ANTHROPIC_VERTEX_PROJECT_ID", "full-project")
-		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
-
-		vars := New().EnvVars("")
-		for _, key := range []string{"CLOUD_ML_REGION", "VERTEX_LOCATION", "ANTHROPIC_VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"} {
-			if vars[key] == "" {
-				t.Errorf("EnvVars() missing or empty key %q", key)
-			}
-		}
-		if vars["CLOUD_ML_REGION"] != "europe-west4" {
-			t.Errorf("CLOUD_ML_REGION = %q, want %q", vars["CLOUD_ML_REGION"], "europe-west4")
-		}
-		if vars["GOOGLE_CLOUD_PROJECT"] != "full-project" {
-			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", vars["GOOGLE_CLOUD_PROJECT"], "full-project")
 		}
 	})
 }

--- a/pkg/credential/registry_test.go
+++ b/pkg/credential/registry_test.go
@@ -39,7 +39,6 @@ func (f *fakeCredential) Detect(_ []workspace.Mount, _ string) (string, *workspa
 func (f *fakeCredential) FakeFile(_ string) ([]byte, error)                            { return nil, nil }
 func (f *fakeCredential) Configure(_ context.Context, _ onecli.Client, _ string) error { return nil }
 func (f *fakeCredential) HostPatterns(_ string) []string                               { return nil }
-func (f *fakeCredential) EnvVars(_ string) map[string]string                           { return nil }
 
 func TestRegistry_Register(t *testing.T) {
 	t.Parallel()

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -238,7 +238,6 @@ type containerConfigArgs struct {
 	caFilePath        string
 	caContainerPath   string
 	credMounts        []credentialMount // fake credential files to mount
-	credEnvVars       map[string]string // env vars contributed by active credentials
 	interceptedMounts map[mountKey]bool // original mounts replaced by credentials (must be skipped)
 }
 
@@ -288,9 +287,6 @@ func (p *podmanRuntime) buildContainerArgs(params runtime.CreateParams, imageNam
 		}
 		for _, cm := range ccArgs.credMounts {
 			args = append(args, "-v", fmt.Sprintf("%s:%s:ro,Z", cm.hostPath, cm.containerPath))
-		}
-		for k, v := range ccArgs.credEnvVars {
-			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 		}
 	}
 
@@ -596,12 +592,6 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 				hostPath:      fakePath,
 				containerPath: ac.cred.ContainerFilePath(),
 			})
-			for k, v := range ac.cred.EnvVars(ac.hostPath) {
-				if ccArgs.credEnvVars == nil {
-					ccArgs.credEnvVars = make(map[string]string)
-				}
-				ccArgs.credEnvVars[k] = v
-			}
 		}
 		ccArgs.interceptedMounts = intercepted
 	}

--- a/pkg/runtime/podman/create_test.go
+++ b/pkg/runtime/podman/create_test.go
@@ -1729,7 +1729,6 @@ type fakeCredentialForDetect struct {
 	intercepted *workspace.Mount
 	fakeContent []byte
 	fakeFileErr error
-	envVars     map[string]string
 }
 
 var _ credential.Credential = (*fakeCredentialForDetect)(nil)
@@ -1745,8 +1744,7 @@ func (f *fakeCredentialForDetect) FakeFile(_ string) ([]byte, error) {
 func (f *fakeCredentialForDetect) Configure(_ context.Context, _ onecli.Client, _ string) error {
 	return nil
 }
-func (f *fakeCredentialForDetect) HostPatterns(_ string) []string     { return nil }
-func (f *fakeCredentialForDetect) EnvVars(_ string) map[string]string { return f.envVars }
+func (f *fakeCredentialForDetect) HostPatterns(_ string) []string { return nil }
 
 func TestCreate_WithActiveCredentials(t *testing.T) {
 	t.Parallel()
@@ -1776,7 +1774,6 @@ func TestCreate_WithActiveCredentials(t *testing.T) {
 			detectPath:  realCredFile,
 			intercepted: &mounts[0],
 			fakeContent: []byte(`{"fake":true}`),
-			envVars:     map[string]string{"CRED_TOKEN": "placeholder"},
 		}
 		reg := credential.NewRegistry()
 		_ = reg.Register(cred)
@@ -1829,11 +1826,6 @@ func TestCreate_WithActiveCredentials(t *testing.T) {
 		expectedCredMount := fmt.Sprintf("-v %s:/fake/mycred:ro,Z", fakePath)
 		if !strings.Contains(argsStr, expectedCredMount) {
 			t.Errorf("Expected credential mount %q in args:\n%s", expectedCredMount, argsStr)
-		}
-
-		// Credential env vars must be injected.
-		if !strings.Contains(argsStr, "-e CRED_TOKEN=placeholder") {
-			t.Errorf("Expected credential env var in args:\n%s", argsStr)
 		}
 
 		// The intercepted mount's container path must NOT appear (mount was suppressed).


### PR DESCRIPTION
Credentials were reading CLOUD_ML_REGION, ANTHROPIC_VERTEX_PROJECT_ID, GOOGLE_CLOUD_PROJECT, and VERTEX_LOCATION from the host environment and injecting them into the workspace container, making workspace creation non-reproducible across machines. These variables should be defined explicitly in the agents config instead.

Removes the EnvVars method from the Credential interface and the gcloud implementation, the host env var fallback in vertexAIFields, and the credEnvVars injection path in the Podman runtime.

Closes #433