### PR TITLE
feat(runtime): add Experimental interface and warn in init command

### DIFF
--- a/.agents/skills/working-with-runtime-system/SKILL.md
+++ b/.agents/skills/working-with-runtime-system/SKILL.md
@@ -224,6 +224,32 @@ return errors.New("runtime does not support terminal sessions")
 
 This pattern allows runtimes to provide additional capabilities without requiring all runtimes to implement every possible feature.
 
+### Experimental Interface
+
+The `Experimental` interface marks a runtime's support as experimental. Its presence alone is the signal — the method carries no return value and callers never invoke it directly.
+
+```go
+type Experimental interface {
+    IsExperimental()
+}
+```
+
+When the `init` command runs, it calls `manager.GetRuntime(runtimeType)` and checks for this interface. If present, it prints a warning to stderr before creating the workspace:
+
+```text
+⚠️  <name> runtime support is experimental
+```
+
+The warning is suppressed in JSON output mode (`--output json`).
+
+**Example implementation:**
+
+```go
+func (r *myRuntime) IsExperimental() {}
+```
+
+Add this method to a runtime when its implementation is not yet stable enough for production use.
+
 ## State Validation
 
 All runtimes must return valid WorkspaceState values in `RuntimeInfo.State`. The instances manager enforces validation at the boundary using a **fail-fast approach**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 - **Terminal**: Enables interactive terminal sessions with instances (auto-starts if needed)
 - **Dashboard**: Enables runtimes to expose a web dashboard URL (`GetURL(ctx, instanceID) (string, error)`)
 - **FlagProvider**: Enables runtimes to declare runtime-specific CLI flags (`Flags() []FlagDef`). Flag values flow through `AddOptions.RuntimeOptions` and `CreateParams.RuntimeOptions` as `map[string]string`, keeping the command layer runtime-agnostic. The `runtimesetup.ListFlags()` bridge discovers flags from all available runtimes for registration on cobra commands.
+- **Experimental**: Signals that a runtime's support is experimental. The `init` command detects this interface via `manager.GetRuntime()` and prints `⚠️  <name> runtime support is experimental` to stderr (suppressed in JSON output mode). No return value — presence of the interface is the signal.
 
 **For detailed runtime implementation guidance, use:** `/working-with-runtime-system`
 
@@ -442,6 +443,9 @@ manager.GetDashboardURL(ctx, id)
 
 // Interactive terminal
 manager.Terminal(ctx, id, []string{"bash"})
+
+// Retrieve a registered runtime by type (e.g. to check optional interfaces like Experimental)
+manager.GetRuntime(runtimeType)
 ```
 
 **Workspace Name Sanitization:** The manager automatically sanitizes workspace names — whether auto-generated from the source directory basename or provided via `--name`. Names are lowercased and any run of invalid characters (spaces, `@`, etc.) is collapsed into a single hyphen. This ensures compatibility with runtimes like Podman that require lowercase image names.

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -227,6 +227,13 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 	}
 	ctx = logger.WithLogger(ctx, l)
 
+	// Warn when the selected runtime is experimental
+	if rt, err := i.manager.GetRuntime(i.runtime); err == nil {
+		if _, ok := rt.(runtime.Experimental); ok && i.output != "json" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  %s runtime support is experimental\n", i.runtime)
+		}
+	}
+
 	// Create a new instance
 	instance, err := instances.NewInstance(instances.NewInstanceParams{
 		SourceDir: i.absSourcesDir,

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,6 +32,7 @@ import (
 	"github.com/openkaiden/kdn/pkg/cmd/testutil"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/runtime/fake"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
 	"github.com/spf13/cobra"
 )
@@ -2535,6 +2537,131 @@ func TestInitCmd_Examples(t *testing.T) {
 	if err != nil {
 		t.Errorf("Example validation failed: %v", err)
 	}
+}
+
+func TestInitCmd_ExperimentalWarning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("displays warning to stderr when runtime is experimental", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.NewWithExperimental()); err != nil {
+			t.Fatalf("Failed to register experimental runtime: %v", err)
+		}
+
+		c := &initCmd{
+			runtime:        "fake",
+			agent:          "test-agent",
+			absSourcesDir:  sourcesDir,
+			absConfigDir:   filepath.Join(sourcesDir, ".kaiden"),
+			manager:        manager,
+			runtimeOptions: map[string]string{},
+		}
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		if err := c.run(cmd, nil); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		stderrStr := stderr.String()
+		if !strings.Contains(stderrStr, "fake runtime support is experimental") {
+			t.Errorf("Expected experimental warning in stderr, got: %q", stderrStr)
+		}
+	})
+
+	t.Run("no warning when runtime is not experimental", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		c := &initCmd{
+			runtime:        "fake",
+			agent:          "test-agent",
+			absSourcesDir:  sourcesDir,
+			absConfigDir:   filepath.Join(sourcesDir, ".kaiden"),
+			manager:        manager,
+			runtimeOptions: map[string]string{},
+		}
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		if err := c.run(cmd, nil); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		stderrStr := stderr.String()
+		if strings.Contains(stderrStr, "experimental") {
+			t.Errorf("Expected no experimental warning in stderr, got: %q", stderrStr)
+		}
+	})
+
+	t.Run("no warning in JSON output mode even when runtime is experimental", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.NewWithExperimental()); err != nil {
+			t.Fatalf("Failed to register experimental runtime: %v", err)
+		}
+
+		c := &initCmd{
+			runtime:        "fake",
+			agent:          "test-agent",
+			absSourcesDir:  sourcesDir,
+			absConfigDir:   filepath.Join(sourcesDir, ".kaiden"),
+			manager:        manager,
+			output:         "json",
+			runtimeOptions: map[string]string{},
+		}
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		if err := c.run(cmd, nil); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		stderrStr := stderr.String()
+		if strings.Contains(stderrStr, "experimental") {
+			t.Errorf("Expected no experimental warning in JSON mode, got: %q", stderrStr)
+		}
+	})
 }
 
 func TestRegisterRuntimeFlags(t *testing.T) {

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -805,12 +805,12 @@ func (m *manager) GetDashboardURL(ctx context.Context, nameOrID string) (string,
 	return dashboardRuntime.GetURL(ctx, runtimeData.InstanceID)
 }
 
-// RegisterRuntime registers a runtime with the manager's registry.
 // GetRuntime retrieves a registered runtime by type.
 func (m *manager) GetRuntime(runtimeType string) (runtime.Runtime, error) {
 	return m.runtimeRegistry.Get(runtimeType)
 }
 
+// RegisterRuntime registers a runtime with the manager's registry.
 func (m *manager) RegisterRuntime(rt runtime.Runtime) error {
 	if err := m.runtimeRegistry.Register(rt); err != nil {
 		return err

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -94,6 +94,9 @@ type Manager interface {
 	// Returns ErrInstanceNotFound if the workspace does not exist.
 	// Returns ErrDashboardNotSupported if the runtime does not implement the Dashboard interface.
 	GetDashboardURL(ctx context.Context, nameOrID string) (string, error)
+	// GetRuntime retrieves a registered runtime by type.
+	// Returns an error if the runtime type is not registered.
+	GetRuntime(runtimeType string) (runtime.Runtime, error)
 	// RegisterRuntime registers a runtime with the manager's registry
 	RegisterRuntime(rt runtime.Runtime) error
 	// RegisterAgent registers an agent with the manager's registry
@@ -803,6 +806,11 @@ func (m *manager) GetDashboardURL(ctx context.Context, nameOrID string) (string,
 }
 
 // RegisterRuntime registers a runtime with the manager's registry.
+// GetRuntime retrieves a registered runtime by type.
+func (m *manager) GetRuntime(runtimeType string) (runtime.Runtime, error) {
+	return m.runtimeRegistry.Get(runtimeType)
+}
+
 func (m *manager) RegisterRuntime(rt runtime.Runtime) error {
 	if err := m.runtimeRegistry.Register(rt); err != nil {
 		return err

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -4836,3 +4836,57 @@ func TestManager_RegisterSecretService(t *testing.T) {
 		}
 	})
 }
+
+func TestManager_GetRuntime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns registered runtime by type", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		rt, err := manager.GetRuntime("fake")
+		if err != nil {
+			t.Fatalf("GetRuntime() error = %v, want nil", err)
+		}
+		if rt.Type() != "fake" {
+			t.Errorf("GetRuntime().Type() = %q, want %q", rt.Type(), "fake")
+		}
+	})
+
+	t.Run("returns error for unregistered runtime type", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		_, err := manager.GetRuntime("nonexistent")
+		if err == nil {
+			t.Error("GetRuntime() for unknown type should return error")
+		}
+	})
+
+	t.Run("returned runtime implements optional interface when registered with one", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		runtimesDir := filepath.Join(tmpDir, RuntimesSubdirectory)
+		reg, err := runtime.NewRegistry(runtimesDir)
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+		if err := reg.Register(fake.NewWithExperimental()); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), reg, agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		rt, err := manager.GetRuntime("fake")
+		if err != nil {
+			t.Fatalf("GetRuntime() error = %v, want nil", err)
+		}
+		if _, ok := rt.(runtime.Experimental); !ok {
+			t.Error("GetRuntime() returned runtime does not implement runtime.Experimental")
+		}
+	})
+}

--- a/pkg/runtime/fake/experimental.go
+++ b/pkg/runtime/fake/experimental.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"github.com/openkaiden/kdn/pkg/runtime"
+)
+
+// runtimeWithExperimental wraps fakeRuntime and implements the Experimental interface.
+type runtimeWithExperimental struct {
+	*fakeRuntime
+}
+
+// Ensure runtimeWithExperimental implements runtime.Experimental at compile time.
+var _ runtime.Experimental = (*runtimeWithExperimental)(nil)
+
+// NewWithExperimental creates a fake runtime that implements the Experimental interface.
+func NewWithExperimental() runtime.Runtime {
+	return &runtimeWithExperimental{
+		fakeRuntime: New().(*fakeRuntime),
+	}
+}
+
+// IsExperimental implements runtime.Experimental.
+func (r *runtimeWithExperimental) IsExperimental() {}

--- a/pkg/runtime/fake/fake_test.go
+++ b/pkg/runtime/fake/fake_test.go
@@ -807,6 +807,54 @@ func TestFakeRuntime_LoadWithNilInfoMap(t *testing.T) {
 	}
 }
 
+func TestNewWithExperimental_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+
+	rt := NewWithExperimental()
+
+	if _, ok := rt.(runtime.Experimental); !ok {
+		t.Fatal("NewWithExperimental() returned a runtime that does not implement runtime.Experimental")
+	}
+}
+
+func TestNewWithExperimental_IsExperimental(t *testing.T) {
+	t.Parallel()
+
+	rt := NewWithExperimental()
+
+	exp, ok := rt.(runtime.Experimental)
+	if !ok {
+		t.Fatal("NewWithExperimental() returned a runtime that does not implement runtime.Experimental")
+	}
+	// IsExperimental carries no return value; calling it must not panic.
+	exp.IsExperimental()
+}
+
+func TestNewWithExperimental_IsFullRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rt := NewWithExperimental()
+
+	info, err := rt.Create(ctx, runtime.CreateParams{
+		Name:       "test-ws",
+		SourcePath: "/tmp/src",
+	})
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if _, err := rt.Start(ctx, info.ID); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+	if err := rt.Stop(ctx, info.ID); err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+	if err := rt.Remove(ctx, info.ID); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+}
+
 func TestNewWithDashboard_GetURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -261,6 +261,18 @@ type ConfigTransformer interface {
 	TransformConfig(config *workspace.WorkspaceConfiguration) error
 }
 
+// Experimental is an optional interface for runtimes whose support is experimental.
+// The mere presence of this interface on a runtime signals experimental status;
+// the IsExperimental method carries no return value and need not be called directly.
+// Commands that use the runtime (e.g. init) display a warning when this interface is detected.
+//
+// Example implementation:
+//
+//	func (r *myRuntime) IsExperimental() {}
+type Experimental interface {
+	IsExperimental()
+}
+
 // ValidateState validates that a runtime state is one of the valid WorkspaceState values.
 // Valid states are: "running", "stopped", "error", "unknown".
 // Returns an error if the state is not valid.


### PR DESCRIPTION
Runtimes implementing the Experimental interface signal that their support is not yet stable. The init command detects the interface via manager.GetRuntime() and prints a warning to stderr before creating the workspace; the warning is suppressed in JSON output mode.

Closes #443

To test, add these lines to `pkg/runtime/fake/fake.go`:

```
// IsExperimental implements runtime.Experimental.
func (f *fakeRuntime) IsExperimental() {}
```

and run `kdn init --runtime fake`