### PR TITLE
feat(autoconf): detect and apply Vertex AI config for Claude workspaces

### DIFF
--- a/.agents/skills/working-with-autoconf/SKILL.md
+++ b/.agents/skills/working-with-autoconf/SKILL.md
@@ -300,15 +300,21 @@ type VertexDetector interface {
     Detect() (*VertexConfig, error)
 }
 ```
-Returns a non-nil `*VertexConfig` only when all three env vars (`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`) are set and the ADC file exists on disk. Constructor: `NewVertexDetector() (VertexDetector, error)`.
+Returns a non-nil `*VertexConfig` only when all three env vars (`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`) are set and the credentials file exists on disk. The credentials file path is resolved in this priority order:
+1. `GOOGLE_APPLICATION_CREDENTIALS` — if set and non-empty, the file at that path is used
+2. Platform-specific ADC default — `~/.config/gcloud/application_default_credentials.json` (Linux/macOS) or `%APPDATA%\gcloud\...` (Windows)
+
+Constructor: `NewVertexDetector() (VertexDetector, error)`.
 
 **`VertexConfig`**:
 ```go
 type VertexConfig struct {
     EnvVars     map[string]string // the three detected env var values
-    ADCHostPath string            // host path for the ADC file mount (starts with $HOME)
+    ADCHostPath string            // host path for the credentials file mount
 }
 ```
+
+`ADCHostPath` is expressed as `$HOME/<rel>` when the credentials file is under the user's home directory (portable across machines); otherwise it is the absolute path as-is.
 
 **`ClaudeVertexAutoconf`** (`autoconfclaudevertex.go`):
 ```go
@@ -330,7 +336,7 @@ Important `ClaudeVertexAutoconfOptions` fields:
 | `Yes` | skip confirm + select, defaults to agent target |
 | `Confirm` / `SelectTarget` | injectable for testing |
 
-**`ADCContainerPath`** — `$HOME/.config/gcloud/application_default_credentials.json` — the container path used for the ADC mount target. On Linux/macOS the host path is identical; on Windows it is computed from `%APPDATA%` via `adcConfigHostPath()` (in `adcpath_windows.go`).
+**`ADCContainerPath`** — `$HOME/.config/gcloud/application_default_credentials.json` — the fixed container path where the credentials file is mounted, regardless of where it lives on the host. The helper `credHostPath(p, homeDir)` converts the host path to `$HOME/<rel>` when possible.
 
 ### Env var write order
 

--- a/.agents/skills/working-with-autoconf/SKILL.md
+++ b/.agents/skills/working-with-autoconf/SKILL.md
@@ -275,6 +275,88 @@ var buf bytes.Buffer
 err := runner.Run(&buf)
 ```
 
+## Vertex AI Detection for Claude (`ClaudeVertexAutoconf`)
+
+In addition to the secret-based flow, `kdn autoconf` also runs a separate Vertex AI detection step for Claude workspaces. This is handled by `ClaudeVertexAutoconf` in `autoconfclaudevertex.go`.
+
+### How it works
+
+```text
+VertexDetector.Detect()   → *VertexConfig (nil = not detected)
+  ↓ non-nil
+  findExistingLocations()  → skip if CLAUDE_CODE_USE_VERTEX already in agent or workspace cfg
+  confirm?  (skipped when --yes)
+  selectTarget()           → ClaudeVertexConfigTargetAgent | ClaudeVertexConfigTargetLocal
+  applyTarget()
+    Agent target  → AgentConfigUpdater.AddEnvVar("claude", ...) × 3 + AddMount
+    Local target  → WorkspaceConfigUpdater.AddEnvVar(...) × 3 + AddMount
+```
+
+### Key types
+
+**`VertexDetector`** (`detectclaudevertex.go`):
+```go
+type VertexDetector interface {
+    Detect() (*VertexConfig, error)
+}
+```
+Returns a non-nil `*VertexConfig` only when all three env vars (`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`) are set and the ADC file exists on disk. Constructor: `NewVertexDetector() (VertexDetector, error)`.
+
+**`VertexConfig`**:
+```go
+type VertexConfig struct {
+    EnvVars     map[string]string // the three detected env var values
+    ADCHostPath string            // host path for the ADC file mount (starts with $HOME)
+}
+```
+
+**`ClaudeVertexAutoconf`** (`autoconfclaudevertex.go`):
+```go
+type ClaudeVertexAutoconf interface {
+    Run(out io.Writer) error
+}
+func NewClaudeVertexAutoconf(opts ClaudeVertexAutoconfOptions) ClaudeVertexAutoconf
+```
+
+Important `ClaudeVertexAutoconfOptions` fields:
+
+| Field | Purpose |
+|-------|---------|
+| `Detector` | `VertexDetector` |
+| `AgentUpdater` | `config.AgentConfigUpdater` — writes to `agents.json` |
+| `WorkspaceUpdater` | `config.WorkspaceConfigUpdater` — nil means local target not offered |
+| `AgentLoader` | `config.AgentConfigLoader` — checks if already configured in agent config |
+| `WorkspaceConfig` | `config.Config` — checks if already configured in workspace config |
+| `Yes` | skip confirm + select, defaults to agent target |
+| `Confirm` / `SelectTarget` | injectable for testing |
+
+**`ADCContainerPath`** — `$HOME/.config/gcloud/application_default_credentials.json` — the container path used for the ADC mount target. On Linux/macOS the host path is identical; on Windows it is computed from `%APPDATA%` via `adcConfigHostPath()` (in `adcpath_windows.go`).
+
+### Env var write order
+
+The three env vars are always written in the order defined by `vertexEnvVars`:
+1. `CLAUDE_CODE_USE_VERTEX`
+2. `ANTHROPIC_VERTEX_PROJECT_ID`
+3. `CLOUD_ML_REGION`
+
+### Testing patterns
+
+Fake `VertexDetector`:
+```go
+type fakeVertexDetector struct{ cfg *autoconf.VertexConfig }
+func (f *fakeVertexDetector) Detect() (*autoconf.VertexConfig, error) { return f.cfg, nil }
+```
+
+Fake `AgentConfigUpdater`:
+```go
+type fakeAgentUpdater struct {
+    envVars []struct{ agentName, name, value string }
+    mounts  []struct{ agentName, host, target string; ro bool }
+}
+func (f *fakeAgentUpdater) AddEnvVar(agent, name, value string) error { ... }
+func (f *fakeAgentUpdater) AddMount(agent, host, target string, ro bool) error { ... }
+```
+
 ## Key Files
 
 | File | Purpose |
@@ -282,9 +364,13 @@ err := runner.Run(&buf)
 | `pkg/autoconf/detect.go` | `SecretDetector` interface + `envSecretDetector` |
 | `pkg/autoconf/filter.go` | `SecretFilter` + `alreadyConfiguredFilter` + `FilterResult` |
 | `pkg/autoconf/autoconf.go` | `Autoconf` interface + `autoconfRunner` + `ConfigTarget` |
+| `pkg/autoconf/detectclaudevertex.go` | `VertexDetector` interface + `envVertexDetector` + `VertexConfig` |
+| `pkg/autoconf/autoconfclaudevertex.go` | `ClaudeVertexAutoconf` interface + runner |
+| `pkg/autoconf/adcpath.go` / `adcpath_windows.go` | Platform-specific ADC file path helpers |
 | `pkg/cmd/autoconf.go` | Thin CLI wiring: flag parsing, dependency construction, `project.Detector` injection |
 | `pkg/project/project.go` | `Detector` interface + shared project-ID detection logic (git remote → URL, no remote → path) |
 | `pkg/config/projectsupdater.go` | `ProjectConfigUpdater` — reads/writes `~/.kdn/config/projects.json` |
 | `pkg/config/workspaceupdater.go` | `WorkspaceConfigUpdater` — reads/writes `.kaiden/workspace.json` |
+| `pkg/config/agents.go` | `AgentConfigUpdater` + `AgentConfigLoader` — reads/writes `~/.kdn/config/agents.json` |
 | `pkg/secretservicesetup/register.go` | `ListServices()` — returns fully-constructed service instances |
 | `pkg/secretservicesetup/secretservices.json` | Authoritative list of known secret services and their env vars |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,12 @@ The config system manages workspace configuration for **injecting environment va
 
 **Configuration Precedence:** Agent > Project > Global > Workspace (highest to lowest)
 
+**Key config interfaces in `pkg/config/`:**
+
+- **`WorkspaceConfigUpdater`** (`workspaceupdater.go`): Reads/writes `.kaiden/workspace.json`. Methods: `AddSecret(name)`, `AddEnvVar(name, value)`, `AddMount(host, target, ro)`.
+- **`AgentConfigUpdater`** (`agents.go`): Reads/writes `~/.kdn/config/agents.json` per agent. Methods: `AddEnvVar(agentName, name, value)`, `AddMount(agentName, host, target, ro)`. Used by `kdn autoconf` to record Vertex AI config for the `claude` agent.
+- **`AgentConfigLoader`** (`agents.go`): Loads a `WorkspaceConfiguration` for a named agent from `agents.json`. Returns an empty config (not an error) when the file or agent key is absent.
+
 ### Agent Default Settings Files
 
 A separate mechanism (distinct from env/mount config) allows default dotfiles to be baked into the workspace image:

--- a/README.md
+++ b/README.md
@@ -215,8 +215,9 @@ To reuse your host Claude Code settings (preferences, custom instructions, etc.)
 **Notes:**
 
 - Run `gcloud auth application-default login` on your host machine before starting the workspace to ensure valid credentials are available
-- kdn automatically intercepts the ADC file mount: a placeholder credential file is written into the container and OneCLI injects the real Application Default Credentials transparently at request time — the actual credential file never touches the container filesystem
-- No `ANTHROPIC_API_KEY` is needed when using Vertex AI — credentials are provided via the mounted application default credentials
+- If `GOOGLE_APPLICATION_CREDENTIALS` is set in your shell, `kdn autoconf` uses the file it points to instead of the default ADC path — no extra steps needed
+- kdn automatically intercepts the credentials file mount: a placeholder file is written into the container and OneCLI injects the real credentials transparently at request time — the actual credential file never touches the container filesystem
+- No `ANTHROPIC_API_KEY` is needed when using Vertex AI — credentials are provided via the mounted credentials file
 - When `network.mode` is `"deny"`, the Google OAuth and Vertex AI endpoints (`oauth2.googleapis.com`, `aiplatform.googleapis.com`) are automatically added to the allow-list — no explicit `hosts` entry is needed
 - To pin a specific Claude model, use `--model` flag during `init` (e.g., `--model claude-sonnet-4-20250514`), which takes precedence over any model in default settings, or add an `ANTHROPIC_MODEL` environment variable (e.g., `"claude-opus-4-5"`)
 - If you run `kdn autoconf` again after Vertex AI is already configured, it reports the existing configuration location and exits without making changes

--- a/README.md
+++ b/README.md
@@ -114,7 +114,31 @@ This scenario demonstrates how to configure Claude Code to use a model hosted on
 
 **Step 1: Configure Claude agent settings**
 
-Create or edit `~/.kdn/config/agents.json` to add the required environment variables and mount your Google Cloud credentials into the workspace:
+The easiest way is to let `kdn autoconf` detect your environment and configure things automatically. Set the required Vertex AI environment variables in your shell and run:
+
+```bash
+export CLAUDE_CODE_USE_VERTEX=1
+export ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project-id
+export CLOUD_ML_REGION=my-region
+
+kdn autoconf
+```
+
+`autoconf` detects all three variables plus your application default credentials file, then asks where to record the configuration:
+
+- **Claude agent config (all Claude workspaces)** — writes to `~/.kdn/config/agents.json`; applies to every Claude workspace you create from now on
+- **Local (.kaiden/workspace.json)** — applies only to the current project
+
+Pick the agent config option to configure all future Claude workspaces at once. To skip the interactive prompt and apply immediately to the agent config, pass `--yes`:
+
+```bash
+CLAUDE_CODE_USE_VERTEX=1 ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project-id CLOUD_ML_REGION=my-region \
+  kdn autoconf --yes
+```
+
+**Alternative: configure manually**
+
+If the environment variables are not present in your shell, create or edit `~/.kdn/config/agents.json` directly:
 
 ```json
 {
@@ -134,7 +158,11 @@ Create or edit `~/.kdn/config/agents.json` to add the required environment varia
       }
     ],
     "mounts": [
-      {"host": "$HOME/.config/gcloud", "target": "$HOME/.config/gcloud", "ro": true}
+      {
+        "host": "$HOME/.config/gcloud/application_default_credentials.json",
+        "target": "$HOME/.config/gcloud/application_default_credentials.json",
+        "ro": true
+      }
     ]
   }
 }
@@ -142,10 +170,10 @@ Create or edit `~/.kdn/config/agents.json` to add the required environment varia
 
 **Fields:**
 
-- `CLAUDE_CODE_USE_VERTEX` - Set to `1` to instruct Claude Code to use Vertex AI instead of the Anthropic API
-- `ANTHROPIC_VERTEX_PROJECT_ID` - Your Google Cloud project ID where Vertex AI is configured
-- `CLOUD_ML_REGION` - The region where Claude is available on Vertex AI
-- `$HOME/.config/gcloud` mounted read-only - Provides the workspace access to your application default credentials
+- `CLAUDE_CODE_USE_VERTEX` — set to `1` to instruct Claude Code to use Vertex AI instead of the Anthropic API
+- `ANTHROPIC_VERTEX_PROJECT_ID` — your Google Cloud project ID where Vertex AI is configured
+- `CLOUD_ML_REGION` — the region where Claude is available on Vertex AI
+- The ADC file mounted read-only — provides the workspace access to your application default credentials
 
 **Step 2: Register and start the workspace**
 
@@ -164,27 +192,17 @@ When Claude Code starts, it detects `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_
 
 **Sharing local Claude settings (optional)**
 
-To reuse your host Claude Code settings (preferences, custom instructions, etc.) inside the workspace, add `~/.claude` and `~/.claude.json` to the mounts:
+To reuse your host Claude Code settings (preferences, custom instructions, etc.) inside the workspace, add `~/.claude` and `~/.claude.json` to the mounts in `~/.kdn/config/agents.json`:
 
 ```json
 {
   "claude": {
-    "environment": [
-      {
-        "name": "CLAUDE_CODE_USE_VERTEX",
-        "value": "1"
-      },
-      {
-        "name": "ANTHROPIC_VERTEX_PROJECT_ID",
-        "value": "my-gcp-project-id"
-      },
-      {
-        "name": "CLOUD_ML_REGION",
-        "value": "my-region"
-      }
-    ],
     "mounts": [
-      {"host": "$HOME/.config/gcloud", "target": "$HOME/.config/gcloud", "ro": true},
+      {
+        "host": "$HOME/.config/gcloud/application_default_credentials.json",
+        "target": "$HOME/.config/gcloud/application_default_credentials.json",
+        "ro": true
+      },
       {"host": "$HOME/.claude", "target": "$HOME/.claude"},
       {"host": "$HOME/.claude.json", "target": "$HOME/.claude.json"}
     ]
@@ -197,10 +215,11 @@ To reuse your host Claude Code settings (preferences, custom instructions, etc.)
 **Notes:**
 
 - Run `gcloud auth application-default login` on your host machine before starting the workspace to ensure valid credentials are available
-- kdn automatically intercepts the gcloud mount: a placeholder credential file is written into the container and OneCLI injects the real Application Default Credentials transparently at request time — the actual credential file never touches the container filesystem
-- No `ANTHROPIC_API_KEY` is needed when using Vertex AI — credentials are provided via the mounted gcloud configuration
+- kdn automatically intercepts the ADC file mount: a placeholder credential file is written into the container and OneCLI injects the real Application Default Credentials transparently at request time — the actual credential file never touches the container filesystem
+- No `ANTHROPIC_API_KEY` is needed when using Vertex AI — credentials are provided via the mounted application default credentials
 - When `network.mode` is `"deny"`, the Google OAuth and Vertex AI endpoints (`oauth2.googleapis.com`, `aiplatform.googleapis.com`) are automatically added to the allow-list — no explicit `hosts` entry is needed
 - To pin a specific Claude model, use `--model` flag during `init` (e.g., `--model claude-sonnet-4-20250514`), which takes precedence over any model in default settings, or add an `ANTHROPIC_MODEL` environment variable (e.g., `"claude-opus-4-5"`)
+- If you run `kdn autoconf` again after Vertex AI is already configured, it reports the existing configuration location and exits without making changes
 
 ### Starting Claude with Default Settings
 

--- a/pkg/autoconf/adcpath.go
+++ b/pkg/autoconf/adcpath.go
@@ -24,13 +24,13 @@ import "path/filepath"
 
 // adcDetectPath returns the absolute host path to the gcloud ADC file used
 // for existence checking.
-func adcDetectPath(homeDir string) string {
+func adcDetectPath(homeDir, _ string) string {
 	return filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json")
 }
 
 // adcConfigHostPath returns the host path to write in a workspace mount entry.
 // On Linux/macOS the ADC file lives under $HOME/.config/gcloud/, so the
 // $HOME-variable form matches the actual file location.
-func adcConfigHostPath(_ string) string {
+func adcConfigHostPath(_, _ string) string {
 	return ADCContainerPath
 }

--- a/pkg/autoconf/adcpath.go
+++ b/pkg/autoconf/adcpath.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import "path/filepath"
+
+// adcDetectPath returns the absolute host path to the gcloud ADC file used
+// for existence checking.
+func adcDetectPath(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json")
+}
+
+// adcConfigHostPath returns the host path to write in a workspace mount entry.
+// On Linux/macOS the ADC file lives under $HOME/.config/gcloud/, so the
+// $HOME-variable form matches the actual file location.
+func adcConfigHostPath(_ string) string {
+	return ADCContainerPath
+}

--- a/pkg/autoconf/adcpath_windows.go
+++ b/pkg/autoconf/adcpath_windows.go
@@ -21,7 +21,6 @@
 package autoconf
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -30,12 +29,11 @@ import (
 // adcDetectPath returns the absolute host path to the gcloud ADC file used
 // for existence checking. On Windows gcloud stores credentials under %APPDATA%
 // rather than under the user home directory.
-func adcDetectPath(_ string) string {
-	appdata := os.Getenv("APPDATA")
-	if appdata == "" {
+func adcDetectPath(_, appDataDir string) string {
+	if appDataDir == "" {
 		return ""
 	}
-	return filepath.Join(appdata, "gcloud", "application_default_credentials.json")
+	return filepath.Join(appDataDir, "gcloud", "application_default_credentials.json")
 }
 
 // adcConfigHostPath returns the host path to write in a workspace mount entry.
@@ -43,12 +41,11 @@ func adcDetectPath(_ string) string {
 // $HOME\AppData\Roaming), so the path is expressed as $HOME/<rel>/gcloud/...
 // so that it starts with $HOME as required by the mount config format.
 // Returns "" if %APPDATA% is unset or is not located under homeDir.
-func adcConfigHostPath(homeDir string) string {
-	appdata := os.Getenv("APPDATA")
-	if appdata == "" {
+func adcConfigHostPath(homeDir, appDataDir string) string {
+	if appDataDir == "" {
 		return ""
 	}
-	rel, err := filepath.Rel(homeDir, appdata)
+	rel, err := filepath.Rel(homeDir, appDataDir)
 	if err != nil || strings.HasPrefix(rel, "..") {
 		return ""
 	}

--- a/pkg/autoconf/adcpath_windows.go
+++ b/pkg/autoconf/adcpath_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// adcDetectPath returns the absolute host path to the gcloud ADC file used
+// for existence checking. On Windows gcloud stores credentials under %APPDATA%
+// rather than under the user home directory.
+func adcDetectPath(_ string) string {
+	appdata := os.Getenv("APPDATA")
+	if appdata == "" {
+		return ""
+	}
+	return filepath.Join(appdata, "gcloud", "application_default_credentials.json")
+}
+
+// adcConfigHostPath returns the host path to write in a workspace mount entry.
+// On Windows %APPDATA% is typically a subdirectory of the user home (e.g.
+// $HOME\AppData\Roaming), so the path is expressed as $HOME/<rel>/gcloud/...
+// so that it starts with $HOME as required by the mount config format.
+// Returns "" if %APPDATA% is unset or is not located under homeDir.
+func adcConfigHostPath(homeDir string) string {
+	appdata := os.Getenv("APPDATA")
+	if appdata == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(homeDir, appdata)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return ""
+	}
+	return path.Join("$HOME", filepath.ToSlash(rel), "gcloud", "application_default_credentials.json")
+}

--- a/pkg/autoconf/autoconf_test.go
+++ b/pkg/autoconf/autoconf_test.go
@@ -66,11 +66,29 @@ func (f *fakeAutoconfUpdater) AddSecret(projectID, secretName string) error {
 
 // fakeWorkspaceUpdater records calls for the workspace updater.
 type fakeWorkspaceUpdater struct {
-	added []string
+	added   []string
+	envVars []struct{ name, value string }
+	mounts  []struct {
+		host, target string
+		ro           bool
+	}
 }
 
 func (f *fakeWorkspaceUpdater) AddSecret(name string) error {
 	f.added = append(f.added, name)
+	return nil
+}
+
+func (f *fakeWorkspaceUpdater) AddEnvVar(name, value string) error {
+	f.envVars = append(f.envVars, struct{ name, value string }{name, value})
+	return nil
+}
+
+func (f *fakeWorkspaceUpdater) AddMount(host, target string, ro bool) error {
+	f.mounts = append(f.mounts, struct {
+		host, target string
+		ro           bool
+	}{host, target, ro})
 	return nil
 }
 

--- a/pkg/autoconf/autoconfclaudevertex.go
+++ b/pkg/autoconf/autoconfclaudevertex.go
@@ -1,0 +1,258 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/config"
+)
+
+// ClaudeVertexConfigTarget identifies where detected Vertex AI configuration
+// is recorded for Claude workspaces.
+type ClaudeVertexConfigTarget int
+
+const (
+	// ClaudeVertexConfigTargetAgent records env vars and the ADC mount in
+	// agents.json under the "claude" key (applies to all Claude workspaces).
+	ClaudeVertexConfigTargetAgent ClaudeVertexConfigTarget = iota
+	// ClaudeVertexConfigTargetLocal records env vars and the ADC mount in
+	// the local .kaiden/workspace.json.
+	ClaudeVertexConfigTargetLocal
+)
+
+// ClaudeVertexConfigTargetOption pairs a ClaudeVertexConfigTarget with a
+// human-readable label for display in selection prompts.
+type ClaudeVertexConfigTargetOption struct {
+	Target ClaudeVertexConfigTarget
+	Label  string
+}
+
+// ClaudeVertexAutoconfOptions configures a ClaudeVertexAutoconf runner.
+type ClaudeVertexAutoconfOptions struct {
+	Detector VertexDetector
+
+	// AgentUpdater writes to ~/.kdn/config/agents.json for the "claude" agent.
+	AgentUpdater config.AgentConfigUpdater
+	// WorkspaceUpdater writes to .kaiden/workspace.json in the current directory.
+	// When nil the local target is not offered.
+	WorkspaceUpdater config.WorkspaceConfigUpdater
+
+	// AgentLoader is used to check whether Vertex AI is already configured in
+	// the claude agent config. May be nil (skips that check).
+	AgentLoader config.AgentConfigLoader
+	// WorkspaceConfig is used to check whether Vertex AI is already configured
+	// in the local workspace config. May be nil (skips that check).
+	WorkspaceConfig config.Config
+
+	Yes bool
+
+	// Confirm is called to ask the user whether to proceed.
+	Confirm func(prompt string) (bool, error)
+
+	// SelectTarget is called to ask the user where to record the configuration.
+	// It may return ErrSkipped to skip without applying.
+	SelectTarget func(options []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error)
+}
+
+// ClaudeVertexAutoconf orchestrates Vertex AI configuration detection and
+// application for Claude workspaces. It adds env vars and an ADC file mount
+// to either the claude agent config (all Claude workspaces) or the local
+// workspace config.
+type ClaudeVertexAutoconf interface {
+	Run(out io.Writer) error
+}
+
+type claudeVertexAutoconfRunner struct {
+	detector         VertexDetector
+	agentUpdater     config.AgentConfigUpdater
+	workspaceUpdater config.WorkspaceConfigUpdater
+	agentLoader      config.AgentConfigLoader
+	workspaceConfig  config.Config
+	yes              bool
+	confirm          func(string) (bool, error)
+	selectTarget     func([]ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error)
+}
+
+var _ ClaudeVertexAutoconf = (*claudeVertexAutoconfRunner)(nil)
+
+// NewClaudeVertexAutoconf returns a ClaudeVertexAutoconf configured by opts.
+func NewClaudeVertexAutoconf(opts ClaudeVertexAutoconfOptions) ClaudeVertexAutoconf {
+	return &claudeVertexAutoconfRunner{
+		detector:         opts.Detector,
+		agentUpdater:     opts.AgentUpdater,
+		workspaceUpdater: opts.WorkspaceUpdater,
+		agentLoader:      opts.AgentLoader,
+		workspaceConfig:  opts.WorkspaceConfig,
+		yes:              opts.Yes,
+		confirm:          opts.Confirm,
+		selectTarget:     opts.SelectTarget,
+	}
+}
+
+func (r *claudeVertexAutoconfRunner) Run(out io.Writer) error {
+	cfg, err := r.detector.Detect()
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return nil
+	}
+
+	// Check if already configured in any target.
+	locations := r.findExistingLocations()
+	if len(locations) > 0 {
+		fmt.Fprintf(out, "%s Vertex AI already configured for Claude (%s).\n", greenCheck, formatVertexLocations(locations))
+		return nil
+	}
+
+	fmt.Fprintf(out, "Detected Vertex AI configuration (CLAUDE_CODE_USE_VERTEX + ADC file)\n")
+
+	if !r.yes {
+		ok, err := r.confirm("Configure Claude workspaces for Vertex AI (env vars + ADC file mount)?")
+		if err != nil {
+			return fmt.Errorf("confirmation failed: %w", err)
+		}
+		if !ok {
+			fmt.Fprintf(out, "%s Skipped Vertex AI configuration.\n", greyDash)
+			return nil
+		}
+	}
+
+	target := ClaudeVertexConfigTargetAgent // default for --yes
+	if !r.yes {
+		options := r.buildTargetOptions()
+		var selErr error
+		target, selErr = r.selectTarget(options)
+		if errors.Is(selErr, ErrSkipped) {
+			fmt.Fprintf(out, "%s Skipped Vertex AI configuration.\n", greyDash)
+			return nil
+		}
+		if selErr != nil {
+			return fmt.Errorf("target selection failed: %w", selErr)
+		}
+	}
+
+	return r.applyTarget(out, cfg, target)
+}
+
+func (r *claudeVertexAutoconfRunner) buildTargetOptions() []ClaudeVertexConfigTargetOption {
+	opts := []ClaudeVertexConfigTargetOption{
+		{Target: ClaudeVertexConfigTargetAgent, Label: "Claude agent config (all Claude workspaces)"},
+	}
+	if r.workspaceUpdater != nil {
+		opts = append(opts, ClaudeVertexConfigTargetOption{
+			Target: ClaudeVertexConfigTargetLocal,
+			Label:  "Local (.kaiden/workspace.json)",
+		})
+	}
+	return opts
+}
+
+func (r *claudeVertexAutoconfRunner) applyTarget(out io.Writer, cfg *VertexConfig, target ClaudeVertexConfigTarget) error {
+	switch target {
+	case ClaudeVertexConfigTargetAgent:
+		for _, name := range vertexEnvVars {
+			value, ok := cfg.EnvVars[name]
+			if !ok {
+				continue
+			}
+			if err := r.agentUpdater.AddEnvVar("claude", name, value); err != nil {
+				return fmt.Errorf("failed to add env var %q to claude agent config: %w", name, err)
+			}
+		}
+		if err := r.agentUpdater.AddMount("claude", cfg.ADCHostPath, ADCContainerPath, true); err != nil {
+			return fmt.Errorf("failed to add ADC mount to claude agent config: %w", err)
+		}
+		fmt.Fprintf(out, "%s Configured Vertex AI in claude agent config.\n", greenCheck)
+
+	case ClaudeVertexConfigTargetLocal:
+		if r.workspaceUpdater == nil {
+			return fmt.Errorf("local config target selected but workspace updater is not configured")
+		}
+		for _, name := range vertexEnvVars {
+			value, ok := cfg.EnvVars[name]
+			if !ok {
+				continue
+			}
+			if err := r.workspaceUpdater.AddEnvVar(name, value); err != nil {
+				return fmt.Errorf("failed to add env var %q to workspace config: %w", name, err)
+			}
+		}
+		if err := r.workspaceUpdater.AddMount(cfg.ADCHostPath, ADCContainerPath, true); err != nil {
+			return fmt.Errorf("failed to add ADC mount to workspace config: %w", err)
+		}
+		fmt.Fprintf(out, "%s Configured Vertex AI in local workspace config.\n", greenCheck)
+
+	default:
+		return fmt.Errorf("unknown vertex config target %d", target)
+	}
+	return nil
+}
+
+// findExistingLocations returns the config targets where CLAUDE_CODE_USE_VERTEX
+// is already present as an environment variable.
+func (r *claudeVertexAutoconfRunner) findExistingLocations() []ClaudeVertexConfigTarget {
+	var locations []ClaudeVertexConfigTarget
+
+	if r.agentLoader != nil {
+		if cfg, err := r.agentLoader.Load("claude"); err == nil && hasVertexEnvVar(cfg) {
+			locations = append(locations, ClaudeVertexConfigTargetAgent)
+		}
+	}
+
+	if r.workspaceConfig != nil {
+		if cfg, err := r.workspaceConfig.Load(); err == nil && hasVertexEnvVar(cfg) {
+			locations = append(locations, ClaudeVertexConfigTargetLocal)
+		}
+	}
+
+	return locations
+}
+
+// hasVertexEnvVar returns true if the config contains CLAUDE_CODE_USE_VERTEX
+// in its environment list.
+func hasVertexEnvVar(cfg *workspace.WorkspaceConfiguration) bool {
+	if cfg == nil || cfg.Environment == nil {
+		return false
+	}
+	for _, e := range *cfg.Environment {
+		if e.Name == "CLAUDE_CODE_USE_VERTEX" {
+			return true
+		}
+	}
+	return false
+}
+
+func formatVertexLocations(locs []ClaudeVertexConfigTarget) string {
+	names := make([]string, 0, len(locs))
+	for _, l := range locs {
+		switch l {
+		case ClaudeVertexConfigTargetAgent:
+			names = append(names, "claude agent")
+		case ClaudeVertexConfigTargetLocal:
+			names = append(names, "local")
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/pkg/autoconf/autoconfclaudevertex_test.go
+++ b/pkg/autoconf/autoconfclaudevertex_test.go
@@ -1,0 +1,412 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/config"
+)
+
+// fakeVertexDetector returns a fixed *VertexConfig.
+type fakeVertexDetector struct {
+	cfg *VertexConfig
+}
+
+func (f *fakeVertexDetector) Detect() (*VertexConfig, error) {
+	return f.cfg, nil
+}
+
+// detectedVertexCfg is a convenience helper that returns a fully-populated VertexConfig.
+func detectedVertexCfg() *VertexConfig {
+	return &VertexConfig{
+		EnvVars: map[string]string{
+			"CLAUDE_CODE_USE_VERTEX":      "1",
+			"ANTHROPIC_VERTEX_PROJECT_ID": "my-project",
+			"CLOUD_ML_REGION":             "us-east5",
+		},
+		ADCHostPath: ADCContainerPath,
+	}
+}
+
+// fakeAgentUpdater records AddEnvVar and AddMount calls.
+type fakeAgentUpdater struct {
+	envVars []struct{ agentName, name, value string }
+	mounts  []struct {
+		agentName, host, target string
+		ro                      bool
+	}
+}
+
+func (f *fakeAgentUpdater) AddEnvVar(agentName, name, value string) error {
+	f.envVars = append(f.envVars, struct{ agentName, name, value string }{agentName, name, value})
+	return nil
+}
+
+func (f *fakeAgentUpdater) AddMount(agentName, host, target string, ro bool) error {
+	f.mounts = append(f.mounts, struct {
+		agentName, host, target string
+		ro                      bool
+	}{agentName, host, target, ro})
+	return nil
+}
+
+// fakeAgentLoader returns a fixed *workspace.WorkspaceConfiguration for "claude".
+type fakeAgentLoader struct {
+	claudeCfg *workspace.WorkspaceConfiguration
+}
+
+func (f *fakeAgentLoader) Load(agentName string) (*workspace.WorkspaceConfiguration, error) {
+	if agentName == "claude" && f.claudeCfg != nil {
+		return f.claudeCfg, nil
+	}
+	return &workspace.WorkspaceConfiguration{}, nil
+}
+
+// fakeVertexWorkspaceConfig returns a fixed *workspace.WorkspaceConfiguration.
+type fakeVertexWorkspaceConfig struct {
+	cfg *workspace.WorkspaceConfiguration
+}
+
+func (f *fakeVertexWorkspaceConfig) Load() (*workspace.WorkspaceConfiguration, error) {
+	if f.cfg != nil {
+		return f.cfg, nil
+	}
+	return nil, config.ErrConfigNotFound
+}
+
+// alwaysAgent is a selectTarget stub that always picks the agent target.
+func alwaysAgent(_ []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error) {
+	return ClaudeVertexConfigTargetAgent, nil
+}
+
+func TestClaudeVertexAutoconf_NotDetected(t *testing.T) {
+	t.Parallel()
+
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: nil},
+		AgentUpdater: agentUpdater,
+		Confirm:      func(string) (bool, error) { return true, nil },
+		SelectTarget: alwaysAgent,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(agentUpdater.envVars) != 0 || len(agentUpdater.mounts) != 0 {
+		t.Error("expected no updates when Vertex AI is not detected")
+	}
+	if buf.String() != "" {
+		t.Errorf("expected no output when not detected, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_AgentTarget_Confirmed(t *testing.T) {
+	t.Parallel()
+
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: agentUpdater,
+		Confirm:      func(string) (bool, error) { return true, nil },
+		SelectTarget: alwaysAgent,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// Three env vars in fixed order.
+	if len(agentUpdater.envVars) != 3 {
+		t.Fatalf("expected 3 env var calls, got %d", len(agentUpdater.envVars))
+	}
+	for _, ev := range agentUpdater.envVars {
+		if ev.agentName != "claude" {
+			t.Errorf("expected agentName=claude, got %q", ev.agentName)
+		}
+	}
+
+	// One mount call for the ADC file.
+	if len(agentUpdater.mounts) != 1 {
+		t.Fatalf("expected 1 mount call, got %d", len(agentUpdater.mounts))
+	}
+	m := agentUpdater.mounts[0]
+	if m.agentName != "claude" {
+		t.Errorf("expected agentName=claude, got %q", m.agentName)
+	}
+	if m.host != ADCContainerPath || m.target != ADCContainerPath {
+		t.Errorf("unexpected mount paths: host=%q target=%q", m.host, m.target)
+	}
+	if !m.ro {
+		t.Error("expected mount to be read-only")
+	}
+
+	if !strings.Contains(buf.String(), "claude agent config") {
+		t.Errorf("expected 'claude agent config' in output, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_LocalTarget(t *testing.T) {
+	t.Parallel()
+
+	workspaceUpdater := &fakeWorkspaceUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:         &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater:     &fakeAgentUpdater{},
+		WorkspaceUpdater: workspaceUpdater,
+		Confirm:          func(string) (bool, error) { return true, nil },
+		SelectTarget: func(_ []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error) {
+			return ClaudeVertexConfigTargetLocal, nil
+		},
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(workspaceUpdater.envVars) != 3 {
+		t.Fatalf("expected 3 env var calls, got %d", len(workspaceUpdater.envVars))
+	}
+	if len(workspaceUpdater.mounts) != 1 {
+		t.Fatalf("expected 1 mount call, got %d", len(workspaceUpdater.mounts))
+	}
+	if !strings.Contains(buf.String(), "local workspace config") {
+		t.Errorf("expected 'local workspace config' in output, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_Declined(t *testing.T) {
+	t.Parallel()
+
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: agentUpdater,
+		Confirm:      func(string) (bool, error) { return false, nil },
+		SelectTarget: alwaysAgent,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(agentUpdater.envVars) != 0 || len(agentUpdater.mounts) != 0 {
+		t.Error("expected no updates when user declines")
+	}
+	if !strings.Contains(buf.String(), "Skipped") {
+		t.Errorf("expected 'Skipped' in output, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_YesFlag_DefaultsToAgent(t *testing.T) {
+	t.Parallel()
+
+	confirmCalled := false
+	selectCalled := false
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: agentUpdater,
+		Yes:          true,
+		Confirm:      func(string) (bool, error) { confirmCalled = true; return true, nil },
+		SelectTarget: func(_ []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error) {
+			selectCalled = true
+			return ClaudeVertexConfigTargetAgent, nil
+		},
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if confirmCalled {
+		t.Error("expected confirm not to be called when yes=true")
+	}
+	if selectCalled {
+		t.Error("expected selectTarget not to be called when yes=true")
+	}
+	if len(agentUpdater.envVars) != 3 {
+		t.Errorf("expected 3 env var calls, got %d", len(agentUpdater.envVars))
+	}
+}
+
+func TestClaudeVertexAutoconf_AlreadyConfiguredInAgent(t *testing.T) {
+	t.Parallel()
+
+	v := "1"
+	claudeCfg := &workspace.WorkspaceConfiguration{
+		Environment: &[]workspace.EnvironmentVariable{
+			{Name: "CLAUDE_CODE_USE_VERTEX", Value: &v},
+		},
+	}
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: agentUpdater,
+		AgentLoader:  &fakeAgentLoader{claudeCfg: claudeCfg},
+		Confirm:      func(string) (bool, error) { return true, nil },
+		SelectTarget: alwaysAgent,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(agentUpdater.envVars) != 0 {
+		t.Error("expected no updates when already configured in agent config")
+	}
+	if !strings.Contains(buf.String(), "already configured") {
+		t.Errorf("expected 'already configured' in output, got: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "claude agent") {
+		t.Errorf("expected 'claude agent' location in output, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_AlreadyConfiguredInWorkspace(t *testing.T) {
+	t.Parallel()
+
+	v := "1"
+	wsCfg := &workspace.WorkspaceConfiguration{
+		Environment: &[]workspace.EnvironmentVariable{
+			{Name: "CLAUDE_CODE_USE_VERTEX", Value: &v},
+		},
+	}
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:        &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater:    agentUpdater,
+		WorkspaceConfig: &fakeVertexWorkspaceConfig{cfg: wsCfg},
+		Confirm:         func(string) (bool, error) { return true, nil },
+		SelectTarget:    alwaysAgent,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(agentUpdater.envVars) != 0 {
+		t.Error("expected no updates when already configured in workspace config")
+	}
+	if !strings.Contains(buf.String(), "local") {
+		t.Errorf("expected 'local' location in output, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_LocalOptionNotOfferedWithoutUpdater(t *testing.T) {
+	t.Parallel()
+
+	var capturedOptions []ClaudeVertexConfigTargetOption
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: &fakeAgentUpdater{},
+		// WorkspaceUpdater intentionally nil.
+		Confirm: func(string) (bool, error) { return true, nil },
+		SelectTarget: func(opts []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error) {
+			capturedOptions = opts
+			return ClaudeVertexConfigTargetAgent, nil
+		},
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	for _, opt := range capturedOptions {
+		if opt.Target == ClaudeVertexConfigTargetLocal {
+			t.Error("local target should not be offered when WorkspaceUpdater is nil")
+		}
+	}
+}
+
+func TestClaudeVertexAutoconf_SkipTarget(t *testing.T) {
+	t.Parallel()
+
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: agentUpdater,
+		Confirm:      func(string) (bool, error) { return true, nil },
+		SelectTarget: func(_ []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error) {
+			return 0, ErrSkipped
+		},
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(agentUpdater.envVars) != 0 {
+		t.Error("expected no updates when target is skipped")
+	}
+	if !strings.Contains(buf.String(), "Skipped") {
+		t.Errorf("expected 'Skipped' in output, got: %q", buf.String())
+	}
+}
+
+func TestClaudeVertexAutoconf_LocalTarget_NilWorkspaceUpdater_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: &fakeAgentUpdater{},
+		// WorkspaceUpdater intentionally nil.
+		Confirm: func(string) (bool, error) { return true, nil },
+		SelectTarget: func(_ []ClaudeVertexConfigTargetOption) (ClaudeVertexConfigTarget, error) {
+			return ClaudeVertexConfigTargetLocal, nil
+		},
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err == nil {
+		t.Error("expected error when local target selected without WorkspaceUpdater")
+	}
+}
+
+func TestClaudeVertexAutoconf_EnvVarsWrittenInFixedOrder(t *testing.T) {
+	t.Parallel()
+
+	agentUpdater := &fakeAgentUpdater{}
+	runner := NewClaudeVertexAutoconf(ClaudeVertexAutoconfOptions{
+		Detector:     &fakeVertexDetector{cfg: detectedVertexCfg()},
+		AgentUpdater: agentUpdater,
+		Yes:          true,
+		Confirm:      func(string) (bool, error) { return true, nil },
+		SelectTarget: alwaysAgent,
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	wantOrder := vertexEnvVars
+	if len(agentUpdater.envVars) != len(wantOrder) {
+		t.Fatalf("expected %d env var calls, got %d", len(wantOrder), len(agentUpdater.envVars))
+	}
+	for i, want := range wantOrder {
+		if agentUpdater.envVars[i].name != want {
+			t.Errorf("env var[%d]: want %q, got %q", i, want, agentUpdater.envVars[i].name)
+		}
+	}
+}

--- a/pkg/autoconf/detectclaudevertex.go
+++ b/pkg/autoconf/detectclaudevertex.go
@@ -21,6 +21,9 @@ package autoconf
 import (
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
 )
 
 // vertexEnvVars lists the environment variables required for Vertex AI configuration,
@@ -89,8 +92,10 @@ func newVertexDetectorWithInjection(lookupEnv func(string) (string, bool), statF
 
 // Detect returns a non-nil VertexConfig when all three required environment
 // variables (CLAUDE_CODE_USE_VERTEX, ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION)
-// are set to non-empty values and the ADC file exists on disk.
-// Returns (nil, nil) when any condition is not met.
+// are set to non-empty values and the credentials file exists on disk.
+// The credentials file is looked up via GOOGLE_APPLICATION_CREDENTIALS first;
+// if that variable is absent or empty the platform-specific ADC default path
+// is used instead. Returns (nil, nil) when any condition is not met.
 func (d *envVertexDetector) Detect() (*VertexConfig, error) {
 	envVarValues := make(map[string]string, len(vertexEnvVars))
 	for _, name := range vertexEnvVars {
@@ -101,18 +106,38 @@ func (d *envVertexDetector) Detect() (*VertexConfig, error) {
 		envVarValues[name] = val
 	}
 
-	detectPath := adcDetectPath(d.homeDir)
-	if detectPath == "" {
-		return nil, nil
+	var detectPath, hostPath string
+	if gac, ok := d.lookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok && gac != "" {
+		detectPath = gac
+		hostPath = credHostPath(gac, d.homeDir)
+	} else {
+		detectPath = adcDetectPath(d.homeDir)
+		if detectPath == "" {
+			return nil, nil
+		}
+		hostPath = adcConfigHostPath(d.homeDir)
+		if hostPath == "" {
+			return nil, nil
+		}
 	}
+
 	if err := d.statFile(detectPath); err != nil {
 		return nil, nil
 	}
 
-	hostPath := adcConfigHostPath(d.homeDir)
-	if hostPath == "" {
-		return nil, nil
-	}
-
 	return &VertexConfig{EnvVars: envVarValues, ADCHostPath: hostPath}, nil
+}
+
+// credHostPath converts an absolute credentials file path to the form used in
+// workspace mount entries. When p is under homeDir it is expressed as
+// $HOME/<rel> so the mount works on any machine; otherwise p is returned as-is.
+func credHostPath(p, homeDir string) string {
+	if homeDir == "" {
+		return p
+	}
+	rel, err := filepath.Rel(homeDir, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return p
+	}
+	return path.Join("$HOME", filepath.ToSlash(rel))
 }

--- a/pkg/autoconf/detectclaudevertex.go
+++ b/pkg/autoconf/detectclaudevertex.go
@@ -59,9 +59,10 @@ type VertexDetector interface {
 // envVertexDetector is the default implementation, reading from os.LookupEnv
 // and checking for the ADC file via os.Stat.
 type envVertexDetector struct {
-	lookupEnv func(string) (string, bool)
-	statFile  func(string) error
-	homeDir   string
+	lookupEnv  func(string) (string, bool)
+	statFile   func(string) error
+	homeDir    string
+	appDataDir string // value of %APPDATA% on Windows; empty on other platforms
 }
 
 var _ VertexDetector = (*envVertexDetector)(nil)
@@ -74,19 +75,22 @@ func NewVertexDetector() (VertexDetector, error) {
 		return nil, fmt.Errorf("could not determine home directory: %w", err)
 	}
 	return &envVertexDetector{
-		lookupEnv: os.LookupEnv,
-		statFile:  func(p string) error { _, err := os.Stat(p); return err },
-		homeDir:   homeDir,
+		lookupEnv:  os.LookupEnv,
+		statFile:   func(p string) error { _, err := os.Stat(p); return err },
+		homeDir:    homeDir,
+		appDataDir: os.Getenv("APPDATA"),
 	}, nil
 }
 
 // newVertexDetectorWithInjection creates an envVertexDetector with injectable
-// lookupEnv and statFile functions. Used in tests.
-func newVertexDetectorWithInjection(lookupEnv func(string) (string, bool), statFile func(string) error, homeDir string) VertexDetector {
+// dependencies. appDataDir substitutes %APPDATA% on Windows; pass "" on
+// non-Windows or in tests that don't exercise the Windows ADC path.
+func newVertexDetectorWithInjection(lookupEnv func(string) (string, bool), statFile func(string) error, homeDir, appDataDir string) VertexDetector {
 	return &envVertexDetector{
-		lookupEnv: lookupEnv,
-		statFile:  statFile,
-		homeDir:   homeDir,
+		lookupEnv:  lookupEnv,
+		statFile:   statFile,
+		homeDir:    homeDir,
+		appDataDir: appDataDir,
 	}
 }
 
@@ -111,11 +115,11 @@ func (d *envVertexDetector) Detect() (*VertexConfig, error) {
 		detectPath = gac
 		hostPath = credHostPath(gac, d.homeDir)
 	} else {
-		detectPath = adcDetectPath(d.homeDir)
+		detectPath = adcDetectPath(d.homeDir, d.appDataDir)
 		if detectPath == "" {
 			return nil, nil
 		}
-		hostPath = adcConfigHostPath(d.homeDir)
+		hostPath = adcConfigHostPath(d.homeDir, d.appDataDir)
 		if hostPath == "" {
 			return nil, nil
 		}

--- a/pkg/autoconf/detectclaudevertex.go
+++ b/pkg/autoconf/detectclaudevertex.go
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"fmt"
+	"os"
+)
+
+// vertexEnvVars lists the environment variables required for Vertex AI configuration,
+// in the order they will be written to config files.
+var vertexEnvVars = []string{
+	"CLAUDE_CODE_USE_VERTEX",
+	"ANTHROPIC_VERTEX_PROJECT_ID",
+	"CLOUD_ML_REGION",
+}
+
+// ADCContainerPath is the target path inside the workspace container for the
+// ADC file mount, expressed with the $HOME variable that the runtime expands.
+const ADCContainerPath = "$HOME/.config/gcloud/application_default_credentials.json"
+
+// VertexConfig holds the Vertex AI environment variables detected from the environment.
+// A non-nil value means all required env vars are set and the ADC file exists.
+type VertexConfig struct {
+	// EnvVars maps env var names to their values for the vars that were detected.
+	EnvVars map[string]string
+	// ADCHostPath is the host-side path to use in the workspace mount entry.
+	// It always starts with $HOME. On Linux/macOS this equals ADCContainerPath;
+	// on Windows it is computed from %APPDATA% relative to the home directory.
+	ADCHostPath string
+}
+
+// VertexDetector detects Vertex AI configuration in the environment.
+// Detect takes no parameters — data sources are baked in at construction time,
+// consistent with the SecretDetector pattern.
+type VertexDetector interface {
+	Detect() (*VertexConfig, error)
+}
+
+// envVertexDetector is the default implementation, reading from os.LookupEnv
+// and checking for the ADC file via os.Stat.
+type envVertexDetector struct {
+	lookupEnv func(string) (string, bool)
+	statFile  func(string) error
+	homeDir   string
+}
+
+var _ VertexDetector = (*envVertexDetector)(nil)
+
+// NewVertexDetector returns a VertexDetector that reads from the process environment.
+// Returns an error only if the home directory cannot be determined.
+func NewVertexDetector() (VertexDetector, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return &envVertexDetector{
+		lookupEnv: os.LookupEnv,
+		statFile:  func(p string) error { _, err := os.Stat(p); return err },
+		homeDir:   homeDir,
+	}, nil
+}
+
+// newVertexDetectorWithInjection creates an envVertexDetector with injectable
+// lookupEnv and statFile functions. Used in tests.
+func newVertexDetectorWithInjection(lookupEnv func(string) (string, bool), statFile func(string) error, homeDir string) VertexDetector {
+	return &envVertexDetector{
+		lookupEnv: lookupEnv,
+		statFile:  statFile,
+		homeDir:   homeDir,
+	}
+}
+
+// Detect returns a non-nil VertexConfig when all three required environment
+// variables (CLAUDE_CODE_USE_VERTEX, ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION)
+// are set to non-empty values and the ADC file exists on disk.
+// Returns (nil, nil) when any condition is not met.
+func (d *envVertexDetector) Detect() (*VertexConfig, error) {
+	envVarValues := make(map[string]string, len(vertexEnvVars))
+	for _, name := range vertexEnvVars {
+		val, ok := d.lookupEnv(name)
+		if !ok || val == "" {
+			return nil, nil
+		}
+		envVarValues[name] = val
+	}
+
+	detectPath := adcDetectPath(d.homeDir)
+	if detectPath == "" {
+		return nil, nil
+	}
+	if err := d.statFile(detectPath); err != nil {
+		return nil, nil
+	}
+
+	hostPath := adcConfigHostPath(d.homeDir)
+	if hostPath == "" {
+		return nil, nil
+	}
+
+	return &VertexConfig{EnvVars: envVarValues, ADCHostPath: hostPath}, nil
+}

--- a/pkg/autoconf/detectclaudevertex_test.go
+++ b/pkg/autoconf/detectclaudevertex_test.go
@@ -20,6 +20,7 @@ package autoconf
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 )
 
@@ -35,6 +36,21 @@ func fullEnv() func(string) (string, bool) {
 			return "us-east5", true
 		}
 		return "", false
+	}
+}
+
+// fullEnvWithGAC returns a lookupEnv stub with all three required Vertex env
+// vars set plus GOOGLE_APPLICATION_CREDENTIALS set to gacPath.
+// When gacPath is empty the variable is reported as absent.
+func fullEnvWithGAC(gacPath string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		if name == "GOOGLE_APPLICATION_CREDENTIALS" {
+			if gacPath == "" {
+				return "", false
+			}
+			return gacPath, true
+		}
+		return fullEnv()(name)
 	}
 }
 
@@ -136,6 +152,77 @@ func TestVertexDetector_ADCFileMissing(t *testing.T) {
 	}
 	if cfg != nil {
 		t.Errorf("expected nil when ADC file is absent, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_UsedWhenSet(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	customCreds := filepath.Join(homeDir, "custom", "creds.json")
+
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcExists, homeDir)
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config when GOOGLE_APPLICATION_CREDENTIALS is set")
+	}
+	want := "$HOME/custom/creds.json"
+	if cfg.ADCHostPath != want {
+		t.Errorf("ADCHostPath: want %q, got %q", want, cfg.ADCHostPath)
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_FileMissing(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	customCreds := filepath.Join(homeDir, "custom", "creds.json")
+
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcMissing, homeDir)
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg != nil {
+		t.Error("expected nil config when GOOGLE_APPLICATION_CREDENTIALS file is missing")
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_EmptyFallsBackToADC(t *testing.T) {
+	t.Parallel()
+
+	// Empty GOOGLE_APPLICATION_CREDENTIALS → fall back to platform-specific ADC path.
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(""), adcExists, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config when falling back to default ADC path")
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_OutsideHome(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	otherDir := t.TempDir() // sibling of homeDir — not under homeDir
+	customCreds := filepath.Join(otherDir, "creds.json")
+
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcExists, homeDir)
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	// Path is not under homeDir → returned as-is (absolute path).
+	if cfg.ADCHostPath != customCreds {
+		t.Errorf("ADCHostPath: want %q, got %q", customCreds, cfg.ADCHostPath)
 	}
 }
 

--- a/pkg/autoconf/detectclaudevertex_test.go
+++ b/pkg/autoconf/detectclaudevertex_test.go
@@ -21,6 +21,7 @@ package autoconf
 import (
 	"errors"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -60,10 +61,150 @@ func adcExists(_ string) error { return nil }
 // adcMissing is a statFile stub that reports the ADC file as absent.
 func adcMissing(_ string) error { return errors.New("file not found") }
 
+func TestVertexDetector_MissingClaudeCodeUseVertex(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "CLAUDE_CODE_USE_VERTEX" {
+			return "", false
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user", "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil VertexConfig when CLAUDE_CODE_USE_VERTEX is unset, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_MissingProjectID(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "ANTHROPIC_VERTEX_PROJECT_ID" {
+			return "", false
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user", "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when ANTHROPIC_VERTEX_PROJECT_ID is unset, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_MissingRegion(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "CLOUD_ML_REGION" {
+			return "", false
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user", "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when CLOUD_ML_REGION is unset, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_ADCFileMissing(t *testing.T) {
+	t.Parallel()
+
+	d := newVertexDetectorWithInjection(fullEnv(), adcMissing, "/home/user", "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when ADC file is absent, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_UsedWhenSet(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	customCreds := filepath.Join(homeDir, "custom", "creds.json")
+
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcExists, homeDir, "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config when GOOGLE_APPLICATION_CREDENTIALS is set")
+	}
+	want := "$HOME/custom/creds.json"
+	if cfg.ADCHostPath != want {
+		t.Errorf("ADCHostPath: want %q, got %q", want, cfg.ADCHostPath)
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_FileMissing(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	customCreds := filepath.Join(homeDir, "custom", "creds.json")
+
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcMissing, homeDir, "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg != nil {
+		t.Error("expected nil config when GOOGLE_APPLICATION_CREDENTIALS file is missing")
+	}
+}
+
+func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_OutsideHome(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	otherDir := t.TempDir() // sibling of homeDir — not under homeDir
+	customCreds := filepath.Join(otherDir, "creds.json")
+
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcExists, homeDir, "")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	// Path is not under homeDir → returned as-is (absolute path).
+	if cfg.ADCHostPath != customCreds {
+		t.Errorf("ADCHostPath: want %q, got %q", customCreds, cfg.ADCHostPath)
+	}
+}
+
+// platformTestDirs returns a homeDir and an appDataDir appropriate for the
+// current OS. On Windows, appDataDir is a subdirectory of homeDir matching the
+// real %APPDATA% layout; on other systems it is empty (the detector ignores it).
+func platformTestDirs(t *testing.T) (homeDir, appDataDir string) {
+	t.Helper()
+	homeDir = t.TempDir()
+	if runtime.GOOS == "windows" {
+		appDataDir = filepath.Join(homeDir, "AppData", "Roaming")
+	}
+	return homeDir, appDataDir
+}
+
 func TestVertexDetector_AllConditionsMet(t *testing.T) {
 	t.Parallel()
 
-	d := newVertexDetectorWithInjection(fullEnv(), adcExists, "/home/user")
+	homeDir, appDataDir := platformTestDirs(t)
+	d := newVertexDetectorWithInjection(fullEnv(), adcExists, homeDir, appDataDir)
 	cfg, err := d.Detect()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -85,144 +226,45 @@ func TestVertexDetector_AllConditionsMet(t *testing.T) {
 	}
 }
 
-func TestVertexDetector_MissingClaudeCodeUseVertex(t *testing.T) {
-	t.Parallel()
-
-	lookup := func(name string) (string, bool) {
-		if name == "CLAUDE_CODE_USE_VERTEX" {
-			return "", false
-		}
-		return fullEnv()(name)
-	}
-	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
-	cfg, err := d.Detect()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg != nil {
-		t.Errorf("expected nil VertexConfig when CLAUDE_CODE_USE_VERTEX is unset, got %+v", cfg)
-	}
-}
-
-func TestVertexDetector_MissingProjectID(t *testing.T) {
-	t.Parallel()
-
-	lookup := func(name string) (string, bool) {
-		if name == "ANTHROPIC_VERTEX_PROJECT_ID" {
-			return "", false
-		}
-		return fullEnv()(name)
-	}
-	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
-	cfg, err := d.Detect()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg != nil {
-		t.Errorf("expected nil when ANTHROPIC_VERTEX_PROJECT_ID is unset, got %+v", cfg)
-	}
-}
-
-func TestVertexDetector_MissingRegion(t *testing.T) {
-	t.Parallel()
-
-	lookup := func(name string) (string, bool) {
-		if name == "CLOUD_ML_REGION" {
-			return "", false
-		}
-		return fullEnv()(name)
-	}
-	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
-	cfg, err := d.Detect()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg != nil {
-		t.Errorf("expected nil when CLOUD_ML_REGION is unset, got %+v", cfg)
-	}
-}
-
-func TestVertexDetector_ADCFileMissing(t *testing.T) {
-	t.Parallel()
-
-	d := newVertexDetectorWithInjection(fullEnv(), adcMissing, "/home/user")
-	cfg, err := d.Detect()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg != nil {
-		t.Errorf("expected nil when ADC file is absent, got %+v", cfg)
-	}
-}
-
-func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_UsedWhenSet(t *testing.T) {
+func TestVertexDetector_AppDataDir_DoesNotBreakDetection(t *testing.T) {
 	t.Parallel()
 
 	homeDir := t.TempDir()
-	customCreds := filepath.Join(homeDir, "custom", "creds.json")
+	var appDataDir string
+	if runtime.GOOS == "windows" {
+		// On Windows appDataDir must be under homeDir so adcConfigHostPath can
+		// compute a $HOME-relative path for the mount entry.
+		appDataDir = filepath.Join(homeDir, "AppData", "Roaming")
+	} else {
+		// On non-Windows adcDetectPath ignores appDataDir; a sibling TempDir
+		// that is unrelated to homeDir must not prevent detection.
+		appDataDir = t.TempDir()
+	}
 
-	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcExists, homeDir)
+	d := newVertexDetectorWithInjection(fullEnv(), adcExists, homeDir, appDataDir)
 	cfg, err := d.Detect()
 	if err != nil {
 		t.Fatalf("Detect: %v", err)
 	}
 	if cfg == nil {
-		t.Fatal("expected non-nil config when GOOGLE_APPLICATION_CREDENTIALS is set")
+		t.Fatal("expected non-nil VertexConfig when appDataDir is set")
 	}
-	want := "$HOME/custom/creds.json"
-	if cfg.ADCHostPath != want {
-		t.Errorf("ADCHostPath: want %q, got %q", want, cfg.ADCHostPath)
-	}
-}
-
-func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_FileMissing(t *testing.T) {
-	t.Parallel()
-
-	homeDir := t.TempDir()
-	customCreds := filepath.Join(homeDir, "custom", "creds.json")
-
-	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcMissing, homeDir)
-	cfg, err := d.Detect()
-	if err != nil {
-		t.Fatalf("Detect: %v", err)
-	}
-	if cfg != nil {
-		t.Error("expected nil config when GOOGLE_APPLICATION_CREDENTIALS file is missing")
+	if cfg.ADCHostPath == "" {
+		t.Error("expected ADCHostPath to be non-empty")
 	}
 }
 
 func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_EmptyFallsBackToADC(t *testing.T) {
 	t.Parallel()
 
-	// Empty GOOGLE_APPLICATION_CREDENTIALS → fall back to platform-specific ADC path.
-	d := newVertexDetectorWithInjection(fullEnvWithGAC(""), adcExists, "/home/user")
+	homeDir, appDataDir := platformTestDirs(t)
+	d := newVertexDetectorWithInjection(fullEnvWithGAC(""), adcExists, homeDir, appDataDir)
 	cfg, err := d.Detect()
 	if err != nil {
 		t.Fatalf("Detect: %v", err)
 	}
 	if cfg == nil {
 		t.Fatal("expected non-nil config when falling back to default ADC path")
-	}
-}
-
-func TestVertexDetector_GOOGLE_APPLICATION_CREDENTIALS_OutsideHome(t *testing.T) {
-	t.Parallel()
-
-	homeDir := t.TempDir()
-	otherDir := t.TempDir() // sibling of homeDir — not under homeDir
-	customCreds := filepath.Join(otherDir, "creds.json")
-
-	d := newVertexDetectorWithInjection(fullEnvWithGAC(customCreds), adcExists, homeDir)
-	cfg, err := d.Detect()
-	if err != nil {
-		t.Fatalf("Detect: %v", err)
-	}
-	if cfg == nil {
-		t.Fatal("expected non-nil config")
-	}
-	// Path is not under homeDir → returned as-is (absolute path).
-	if cfg.ADCHostPath != customCreds {
-		t.Errorf("ADCHostPath: want %q, got %q", customCreds, cfg.ADCHostPath)
 	}
 }
 
@@ -235,7 +277,7 @@ func TestVertexDetector_EmptyEnvVarValue(t *testing.T) {
 		}
 		return fullEnv()(name)
 	}
-	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user", "")
 	cfg, err := d.Detect()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/autoconf/detectclaudevertex_test.go
+++ b/pkg/autoconf/detectclaudevertex_test.go
@@ -1,0 +1,159 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"errors"
+	"testing"
+)
+
+// fullEnv returns a lookupEnv stub with all three required Vertex env vars set.
+func fullEnv() func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		switch name {
+		case "CLAUDE_CODE_USE_VERTEX":
+			return "1", true
+		case "ANTHROPIC_VERTEX_PROJECT_ID":
+			return "my-project", true
+		case "CLOUD_ML_REGION":
+			return "us-east5", true
+		}
+		return "", false
+	}
+}
+
+// adcExists is a statFile stub that reports the ADC file as present.
+func adcExists(_ string) error { return nil }
+
+// adcMissing is a statFile stub that reports the ADC file as absent.
+func adcMissing(_ string) error { return errors.New("file not found") }
+
+func TestVertexDetector_AllConditionsMet(t *testing.T) {
+	t.Parallel()
+
+	d := newVertexDetectorWithInjection(fullEnv(), adcExists, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil VertexConfig, got nil")
+	}
+	if cfg.EnvVars["CLAUDE_CODE_USE_VERTEX"] != "1" {
+		t.Errorf("expected CLAUDE_CODE_USE_VERTEX=1, got %q", cfg.EnvVars["CLAUDE_CODE_USE_VERTEX"])
+	}
+	if cfg.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"] != "my-project" {
+		t.Errorf("expected ANTHROPIC_VERTEX_PROJECT_ID=my-project, got %q", cfg.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"])
+	}
+	if cfg.EnvVars["CLOUD_ML_REGION"] != "us-east5" {
+		t.Errorf("expected CLOUD_ML_REGION=us-east5, got %q", cfg.EnvVars["CLOUD_ML_REGION"])
+	}
+	if cfg.ADCHostPath == "" {
+		t.Error("expected ADCHostPath to be set")
+	}
+}
+
+func TestVertexDetector_MissingClaudeCodeUseVertex(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "CLAUDE_CODE_USE_VERTEX" {
+			return "", false
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil VertexConfig when CLAUDE_CODE_USE_VERTEX is unset, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_MissingProjectID(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "ANTHROPIC_VERTEX_PROJECT_ID" {
+			return "", false
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when ANTHROPIC_VERTEX_PROJECT_ID is unset, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_MissingRegion(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "CLOUD_ML_REGION" {
+			return "", false
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when CLOUD_ML_REGION is unset, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_ADCFileMissing(t *testing.T) {
+	t.Parallel()
+
+	d := newVertexDetectorWithInjection(fullEnv(), adcMissing, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when ADC file is absent, got %+v", cfg)
+	}
+}
+
+func TestVertexDetector_EmptyEnvVarValue(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		if name == "CLAUDE_CODE_USE_VERTEX" {
+			return "", true // present but empty
+		}
+		return fullEnv()(name)
+	}
+	d := newVertexDetectorWithInjection(lookup, adcExists, "/home/user")
+	cfg, err := d.Detect()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil when env var is present but empty, got %+v", cfg)
+	}
+}

--- a/pkg/cmd/autoconf.go
+++ b/pkg/cmd/autoconf.go
@@ -44,6 +44,12 @@ type autoconfCmd struct {
 	detector         autoconf.SecretDetector
 	confirm          func(prompt string) (bool, error)
 	selectTarget     func(secretName string, options []autoconf.ConfigTargetOption) (autoconf.ConfigTarget, error)
+
+	vertexDetector     autoconf.VertexDetector
+	agentUpdater       config.AgentConfigUpdater
+	agentLoader        config.AgentConfigLoader
+	workspaceCfg       config.Config
+	vertexSelectTarget func(options []autoconf.ClaudeVertexConfigTargetOption) (autoconf.ClaudeVertexConfigTarget, error)
 }
 
 func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
@@ -89,10 +95,31 @@ func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
 	if wcErr != nil {
 		return fmt.Errorf("failed to create workspace config: %w", wcErr)
 	}
+	a.workspaceCfg = workspaceCfg
 
 	if a.detector == nil {
 		a.detector = autoconf.NewFilteredSecretDetector(services, a.store, loader, a.projectID, workspaceCfg)
 	}
+
+	if a.vertexDetector == nil {
+		vd, vdErr := autoconf.NewVertexDetector()
+		if vdErr != nil {
+			return fmt.Errorf("failed to create vertex detector: %w", vdErr)
+		}
+		a.vertexDetector = vd
+	}
+
+	agentUpdater, auErr := config.NewAgentConfigUpdater(absStorageDir)
+	if auErr != nil {
+		return fmt.Errorf("failed to create agent config updater: %w", auErr)
+	}
+	a.agentUpdater = agentUpdater
+
+	agentLoader, alErr := config.NewAgentConfigLoader(absStorageDir)
+	if alErr != nil {
+		return fmt.Errorf("failed to create agent config loader: %w", alErr)
+	}
+	a.agentLoader = agentLoader
 
 	wu, wuErr := config.NewWorkspaceConfigUpdater(kaidenDir)
 	if wuErr != nil {
@@ -105,6 +132,9 @@ func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
 	}
 	if a.selectTarget == nil {
 		a.selectTarget = huhSelectTarget
+	}
+	if a.vertexSelectTarget == nil {
+		a.vertexSelectTarget = huhSelectVertexTarget
 	}
 
 	return nil
@@ -122,6 +152,24 @@ func huhConfirm(prompt string) (bool, error) {
 		return false, nil
 	}
 	return ok, err
+}
+
+func huhSelectVertexTarget(options []autoconf.ClaudeVertexConfigTargetOption) (autoconf.ClaudeVertexConfigTarget, error) {
+	huhOptions := make([]huh.Option[autoconf.ClaudeVertexConfigTarget], len(options))
+	for i, opt := range options {
+		huhOptions[i] = huh.NewOption(opt.Label, opt.Target)
+	}
+
+	var selected autoconf.ClaudeVertexConfigTarget
+	err := huh.NewSelect[autoconf.ClaudeVertexConfigTarget]().
+		Title("Add Vertex AI configuration to:").
+		Options(huhOptions...).
+		Value(&selected).
+		Run()
+	if errors.Is(err, huh.ErrUserAborted) {
+		return 0, autoconf.ErrSkipped
+	}
+	return selected, err
 }
 
 func huhSelectTarget(secretName string, options []autoconf.ConfigTargetOption) (autoconf.ConfigTarget, error) {
@@ -143,6 +191,8 @@ func huhSelectTarget(secretName string, options []autoconf.ConfigTargetOption) (
 }
 
 func (a *autoconfCmd) run(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+
 	runner := autoconf.New(autoconf.Options{
 		Detector:         a.detector,
 		Store:            a.store,
@@ -153,7 +203,24 @@ func (a *autoconfCmd) run(cmd *cobra.Command, args []string) error {
 		Confirm:          a.confirm,
 		SelectTarget:     a.selectTarget,
 	})
-	return runner.Run(cmd.OutOrStdout())
+	if err := runner.Run(out); err != nil {
+		return err
+	}
+
+	if a.vertexDetector == nil {
+		return nil
+	}
+	vertexRunner := autoconf.NewClaudeVertexAutoconf(autoconf.ClaudeVertexAutoconfOptions{
+		Detector:         a.vertexDetector,
+		AgentUpdater:     a.agentUpdater,
+		WorkspaceUpdater: a.workspaceUpdater,
+		AgentLoader:      a.agentLoader,
+		WorkspaceConfig:  a.workspaceCfg,
+		Yes:              a.yes,
+		Confirm:          a.confirm,
+		SelectTarget:     a.vertexSelectTarget,
+	})
+	return vertexRunner.Run(out)
 }
 
 // NewAutoconfCmd returns the autoconf command.

--- a/pkg/cmd/autoconf_test.go
+++ b/pkg/cmd/autoconf_test.go
@@ -251,6 +251,104 @@ func TestAutoconfCmd_Run_YesFlag(t *testing.T) {
 	}
 }
 
+// TestAutoconfCmd_Run_WithVertexDetector verifies that when a vertexDetector is
+// wired in, run() invokes the Vertex AI autoconf path.
+func TestAutoconfCmd_Run_WithVertexDetector(t *testing.T) {
+	t.Parallel()
+
+	agentUpdater := &fakeAutoconfCmdAgentUpdater{}
+	c := &autoconfCmd{
+		detector: &fakeAutoconfCmdDetector{},
+		confirm:  func(string) (bool, error) { return true, nil },
+		selectTarget: func(_ string, _ []autoconf.ConfigTargetOption) (autoconf.ConfigTarget, error) {
+			return autoconf.ConfigTargetGlobal, nil
+		},
+		vertexDetector: &fakeAutoconfCmdVertexDetector{cfg: &autoconf.VertexConfig{
+			EnvVars: map[string]string{
+				"CLAUDE_CODE_USE_VERTEX":      "1",
+				"ANTHROPIC_VERTEX_PROJECT_ID": "my-project",
+				"CLOUD_ML_REGION":             "us-east5",
+			},
+			ADCHostPath: autoconf.ADCContainerPath,
+		}},
+		agentUpdater: agentUpdater,
+		yes:          true,
+		vertexSelectTarget: func(_ []autoconf.ClaudeVertexConfigTargetOption) (autoconf.ClaudeVertexConfigTarget, error) {
+			return autoconf.ClaudeVertexConfigTargetAgent, nil
+		},
+	}
+
+	cmd := NewAutoconfCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+
+	if err := c.run(cmd, []string{}); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	if len(agentUpdater.envVars) != 3 {
+		t.Errorf("expected 3 env vars written to agent config, got %d", len(agentUpdater.envVars))
+	}
+	if len(agentUpdater.mounts) != 1 {
+		t.Errorf("expected 1 mount written to agent config, got %d", len(agentUpdater.mounts))
+	}
+	if !strings.Contains(out.String(), "claude agent config") {
+		t.Errorf("expected vertex output in stdout, got: %q", out.String())
+	}
+}
+
+// TestAutoconfCmd_PreRun_SetsVertexFields verifies that preRun wires vertex-related
+// dependencies (vertexDetector, agentUpdater, agentLoader, vertexSelectTarget).
+func TestAutoconfCmd_PreRun_SetsVertexFields(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	c := &autoconfCmd{}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.Flags().String("storage", storageDir, "")
+
+	if err := c.preRun(cmd, []string{}); err != nil {
+		t.Fatalf("preRun returned error: %v", err)
+	}
+
+	if c.vertexDetector == nil {
+		t.Error("vertexDetector not set by preRun")
+	}
+	if c.agentUpdater == nil {
+		t.Error("agentUpdater not set by preRun")
+	}
+	if c.agentLoader == nil {
+		t.Error("agentLoader not set by preRun")
+	}
+	if c.vertexSelectTarget == nil {
+		t.Error("vertexSelectTarget not set by preRun")
+	}
+}
+
+// TestAutoconfCmd_PreRun_PreservesInjectedVertexDetector verifies the nil-guard:
+// a pre-populated vertexDetector must not be overwritten by preRun.
+func TestAutoconfCmd_PreRun_PreservesInjectedVertexDetector(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	injected := &fakeAutoconfCmdVertexDetector{}
+	c := &autoconfCmd{vertexDetector: injected}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.Flags().String("storage", storageDir, "")
+
+	if err := c.preRun(cmd, []string{}); err != nil {
+		t.Fatalf("preRun returned error: %v", err)
+	}
+
+	if c.vertexDetector != injected {
+		t.Error("preRun overwrote the pre-injected vertexDetector")
+	}
+}
+
 // fakeAutoconfCmdStore satisfies secret.Store for cmd-level run() tests.
 type fakeAutoconfCmdStore struct{}
 
@@ -265,3 +363,28 @@ func (fakeAutoconfCmdStore) Get(_ string) (secret.ListItem, string, error) {
 type fakeAutoconfCmdUpdater struct{}
 
 func (f *fakeAutoconfCmdUpdater) AddSecret(_, _ string) error { return nil }
+
+// fakeAutoconfCmdVertexDetector satisfies autoconf.VertexDetector for cmd-level tests.
+type fakeAutoconfCmdVertexDetector struct {
+	cfg *autoconf.VertexConfig
+}
+
+func (f *fakeAutoconfCmdVertexDetector) Detect() (*autoconf.VertexConfig, error) {
+	return f.cfg, nil
+}
+
+// fakeAutoconfCmdAgentUpdater satisfies config.AgentConfigUpdater for cmd-level tests.
+type fakeAutoconfCmdAgentUpdater struct {
+	envVars []struct{ agentName, name, value string }
+	mounts  []struct{ agentName, host, target string }
+}
+
+func (f *fakeAutoconfCmdAgentUpdater) AddEnvVar(agentName, name, value string) error {
+	f.envVars = append(f.envVars, struct{ agentName, name, value string }{agentName, name, value})
+	return nil
+}
+
+func (f *fakeAutoconfCmdAgentUpdater) AddMount(agentName, host, target string, _ bool) error {
+	f.mounts = append(f.mounts, struct{ agentName, host, target string }{agentName, host, target})
+	return nil
+}

--- a/pkg/config/agents.go
+++ b/pkg/config/agents.go
@@ -34,6 +34,130 @@ var (
 	ErrInvalidAgentConfig = errors.New("invalid agent configuration")
 )
 
+// AgentConfigUpdater adds entries to the per-agent configuration file (agents.json).
+type AgentConfigUpdater interface {
+	// AddEnvVar adds or updates an environment variable in the agent's config.
+	// If an entry with the same name already exists its value is replaced.
+	AddEnvVar(agentName, name, value string) error
+
+	// AddMount adds a mount entry to the agent's config.
+	// The call is idempotent: if a mount with the same host and target already exists
+	// it is not duplicated.
+	AddMount(agentName, host, target string, ro bool) error
+}
+
+// agentConfigUpdater is the unexported implementation.
+type agentConfigUpdater struct {
+	storageDir string
+}
+
+var _ AgentConfigUpdater = (*agentConfigUpdater)(nil)
+
+// NewAgentConfigUpdater returns an AgentConfigUpdater backed by
+// <storageDir>/config/agents.json.
+func NewAgentConfigUpdater(storageDir string) (AgentConfigUpdater, error) {
+	if storageDir == "" {
+		return nil, ErrInvalidPath
+	}
+	absPath, err := filepath.Abs(storageDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve storage directory path: %w", err)
+	}
+	return &agentConfigUpdater{storageDir: absPath}, nil
+}
+
+func (a *agentConfigUpdater) AddEnvVar(agentName, name, value string) error {
+	configPath := filepath.Join(a.storageDir, "config", AgentsConfigFile)
+
+	agentsConfig, err := a.readAgentsFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	cfg := agentsConfig[agentName]
+
+	if cfg.Environment == nil {
+		v := value
+		envVars := []workspace.EnvironmentVariable{{Name: name, Value: &v}}
+		cfg.Environment = &envVars
+	} else {
+		for i, e := range *cfg.Environment {
+			if e.Name == name {
+				v := value
+				(*cfg.Environment)[i].Value = &v
+				(*cfg.Environment)[i].Secret = nil
+				agentsConfig[agentName] = cfg
+				return a.writeAgentsFile(configPath, agentsConfig)
+			}
+		}
+		v := value
+		*cfg.Environment = append(*cfg.Environment, workspace.EnvironmentVariable{Name: name, Value: &v})
+	}
+
+	agentsConfig[agentName] = cfg
+	return a.writeAgentsFile(configPath, agentsConfig)
+}
+
+func (a *agentConfigUpdater) AddMount(agentName, host, target string, ro bool) error {
+	configPath := filepath.Join(a.storageDir, "config", AgentsConfigFile)
+
+	agentsConfig, err := a.readAgentsFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	cfg := agentsConfig[agentName]
+
+	if cfg.Mounts == nil {
+		roVal := ro
+		mounts := []workspace.Mount{{Host: host, Target: target, Ro: &roVal}}
+		cfg.Mounts = &mounts
+	} else {
+		for _, m := range *cfg.Mounts {
+			if m.Host == host && m.Target == target {
+				return nil
+			}
+		}
+		roVal := ro
+		*cfg.Mounts = append(*cfg.Mounts, workspace.Mount{Host: host, Target: target, Ro: &roVal})
+	}
+
+	agentsConfig[agentName] = cfg
+	return a.writeAgentsFile(configPath, agentsConfig)
+}
+
+func (a *agentConfigUpdater) readAgentsFile(configPath string) (map[string]workspace.WorkspaceConfiguration, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]workspace.WorkspaceConfiguration), nil
+		}
+		return nil, fmt.Errorf("failed to read agents config: %w", err)
+	}
+
+	var agentsConfig map[string]workspace.WorkspaceConfiguration
+	if err := json.Unmarshal(data, &agentsConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse agents config: %w", err)
+	}
+	return agentsConfig, nil
+}
+
+func (a *agentConfigUpdater) writeAgentsFile(configPath string, agentsConfig map[string]workspace.WorkspaceConfiguration) error {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(agentsConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal agents config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write agents config: %w", err)
+	}
+	return nil
+}
+
 // AgentConfigLoader loads agent-specific workspace configurations
 type AgentConfigLoader interface {
 	// Load reads and returns the workspace configuration for the specified agent.

--- a/pkg/config/agents_test.go
+++ b/pkg/config/agents_test.go
@@ -349,3 +349,152 @@ func TestAgentConfigLoader_ModuleDesignPattern(t *testing.T) {
 		var _ AgentConfigLoader = (*agentConfigLoader)(nil)
 	})
 }
+
+func TestNewAgentConfigUpdater(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates updater successfully", func(t *testing.T) {
+		t.Parallel()
+
+		u, err := NewAgentConfigUpdater(t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u == nil {
+			t.Error("expected non-nil updater")
+		}
+	})
+
+	t.Run("returns error for empty storage dir", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewAgentConfigUpdater("")
+		if !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("expected ErrInvalidPath, got %v", err)
+		}
+	})
+}
+
+func TestAgentConfigUpdater_AddEnvVar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates file when absent", func(t *testing.T) {
+		t.Parallel()
+
+		u, _ := NewAgentConfigUpdater(t.TempDir())
+		if err := u.AddEnvVar("claude", "MY_VAR", "hello"); err != nil {
+			t.Fatalf("AddEnvVar: %v", err)
+		}
+
+		loader, _ := NewAgentConfigLoader(u.(*agentConfigUpdater).storageDir)
+		cfg, err := loader.Load("claude")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Environment == nil || len(*cfg.Environment) != 1 {
+			t.Fatalf("expected 1 env var, got %v", cfg.Environment)
+		}
+		if (*cfg.Environment)[0].Name != "MY_VAR" || *(*cfg.Environment)[0].Value != "hello" {
+			t.Errorf("unexpected env var: %+v", (*cfg.Environment)[0])
+		}
+	})
+
+	t.Run("appends to existing env vars", func(t *testing.T) {
+		t.Parallel()
+
+		u, _ := NewAgentConfigUpdater(t.TempDir())
+		if err := u.AddEnvVar("claude", "A", "1"); err != nil {
+			t.Fatalf("AddEnvVar A: %v", err)
+		}
+		if err := u.AddEnvVar("claude", "B", "2"); err != nil {
+			t.Fatalf("AddEnvVar B: %v", err)
+		}
+
+		loader, _ := NewAgentConfigLoader(u.(*agentConfigUpdater).storageDir)
+		cfg, _ := loader.Load("claude")
+		if len(*cfg.Environment) != 2 {
+			t.Errorf("expected 2 env vars, got %d", len(*cfg.Environment))
+		}
+	})
+
+	t.Run("updates existing env var value", func(t *testing.T) {
+		t.Parallel()
+
+		u, _ := NewAgentConfigUpdater(t.TempDir())
+		if err := u.AddEnvVar("claude", "MY_VAR", "old"); err != nil {
+			t.Fatalf("AddEnvVar first: %v", err)
+		}
+		if err := u.AddEnvVar("claude", "MY_VAR", "new"); err != nil {
+			t.Fatalf("AddEnvVar second: %v", err)
+		}
+
+		loader, _ := NewAgentConfigLoader(u.(*agentConfigUpdater).storageDir)
+		cfg, _ := loader.Load("claude")
+		if len(*cfg.Environment) != 1 {
+			t.Errorf("expected 1 env var (no duplicate), got %d", len(*cfg.Environment))
+		}
+		if *(*cfg.Environment)[0].Value != "new" {
+			t.Errorf("expected value=new, got %q", *(*cfg.Environment)[0].Value)
+		}
+	})
+
+	t.Run("does not affect other agents", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		u, _ := NewAgentConfigUpdater(storageDir)
+		if err := u.AddEnvVar("claude", "MY_VAR", "hello"); err != nil {
+			t.Fatalf("AddEnvVar: %v", err)
+		}
+
+		loader, _ := NewAgentConfigLoader(storageDir)
+		gooseCfg, _ := loader.Load("goose")
+		if gooseCfg.Environment != nil {
+			t.Error("expected goose to have no env vars")
+		}
+	})
+}
+
+func TestAgentConfigUpdater_AddMount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates file when absent", func(t *testing.T) {
+		t.Parallel()
+
+		u, _ := NewAgentConfigUpdater(t.TempDir())
+		if err := u.AddMount("claude", "$HOME/.foo", "$HOME/.foo", true); err != nil {
+			t.Fatalf("AddMount: %v", err)
+		}
+
+		loader, _ := NewAgentConfigLoader(u.(*agentConfigUpdater).storageDir)
+		cfg, _ := loader.Load("claude")
+		if cfg.Mounts == nil || len(*cfg.Mounts) != 1 {
+			t.Fatalf("expected 1 mount, got %v", cfg.Mounts)
+		}
+		m := (*cfg.Mounts)[0]
+		if m.Host != "$HOME/.foo" || m.Target != "$HOME/.foo" {
+			t.Errorf("unexpected mount: %+v", m)
+		}
+		if m.Ro == nil || !*m.Ro {
+			t.Error("expected mount to be read-only")
+		}
+	})
+
+	t.Run("idempotent on same host+target", func(t *testing.T) {
+		t.Parallel()
+
+		u, _ := NewAgentConfigUpdater(t.TempDir())
+		if err := u.AddMount("claude", "$HOME/.foo", "$HOME/.foo", true); err != nil {
+			t.Fatalf("AddMount first: %v", err)
+		}
+		if err := u.AddMount("claude", "$HOME/.foo", "$HOME/.foo", true); err != nil {
+			t.Fatalf("AddMount second: %v", err)
+		}
+
+		loader, _ := NewAgentConfigLoader(u.(*agentConfigUpdater).storageDir)
+		cfg, _ := loader.Load("claude")
+		if len(*cfg.Mounts) != 1 {
+			t.Errorf("expected 1 mount after duplicate, got %d", len(*cfg.Mounts))
+		}
+	})
+}

--- a/pkg/config/workspaceupdater.go
+++ b/pkg/config/workspaceupdater.go
@@ -34,6 +34,15 @@ type WorkspaceConfigUpdater interface {
 	// creating the file and directory if they do not yet exist.
 	// The call is idempotent: if the secret is already present it is not duplicated.
 	AddSecret(secretName string) error
+
+	// AddEnvVar adds or updates an environment variable in the workspace config.
+	// If an entry with the same name already exists its value is replaced.
+	AddEnvVar(name, value string) error
+
+	// AddMount adds a mount entry to the workspace config.
+	// The call is idempotent: if a mount with the same host and target already exists
+	// it is not duplicated.
+	AddMount(host, target string, ro bool) error
 }
 
 type workspaceConfigUpdater struct {
@@ -53,6 +62,59 @@ func NewWorkspaceConfigUpdater(configDir string) (WorkspaceConfigUpdater, error)
 		return nil, fmt.Errorf("failed to resolve config directory path: %w", err)
 	}
 	return &workspaceConfigUpdater{configDir: absPath}, nil
+}
+
+func (w *workspaceConfigUpdater) AddEnvVar(name, value string) error {
+	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
+
+	cfg, err := w.readConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	if cfg.Environment == nil {
+		v := value
+		envVars := []workspace.EnvironmentVariable{{Name: name, Value: &v}}
+		cfg.Environment = &envVars
+	} else {
+		for i, e := range *cfg.Environment {
+			if e.Name == name {
+				v := value
+				(*cfg.Environment)[i].Value = &v
+				(*cfg.Environment)[i].Secret = nil
+				return w.writeConfig(configPath, cfg)
+			}
+		}
+		v := value
+		*cfg.Environment = append(*cfg.Environment, workspace.EnvironmentVariable{Name: name, Value: &v})
+	}
+
+	return w.writeConfig(configPath, cfg)
+}
+
+func (w *workspaceConfigUpdater) AddMount(host, target string, ro bool) error {
+	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
+
+	cfg, err := w.readConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	if cfg.Mounts == nil {
+		roVal := ro
+		mounts := []workspace.Mount{{Host: host, Target: target, Ro: &roVal}}
+		cfg.Mounts = &mounts
+	} else {
+		for _, m := range *cfg.Mounts {
+			if m.Host == host && m.Target == target {
+				return nil
+			}
+		}
+		roVal := ro
+		*cfg.Mounts = append(*cfg.Mounts, workspace.Mount{Host: host, Target: target, Ro: &roVal})
+	}
+
+	return w.writeConfig(configPath, cfg)
 }
 
 func (w *workspaceConfigUpdater) AddSecret(secretName string) error {

--- a/pkg/config/workspaceupdater_test.go
+++ b/pkg/config/workspaceupdater_test.go
@@ -233,6 +233,98 @@ func TestWorkspaceUpdater_WriteConfig_WriteFileFails(t *testing.T) {
 	}
 }
 
+func TestWorkspaceUpdater_AddEnvVar_CreatesFile(t *testing.T) {
+	t.Parallel()
+
+	u, _ := NewWorkspaceConfigUpdater(t.TempDir())
+	if err := u.AddEnvVar("MY_VAR", "hello"); err != nil {
+		t.Fatalf("AddEnvVar: %v", err)
+	}
+
+	dir := u.(*workspaceConfigUpdater).configDir
+	data, err := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	var cfg workspace.WorkspaceConfiguration
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Environment == nil || len(*cfg.Environment) != 1 {
+		t.Fatalf("expected 1 env var, got %v", cfg.Environment)
+	}
+	if (*cfg.Environment)[0].Name != "MY_VAR" || *(*cfg.Environment)[0].Value != "hello" {
+		t.Errorf("unexpected env var: %+v", (*cfg.Environment)[0])
+	}
+}
+
+func TestWorkspaceUpdater_AddEnvVar_UpdatesExisting(t *testing.T) {
+	t.Parallel()
+
+	u, _ := NewWorkspaceConfigUpdater(t.TempDir())
+	if err := u.AddEnvVar("MY_VAR", "old"); err != nil {
+		t.Fatalf("first AddEnvVar: %v", err)
+	}
+	if err := u.AddEnvVar("MY_VAR", "new"); err != nil {
+		t.Fatalf("second AddEnvVar: %v", err)
+	}
+
+	dir := u.(*workspaceConfigUpdater).configDir
+	data, _ := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	var cfg workspace.WorkspaceConfiguration
+	_ = json.Unmarshal(data, &cfg)
+	if len(*cfg.Environment) != 1 {
+		t.Errorf("expected 1 env var (no duplicate), got %d", len(*cfg.Environment))
+	}
+	if *(*cfg.Environment)[0].Value != "new" {
+		t.Errorf("expected value=new, got %q", *(*cfg.Environment)[0].Value)
+	}
+}
+
+func TestWorkspaceUpdater_AddMount_CreatesFile(t *testing.T) {
+	t.Parallel()
+
+	u, _ := NewWorkspaceConfigUpdater(t.TempDir())
+	if err := u.AddMount("$HOME/.foo", "$HOME/.foo", true); err != nil {
+		t.Fatalf("AddMount: %v", err)
+	}
+
+	dir := u.(*workspaceConfigUpdater).configDir
+	data, _ := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	var cfg workspace.WorkspaceConfiguration
+	_ = json.Unmarshal(data, &cfg)
+	if cfg.Mounts == nil || len(*cfg.Mounts) != 1 {
+		t.Fatalf("expected 1 mount, got %v", cfg.Mounts)
+	}
+	m := (*cfg.Mounts)[0]
+	if m.Host != "$HOME/.foo" || m.Target != "$HOME/.foo" {
+		t.Errorf("unexpected mount: %+v", m)
+	}
+	if m.Ro == nil || !*m.Ro {
+		t.Error("expected read-only mount")
+	}
+}
+
+func TestWorkspaceUpdater_AddMount_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	u, _ := NewWorkspaceConfigUpdater(t.TempDir())
+	if err := u.AddMount("$HOME/.foo", "$HOME/.foo", true); err != nil {
+		t.Fatalf("first AddMount: %v", err)
+	}
+	if err := u.AddMount("$HOME/.foo", "$HOME/.foo", true); err != nil {
+		t.Fatalf("second AddMount: %v", err)
+	}
+
+	dir := u.(*workspaceConfigUpdater).configDir
+	data, _ := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	var cfg workspace.WorkspaceConfiguration
+	_ = json.Unmarshal(data, &cfg)
+	if len(*cfg.Mounts) != 1 {
+		t.Errorf("expected 1 mount after duplicate, got %d", len(*cfg.Mounts))
+	}
+}
+
 // TestWorkspaceUpdater_EmptyFile_TreatedAsMissing verifies that a zero-byte
 // workspace.json is treated as an empty config rather than returning a JSON error.
 func TestWorkspaceUpdater_EmptyFile_TreatedAsMissing(t *testing.T) {


### PR DESCRIPTION
Extends kdn autoconf to detect CLAUDE_CODE_USE_VERTEX, ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION, and the ADC file, then writes the env vars and a precise ADC mount to either the claude agent config (all workspaces) or the local workspace.json.

New types: VertexDetector, VertexConfig, ClaudeVertexAutoconf in pkg/autoconf; AgentConfigUpdater, AgentConfigLoader in pkg/config; AddEnvVar and AddMount added to WorkspaceConfigUpdater. Platform-aware helpers compute the Windows %APPDATA% ADC path. README Vertex AI scenario updated to lead with kdn autoconf.

When GOOGLE_APPLICATION_CREDENTIALS is set on the host, the Vertex AI
detector now uses that file instead of the platform-specific ADC
default. The host path is expressed as $HOME/<rel> when the file is
under the user's home directory, or kept absolute otherwise.

Part of #377 

To test it: 
```
gcloud auth application-default login 
export CLAUDE_CODE_USE_VERTEX=1
export ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project-id
export CLOUD_ML_REGION=my-region

kdn autoconf
```