### PR TITLE
chore(OpenShell): prevent nil error on workspace removal

### DIFF
--- a/pkg/runtime/openshell/stop.go
+++ b/pkg/runtime/openshell/stop.go
@@ -53,6 +53,9 @@ func (r *openshellRuntime) Stop(ctx context.Context, id string) error {
 
 // stopPortForwards stops background port forwards. Best-effort — errors are ignored.
 func (r *openshellRuntime) stopPortForwards(ctx context.Context, sandboxName string, ports []int) {
+	if r.executor == nil {
+		return
+	}
 	l := logger.FromContext(ctx)
 	for _, port := range ports {
 		_ = r.executor.Run(ctx, l.Stdout(), l.Stderr(),

--- a/pkg/runtime/openshell/stop_test.go
+++ b/pkg/runtime/openshell/stop_test.go
@@ -113,6 +113,35 @@ func TestStop_StopsPortForwards(t *testing.T) {
 	}
 }
 
+func TestStop_NilExecutorWithPorts(t *testing.T) {
+	t.Parallel()
+
+	storageDir := t.TempDir()
+	rt := &openshellRuntime{
+		storageDir: storageDir,
+		states:     newStateOverrides(storageDir),
+		config:     loadConfig(storageDir),
+	}
+
+	if err := rt.writeSandboxData("kdn-test", sandboxData{
+		SourcePath: "/src",
+		Agent:      "claude",
+		Ports:      []int{8080},
+	}); err != nil {
+		t.Fatalf("writeSandboxData() failed: %v", err)
+	}
+
+	err := rt.Stop(context.Background(), "kdn-test")
+	if err != nil {
+		t.Fatalf("Stop() should not panic or error with nil executor, got: %v", err)
+	}
+
+	state, ok := rt.states.Get("kdn-test")
+	if !ok || state != api.WorkspaceStateStopped {
+		t.Errorf("Expected stopped state, got %q", state)
+	}
+}
+
 func TestStop_OverwritesPreviousState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
if OpenShell sandbox has been started outside of the kdn scope