### PR TITLE
feat(autoconf): auto-mount home config  files (e.g. .gitconfig)

### DIFF
--- a/.agents/skills/working-with-autoconf/SKILL.md
+++ b/.agents/skills/working-with-autoconf/SKILL.md
@@ -363,6 +363,112 @@ func (f *fakeAgentUpdater) AddEnvVar(agent, name, value string) error { ... }
 func (f *fakeAgentUpdater) AddMount(agent, host, target string, ro bool) error { ... }
 ```
 
+## Home Config File Detection (`HomeConfigFilesAutoconf`)
+
+`kdn autoconf` also detects home-directory config files (e.g. `$HOME/.gitconfig`) and offers to mount them read-only into workspace containers. This is a separate flow from secret detection, handled by `HomeConfigFilesAutoconf` in `autoconfhomeconfigfiles.go`.
+
+### How it works
+
+```text
+HomeConfigFilesDetector.Detect()   → []DetectedHomeConfigFile (files present on disk)
+  ↓ per file
+  findExistingLocations()            → skip with "already mounted" message if found
+  confirm?  (skipped when --yes)
+  selectTarget()                     → Global | Project | Local
+  applyTarget()
+    Global  → ProjectUpdater.AddMount("", hostPath, containerPath, true)
+    Project → ProjectUpdater.AddMount(projectID, hostPath, containerPath, true)
+    Local   → WorkspaceUpdater.AddMount(hostPath, containerPath, true)
+```
+
+Default when `--yes`: `HomeConfigFilesConfigTargetGlobal`.
+
+### Registered files
+
+`registeredHomeConfigFiles` in `detecthomeconfigfiles.go` is the authoritative list. Each entry is a `homeConfigFileSpec`:
+
+```go
+type homeConfigFileSpec struct {
+    name             string // display identifier (e.g. "gitconfig")
+    hostRelPath      string // path relative to $HOME on the host (Windows may differ)
+    containerRelPath string // path relative to $HOME inside the Linux container
+}
+```
+
+`hostRelPath` and `containerRelPath` are kept separate so Windows config files (e.g. `AppData/Roaming/tool/config`) can be mounted at the correct Linux container path (e.g. `.config/tool/config`). To register a new file, add one entry to the slice — no other changes needed.
+
+`Detect()` stats `filepath.Join(homeDir, filepath.FromSlash(spec.hostRelPath))` for each entry, and returns:
+```go
+DetectedHomeConfigFile{
+    Name:          spec.name,
+    HostPath:      path.Join("$HOME", spec.hostRelPath),       // e.g. "$HOME/.gitconfig"
+    ContainerPath: path.Join("$HOME", spec.containerRelPath),  // e.g. "$HOME/.gitconfig"
+}
+```
+
+### Key types
+
+**`HomeConfigFilesDetector`** (`detecthomeconfigfiles.go`):
+```go
+type HomeConfigFilesDetector interface {
+    Detect() ([]DetectedHomeConfigFile, error)
+}
+```
+Constructor: `NewHomeConfigFilesDetector() (HomeConfigFilesDetector, error)`. For tests: `newHomeConfigFilesDetectorWithInjection(homeDir, statFile, specs)`.
+
+**`HomeConfigFilesAutoconf`** (`autoconfhomeconfigfiles.go`):
+```go
+type HomeConfigFilesAutoconf interface {
+    Run(out io.Writer) error
+}
+func NewHomeConfigFilesAutoconf(opts HomeConfigFilesAutoconfOptions) HomeConfigFilesAutoconf
+```
+
+Important `HomeConfigFilesAutoconfOptions` fields:
+
+| Field | Purpose |
+|-------|---------|
+| `Detector` | `HomeConfigFilesDetector` |
+| `ProjectUpdater` | `config.ProjectConfigUpdater` — writes global or project entry to `projects.json` |
+| `WorkspaceUpdater` | `config.WorkspaceConfigUpdater` — nil means local target not offered |
+| `ProjectLoader` | `config.ProjectConfigLoader` — checks if already configured in global/project config |
+| `WorkspaceConfig` | `config.Config` — checks if already configured in workspace config |
+| `ProjectID` | empty string means project target not offered |
+| `Yes` | skip confirm + select, defaults to global target |
+| `Confirm` / `SelectTarget` | injectable for testing |
+
+### Testing patterns
+
+```go
+type fakeHomeConfigFilesDetector struct {
+    files []autoconf.DetectedHomeConfigFile
+    err   error
+}
+func (f *fakeHomeConfigFilesDetector) Detect() ([]autoconf.DetectedHomeConfigFile, error) {
+    return f.files, f.err
+}
+
+// ProjectConfigUpdater fake must implement both AddSecret and AddMount
+type fakeProjectUpdater struct {
+    mounts []struct{ projectID, host, target string; ro bool }
+}
+func (f *fakeProjectUpdater) AddSecret(projectID, secretName string) error { return nil }
+func (f *fakeProjectUpdater) AddMount(projectID, host, target string, ro bool) error {
+    f.mounts = append(f.mounts, ...)
+    return nil
+}
+
+runner := autoconf.NewHomeConfigFilesAutoconf(autoconf.HomeConfigFilesAutoconfOptions{
+    Detector:       &fakeHomeConfigFilesDetector{files: []autoconf.DetectedHomeConfigFile{{
+        Name: "gitconfig", HostPath: "$HOME/.gitconfig", ContainerPath: "$HOME/.gitconfig",
+    }}},
+    ProjectUpdater: &fakeProjectUpdater{},
+    Yes:            true,
+})
+var buf bytes.Buffer
+err := runner.Run(&buf)
+```
+
 ## Key Files
 
 | File | Purpose |
@@ -373,9 +479,11 @@ func (f *fakeAgentUpdater) AddMount(agent, host, target string, ro bool) error {
 | `pkg/autoconf/detectclaudevertex.go` | `VertexDetector` interface + `envVertexDetector` + `VertexConfig` |
 | `pkg/autoconf/autoconfclaudevertex.go` | `ClaudeVertexAutoconf` interface + runner |
 | `pkg/autoconf/adcpath.go` / `adcpath_windows.go` | Platform-specific ADC file path helpers |
+| `pkg/autoconf/detecthomeconfigfiles.go` | `HomeConfigFilesDetector` interface + `envHomeConfigFilesDetector` + `registeredHomeConfigFiles` |
+| `pkg/autoconf/autoconfhomeconfigfiles.go` | `HomeConfigFilesAutoconf` interface + runner + target constants |
 | `pkg/cmd/autoconf.go` | Thin CLI wiring: flag parsing, dependency construction, `project.Detector` injection |
 | `pkg/project/project.go` | `Detector` interface + shared project-ID detection logic (git remote → URL, no remote → path) |
-| `pkg/config/projectsupdater.go` | `ProjectConfigUpdater` — reads/writes `~/.kdn/config/projects.json` |
+| `pkg/config/projectsupdater.go` | `ProjectConfigUpdater` — reads/writes `~/.kdn/config/projects.json`; `AddMount` is idempotent by (host, target) pair |
 | `pkg/config/workspaceupdater.go` | `WorkspaceConfigUpdater` — reads/writes `.kaiden/workspace.json` |
 | `pkg/config/agents.go` | `AgentConfigUpdater` + `AgentConfigLoader` — reads/writes `~/.kdn/config/agents.json` |
 | `pkg/secretservicesetup/register.go` | `ListServices()` — returns fully-constructed service instances |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,7 @@ The config system manages workspace configuration for **injecting environment va
 **Key config interfaces in `pkg/config/`:**
 
 - **`WorkspaceConfigUpdater`** (`workspaceupdater.go`): Reads/writes `.kaiden/workspace.json`. Methods: `AddSecret(name)`, `AddEnvVar(name, value)`, `AddMount(host, target, ro)`.
+- **`ProjectConfigUpdater`** (`projectsupdater.go`): Reads/writes `~/.kdn/config/projects.json`. Methods: `AddSecret(projectID, secretName)`, `AddMount(projectID, host, target string, ro bool)`. Pass `""` as `projectID` for the global entry. Both methods are idempotent.
 - **`AgentConfigUpdater`** (`agents.go`): Reads/writes `~/.kdn/config/agents.json` per agent. Methods: `AddEnvVar(agentName, name, value)`, `AddMount(agentName, host, target, ro)`. Used by `kdn autoconf` to record Vertex AI config for the `claude` agent.
 - **`AgentConfigLoader`** (`agents.go`): Loads a `WorkspaceConfiguration` for a named agent from `agents.json`. Returns an empty config (not an error) when the file or agent key is absent.
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ endif
 BUILD_DIR=.
 # Go command
 GO=go
-# Go files
-GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 # Default target
 all: build
@@ -68,7 +66,7 @@ test-coverage: ## Run tests with coverage report
 
 fmt: ## Format code with gofmt
 	@echo "Formatting code..."
-	@gofmt -w $(GOFILES)
+	@gofmt -w .
 
 vet: ## Run go vet
 	@echo "Running go vet..."
@@ -76,13 +74,7 @@ vet: ## Run go vet
 
 check-fmt: ## Check if code is formatted (for CI)
 	@echo "Checking code formatting..."
-	@unformatted=$$(gofmt -l $(GOFILES)); \
-	if [ -n "$$unformatted" ]; then \
-		echo "The following files are not formatted:"; \
-		echo "$$unformatted"; \
-		echo "Run 'make fmt' to format the code."; \
-		exit 1; \
-	fi
+	@unformatted=$$(gofmt -l .); [ -z "$$unformatted" ] || { echo "The following files are not formatted:"; echo "$$unformatted"; echo "Run 'make fmt' to format the code."; exit 1; }
 	@echo "All files are properly formatted."
 
 check-vet: ## Run go vet and fail on issues (for CI)

--- a/README.md
+++ b/README.md
@@ -724,6 +724,46 @@ When run interactively, `autoconf` asks one question per detected secret:
 
 Secrets that are already stored **and** referenced in any config source are reported as already configured and skipped.
 
+### Auto-mounting Home Config Files
+
+`kdn autoconf` also scans your home directory for known config files and, when found, offers to mount them read-only into workspace containers. This gives agents access to your local tool settings (git identity, editor preferences, etc.) without any manual configuration.
+
+```bash
+# Detect config files and apply interactively
+kdn autoconf
+
+# Apply immediately without prompts (mounts to global config)
+kdn autoconf --yes
+```
+
+When a matching file is found, `autoconf` follows the same flow as for secrets:
+
+1. **Confirm mounting** — add the read-only bind mount?
+2. **Choose target** — where to record it:
+   - *Global* — available across all projects (`~/.kdn/config/projects.json` global key)
+   - *Project* — scoped to the current directory's git project
+   - *Local* — written to `.kaiden/workspace.json` in the current directory
+
+Files already mounted in any config source are reported as already configured and skipped.
+
+**Example: `$HOME/.gitconfig`**
+
+If `~/.gitconfig` exists on your machine, `kdn autoconf` detects it and offers to mount it read-only at `$HOME/.gitconfig` inside workspace containers. This makes your git identity (name, email, aliases) available to the agent without embedding it in any config file.
+
+The resulting entry in `~/.kdn/config/projects.json` looks like:
+
+```json
+{
+  "": {
+    "mounts": [
+      {"host": "$HOME/.gitconfig", "target": "$HOME/.gitconfig", "ro": true}
+    ]
+  }
+}
+```
+
+The `$HOME` variable is resolved at workspace-start time, keeping the config portable across machines.
+
 ### Sharing a GitHub Token
 
 This scenario demonstrates how to make a GitHub token available inside workspaces using the multi-level configuration system — either globally for all projects or scoped to a specific project.

--- a/pkg/autoconf/autoconf_test.go
+++ b/pkg/autoconf/autoconf_test.go
@@ -64,6 +64,10 @@ func (f *fakeAutoconfUpdater) AddSecret(projectID, secretName string) error {
 	return f.err
 }
 
+func (f *fakeAutoconfUpdater) AddMount(_, _, _ string, _ bool) error {
+	return f.err
+}
+
 // fakeWorkspaceUpdater records calls for the workspace updater.
 type fakeWorkspaceUpdater struct {
 	added   []string

--- a/pkg/autoconf/autoconfhomeconfigfiles.go
+++ b/pkg/autoconf/autoconfhomeconfigfiles.go
@@ -1,0 +1,279 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/config"
+)
+
+// HomeConfigFilesConfigTarget identifies where a detected home config file mount is recorded.
+type HomeConfigFilesConfigTarget int
+
+const (
+	// HomeConfigFilesConfigTargetGlobal records the mount in the global entry of
+	// projects.json (applies to all projects and workspaces).
+	HomeConfigFilesConfigTargetGlobal HomeConfigFilesConfigTarget = iota
+	// HomeConfigFilesConfigTargetProject records the mount in the project-specific
+	// entry of projects.json (keyed by the computed project ID).
+	HomeConfigFilesConfigTargetProject
+	// HomeConfigFilesConfigTargetLocal records the mount in the local
+	// .kaiden/workspace.json.
+	HomeConfigFilesConfigTargetLocal
+)
+
+// HomeConfigFilesConfigTargetOption pairs a HomeConfigFilesConfigTarget with a
+// human-readable label for display in selection prompts.
+type HomeConfigFilesConfigTargetOption struct {
+	Target HomeConfigFilesConfigTarget
+	Label  string
+}
+
+// HomeConfigFilesAutoconfOptions configures a HomeConfigFilesAutoconf runner.
+type HomeConfigFilesAutoconfOptions struct {
+	Detector HomeConfigFilesDetector
+
+	// ProjectUpdater writes to ~/.kdn/config/projects.json for global/project targets.
+	ProjectUpdater config.ProjectConfigUpdater
+	// WorkspaceUpdater writes to .kaiden/workspace.json. When nil the local target
+	// is not offered.
+	WorkspaceUpdater config.WorkspaceConfigUpdater
+
+	// ProjectLoader is used to check whether a file is already mounted in the
+	// global or project-specific config. May be nil (skips those checks).
+	ProjectLoader config.ProjectConfigLoader
+	// WorkspaceConfig is used to check whether a file is already mounted in the
+	// local workspace config. May be nil (skips that check).
+	WorkspaceConfig config.Config
+
+	// ProjectID is the project identifier for the current working directory,
+	// used for the project target. When empty the project target is not offered.
+	ProjectID string
+
+	Yes bool
+
+	// Confirm is called to ask whether to mount a detected file.
+	// Returning false skips the file.
+	Confirm func(prompt string) (bool, error)
+
+	// SelectTarget is called to ask where to record the mount.
+	// It may return ErrSkipped to skip without applying.
+	SelectTarget func(options []HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error)
+}
+
+// HomeConfigFilesAutoconf orchestrates home config file detection and mount
+// application. For each registered config file that exists in the host home
+// directory and is not yet mounted, it confirms with the user and writes the
+// mount to the chosen configuration target.
+type HomeConfigFilesAutoconf interface {
+	Run(out io.Writer) error
+}
+
+type homeConfigFilesAutoconfRunner struct {
+	detector         HomeConfigFilesDetector
+	projectUpdater   config.ProjectConfigUpdater
+	workspaceUpdater config.WorkspaceConfigUpdater
+	projectLoader    config.ProjectConfigLoader
+	workspaceConfig  config.Config
+	projectID        string
+	yes              bool
+	confirm          func(string) (bool, error)
+	selectTarget     func([]HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error)
+}
+
+var _ HomeConfigFilesAutoconf = (*homeConfigFilesAutoconfRunner)(nil)
+
+// NewHomeConfigFilesAutoconf returns a HomeConfigFilesAutoconf configured by opts.
+func NewHomeConfigFilesAutoconf(opts HomeConfigFilesAutoconfOptions) HomeConfigFilesAutoconf {
+	return &homeConfigFilesAutoconfRunner{
+		detector:         opts.Detector,
+		projectUpdater:   opts.ProjectUpdater,
+		workspaceUpdater: opts.WorkspaceUpdater,
+		projectLoader:    opts.ProjectLoader,
+		workspaceConfig:  opts.WorkspaceConfig,
+		projectID:        opts.ProjectID,
+		yes:              opts.Yes,
+		confirm:          opts.Confirm,
+		selectTarget:     opts.SelectTarget,
+	}
+}
+
+func (r *homeConfigFilesAutoconfRunner) Run(out io.Writer) error {
+	detected, err := r.detector.Detect()
+	if err != nil {
+		return err
+	}
+
+	for _, f := range detected {
+		if err := r.processFile(out, f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *homeConfigFilesAutoconfRunner) processFile(out io.Writer, f DetectedHomeConfigFile) error {
+	locations := r.findExistingLocations(f)
+	if len(locations) > 0 {
+		fmt.Fprintf(out, "%s %s already mounted (%s).\n", greenCheck, f.HostPath, formatHomeConfigLocations(locations))
+		return nil
+	}
+
+	fmt.Fprintf(out, "Detected home config file %s\n", f.HostPath)
+
+	if !r.yes {
+		ok, err := r.confirm(fmt.Sprintf("Mount %s read-only?", f.HostPath))
+		if err != nil {
+			return fmt.Errorf("confirmation failed: %w", err)
+		}
+		if !ok {
+			fmt.Fprintf(out, "%s Skipped %s.\n", greyDash, f.HostPath)
+			return nil
+		}
+	}
+
+	target := HomeConfigFilesConfigTargetGlobal // default for --yes
+	if !r.yes {
+		options := r.buildTargetOptions()
+		var selErr error
+		target, selErr = r.selectTarget(options)
+		if errors.Is(selErr, ErrSkipped) {
+			fmt.Fprintf(out, "%s Skipped %s.\n", greyDash, f.HostPath)
+			return nil
+		}
+		if selErr != nil {
+			return fmt.Errorf("target selection failed: %w", selErr)
+		}
+	}
+
+	return r.applyTarget(out, f, target)
+}
+
+func (r *homeConfigFilesAutoconfRunner) buildTargetOptions() []HomeConfigFilesConfigTargetOption {
+	opts := []HomeConfigFilesConfigTargetOption{
+		{Target: HomeConfigFilesConfigTargetGlobal, Label: "Global (all projects)"},
+	}
+	if r.projectID != "" {
+		opts = append(opts, HomeConfigFilesConfigTargetOption{
+			Target: HomeConfigFilesConfigTargetProject,
+			Label:  fmt.Sprintf("Project (%s)", r.projectID),
+		})
+	}
+	if r.workspaceUpdater != nil {
+		opts = append(opts, HomeConfigFilesConfigTargetOption{
+			Target: HomeConfigFilesConfigTargetLocal,
+			Label:  "Local (.kaiden/workspace.json)",
+		})
+	}
+	return opts
+}
+
+func (r *homeConfigFilesAutoconfRunner) applyTarget(out io.Writer, f DetectedHomeConfigFile, target HomeConfigFilesConfigTarget) error {
+	switch target {
+	case HomeConfigFilesConfigTargetGlobal:
+		if err := r.projectUpdater.AddMount("", f.HostPath, f.ContainerPath, true); err != nil {
+			return fmt.Errorf("failed to add %s mount to global config: %w", f.HostPath, err)
+		}
+		fmt.Fprintf(out, "%s Added %s mount to global project config.\n", greenCheck, f.HostPath)
+
+	case HomeConfigFilesConfigTargetProject:
+		if r.projectID == "" {
+			return fmt.Errorf("project config target selected but no project was detected")
+		}
+		if err := r.projectUpdater.AddMount(r.projectID, f.HostPath, f.ContainerPath, true); err != nil {
+			return fmt.Errorf("failed to add %s mount to project config: %w", f.HostPath, err)
+		}
+		fmt.Fprintf(out, "%s Added %s mount to project config.\n", greenCheck, f.HostPath)
+
+	case HomeConfigFilesConfigTargetLocal:
+		if r.workspaceUpdater == nil {
+			return fmt.Errorf("local config target selected but workspace updater is not configured")
+		}
+		if err := r.workspaceUpdater.AddMount(f.HostPath, f.ContainerPath, true); err != nil {
+			return fmt.Errorf("failed to add %s mount to local workspace config: %w", f.HostPath, err)
+		}
+		fmt.Fprintf(out, "%s Added %s mount to local workspace config.\n", greenCheck, f.HostPath)
+
+	default:
+		return fmt.Errorf("unknown home config files target %d", target)
+	}
+	return nil
+}
+
+// findExistingLocations returns the config targets where the file's mount is
+// already recorded.
+func (r *homeConfigFilesAutoconfRunner) findExistingLocations(f DetectedHomeConfigFile) []HomeConfigFilesConfigTarget {
+	var locations []HomeConfigFilesConfigTarget
+
+	if r.projectLoader != nil {
+		inGlobal := false
+		if cfg, err := r.projectLoader.Load(""); err == nil && hasMountTarget(cfg, f.ContainerPath) {
+			inGlobal = true
+			locations = append(locations, HomeConfigFilesConfigTargetGlobal)
+		}
+		if r.projectID != "" && !inGlobal {
+			// Load(projectID) merges global into the result, so only report the
+			// project location when the mount is not already counted as global.
+			if cfg, err := r.projectLoader.Load(r.projectID); err == nil && hasMountTarget(cfg, f.ContainerPath) {
+				locations = append(locations, HomeConfigFilesConfigTargetProject)
+			}
+		}
+	}
+
+	if r.workspaceConfig != nil {
+		if cfg, err := r.workspaceConfig.Load(); err == nil && hasMountTarget(cfg, f.ContainerPath) {
+			locations = append(locations, HomeConfigFilesConfigTargetLocal)
+		}
+	}
+
+	return locations
+}
+
+// hasMountTarget returns true if cfg contains a mount with the given target path.
+func hasMountTarget(cfg *workspace.WorkspaceConfiguration, target string) bool {
+	if cfg == nil || cfg.Mounts == nil {
+		return false
+	}
+	for _, m := range *cfg.Mounts {
+		if m.Target == target {
+			return true
+		}
+	}
+	return false
+}
+
+func formatHomeConfigLocations(locs []HomeConfigFilesConfigTarget) string {
+	names := make([]string, 0, len(locs))
+	for _, l := range locs {
+		switch l {
+		case HomeConfigFilesConfigTargetGlobal:
+			names = append(names, "global")
+		case HomeConfigFilesConfigTargetProject:
+			names = append(names, "project")
+		case HomeConfigFilesConfigTargetLocal:
+			names = append(names, "local")
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/pkg/autoconf/autoconfhomeconfigfiles_test.go
+++ b/pkg/autoconf/autoconfhomeconfigfiles_test.go
@@ -1,0 +1,509 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/config"
+)
+
+// fakeHomeConfigFilesDetector returns a fixed []DetectedHomeConfigFile.
+type fakeHomeConfigFilesDetector struct {
+	files []DetectedHomeConfigFile
+	err   error
+}
+
+func (f *fakeHomeConfigFilesDetector) Detect() ([]DetectedHomeConfigFile, error) {
+	return f.files, f.err
+}
+
+// fakeProjectUpdater records AddSecret and AddMount calls for the project config updater.
+type fakeProjectUpdater struct {
+	secrets []struct{ projectID, secretName string }
+	mounts  []struct {
+		projectID, host, target string
+		ro                      bool
+	}
+	err error
+}
+
+func (f *fakeProjectUpdater) AddSecret(projectID, secretName string) error {
+	f.secrets = append(f.secrets, struct{ projectID, secretName string }{projectID, secretName})
+	return f.err
+}
+
+func (f *fakeProjectUpdater) AddMount(projectID, host, target string, ro bool) error {
+	f.mounts = append(f.mounts, struct {
+		projectID, host, target string
+		ro                      bool
+	}{projectID, host, target, ro})
+	return f.err
+}
+
+// fakeProjectLoader returns a fixed *workspace.WorkspaceConfiguration per projectID.
+type fakeProjectLoader struct {
+	configs map[string]*workspace.WorkspaceConfiguration
+}
+
+func (f *fakeProjectLoader) Load(projectID string) (*workspace.WorkspaceConfiguration, error) {
+	if cfg, ok := f.configs[projectID]; ok {
+		return cfg, nil
+	}
+	// Mirror the real loader: when no project-specific entry exists but a global
+	// one does, return the global config (it is the merged result).
+	if projectID != "" {
+		if global, ok := f.configs[""]; ok {
+			return global, nil
+		}
+	}
+	return &workspace.WorkspaceConfiguration{}, nil
+}
+
+// fakeHomeConfigWorkspaceConfig returns a fixed *workspace.WorkspaceConfiguration.
+type fakeHomeConfigWorkspaceConfig struct {
+	cfg *workspace.WorkspaceConfiguration
+}
+
+func (f *fakeHomeConfigWorkspaceConfig) Load() (*workspace.WorkspaceConfiguration, error) {
+	if f.cfg != nil {
+		return f.cfg, nil
+	}
+	return nil, config.ErrConfigNotFound
+}
+
+func detectedGitconfig() DetectedHomeConfigFile {
+	return DetectedHomeConfigFile{
+		Name:          "gitconfig",
+		HostPath:      "$HOME/.gitconfig",
+		ContainerPath: "$HOME/.gitconfig",
+	}
+}
+
+// alwaysLocalHomeConfig is a selectTarget stub that always picks the local target.
+func alwaysLocalHomeConfig(_ []HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error) {
+	return HomeConfigFilesConfigTargetLocal, nil
+}
+
+// alwaysProjectHomeConfig is a selectTarget stub that always picks the project target.
+func alwaysProjectHomeConfig(_ []HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error) {
+	return HomeConfigFilesConfigTargetProject, nil
+}
+
+func confirmYes(_ string) (bool, error) { return true, nil }
+func confirmNo(_ string) (bool, error)  { return false, nil }
+
+func TestHomeConfigFilesAutoconf_NoFilesDetected(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{},
+		ProjectUpdater: updater,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no mounts, got %v", updater.mounts)
+	}
+}
+
+func TestHomeConfigFilesAutoconf_YesGlobalTarget(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: updater,
+		Yes:            true,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 1 {
+		t.Fatalf("expected 1 mount, got %d", len(updater.mounts))
+	}
+	m := updater.mounts[0]
+	if m.projectID != "" {
+		t.Errorf("projectID = %q, want empty (global)", m.projectID)
+	}
+	if m.host != "$HOME/.gitconfig" || m.target != "$HOME/.gitconfig" || !m.ro {
+		t.Errorf("unexpected mount: %+v", m)
+	}
+	if !strings.Contains(buf.String(), "global project config") {
+		t.Errorf("expected global message, got: %s", buf.String())
+	}
+}
+
+func TestHomeConfigFilesAutoconf_ConfirmApplyLocalTarget(t *testing.T) {
+	t.Parallel()
+
+	projectUpdater := &fakeProjectUpdater{}
+	workspaceUpdater := &fakeWorkspaceUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:         &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater:   projectUpdater,
+		WorkspaceUpdater: workspaceUpdater,
+		Yes:              false,
+		Confirm:          confirmYes,
+		SelectTarget:     alwaysLocalHomeConfig,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(workspaceUpdater.mounts) != 1 {
+		t.Fatalf("expected 1 workspace mount, got %d", len(workspaceUpdater.mounts))
+	}
+	if len(projectUpdater.mounts) != 0 {
+		t.Errorf("expected no project mounts, got %v", projectUpdater.mounts)
+	}
+	m := workspaceUpdater.mounts[0]
+	if m.host != "$HOME/.gitconfig" || m.target != "$HOME/.gitconfig" || !m.ro {
+		t.Errorf("unexpected mount: %+v", m)
+	}
+}
+
+func TestHomeConfigFilesAutoconf_ConfirmApplyProjectTarget(t *testing.T) {
+	t.Parallel()
+
+	projectUpdater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:         &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater:   projectUpdater,
+		WorkspaceUpdater: &fakeWorkspaceUpdater{},
+		ProjectID:        "github.com/org/repo",
+		Yes:              false,
+		Confirm:          confirmYes,
+		SelectTarget:     alwaysProjectHomeConfig,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(projectUpdater.mounts) != 1 {
+		t.Fatalf("expected 1 project mount, got %d", len(projectUpdater.mounts))
+	}
+	m := projectUpdater.mounts[0]
+	if m.projectID != "github.com/org/repo" {
+		t.Errorf("projectID = %q, want %q", m.projectID, "github.com/org/repo")
+	}
+}
+
+func TestHomeConfigFilesAutoconf_ConfirmDeclined(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: updater,
+		Yes:            false,
+		Confirm:        confirmNo,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no mounts after decline, got %v", updater.mounts)
+	}
+	if !strings.Contains(buf.String(), "Skipped") {
+		t.Errorf("expected skip message, got: %s", buf.String())
+	}
+}
+
+func TestHomeConfigFilesAutoconf_SelectTargetSkipped(t *testing.T) {
+	t.Parallel()
+
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: updater,
+		Yes:            false,
+		Confirm:        confirmYes,
+		SelectTarget: func(_ []HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error) {
+			return 0, ErrSkipped
+		},
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no mounts after skip, got %v", updater.mounts)
+	}
+}
+
+func TestHomeConfigFilesAutoconf_AlreadyMountedGlobal(t *testing.T) {
+	t.Parallel()
+
+	ro := true
+	globalCfg := &workspace.WorkspaceConfiguration{
+		Mounts: &[]workspace.Mount{
+			{Host: "$HOME/.gitconfig", Target: "$HOME/.gitconfig", Ro: &ro},
+		},
+	}
+	loader := &fakeProjectLoader{
+		configs: map[string]*workspace.WorkspaceConfiguration{
+			"": globalCfg,
+		},
+	}
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: updater,
+		ProjectLoader:  loader,
+		Yes:            true,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no new mounts (already configured), got %v", updater.mounts)
+	}
+	if !strings.Contains(buf.String(), "already mounted") {
+		t.Errorf("expected 'already mounted' message, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "global") {
+		t.Errorf("expected 'global' in message, got: %s", buf.String())
+	}
+}
+
+func TestHomeConfigFilesAutoconf_AlreadyMountedGlobalWithProjectID(t *testing.T) {
+	t.Parallel()
+
+	// Mount exists only in global. With a ProjectID set, Load(projectID) would
+	// return the merged (global+project) config, which also contains the mount.
+	// The runner must NOT report "project" in that case.
+	ro := true
+	globalCfg := &workspace.WorkspaceConfiguration{
+		Mounts: &[]workspace.Mount{
+			{Host: "$HOME/.gitconfig", Target: "$HOME/.gitconfig", Ro: &ro},
+		},
+	}
+	loader := &fakeProjectLoader{
+		configs: map[string]*workspace.WorkspaceConfiguration{
+			"": globalCfg,
+			// "my-project" key intentionally absent — mount comes from global only.
+		},
+	}
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: updater,
+		ProjectLoader:  loader,
+		ProjectID:      "my-project",
+		Yes:            true,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no new mounts (already configured globally), got %v", updater.mounts)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "global") {
+		t.Errorf("expected 'global' in message, got: %s", out)
+	}
+	if strings.Contains(out, "project") {
+		t.Errorf("must not report 'project' when mount is only in global, got: %s", out)
+	}
+}
+
+func TestHomeConfigFilesAutoconf_AlreadyMountedProject(t *testing.T) {
+	t.Parallel()
+
+	ro := true
+	projectCfg := &workspace.WorkspaceConfiguration{
+		Mounts: &[]workspace.Mount{
+			{Host: "$HOME/.gitconfig", Target: "$HOME/.gitconfig", Ro: &ro},
+		},
+	}
+	loader := &fakeProjectLoader{
+		configs: map[string]*workspace.WorkspaceConfiguration{
+			"my-project": projectCfg,
+		},
+	}
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: updater,
+		ProjectLoader:  loader,
+		ProjectID:      "my-project",
+		Yes:            true,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no new mounts (already configured), got %v", updater.mounts)
+	}
+	if !strings.Contains(buf.String(), "project") {
+		t.Errorf("expected 'project' in message, got: %s", buf.String())
+	}
+}
+
+func TestHomeConfigFilesAutoconf_AlreadyMountedLocal(t *testing.T) {
+	t.Parallel()
+
+	ro := true
+	workspaceCfg := &fakeHomeConfigWorkspaceConfig{
+		cfg: &workspace.WorkspaceConfiguration{
+			Mounts: &[]workspace.Mount{
+				{Host: "$HOME/.gitconfig", Target: "$HOME/.gitconfig", Ro: &ro},
+			},
+		},
+	}
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:        &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater:  updater,
+		WorkspaceConfig: workspaceCfg,
+		Yes:             true,
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(updater.mounts) != 0 {
+		t.Errorf("expected no new mounts (already configured locally), got %v", updater.mounts)
+	}
+}
+
+func TestHomeConfigFilesAutoconf_DetectorError(t *testing.T) {
+	t.Parallel()
+
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector: &fakeHomeConfigFilesDetector{err: errors.New("stat failed")},
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err == nil {
+		t.Error("expected error from detector, got nil")
+	}
+}
+
+func TestHomeConfigFilesAutoconf_LocalTargetNotOfferedWhenUpdaterNil(t *testing.T) {
+	t.Parallel()
+
+	var capturedOptions []HomeConfigFilesConfigTargetOption
+	updater := &fakeProjectUpdater{}
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:         &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater:   updater,
+		WorkspaceUpdater: nil, // no local updater
+		ProjectID:        "proj",
+		Yes:              false,
+		Confirm:          confirmYes,
+		SelectTarget: func(opts []HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error) {
+			capturedOptions = opts
+			return HomeConfigFilesConfigTargetGlobal, nil
+		},
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, opt := range capturedOptions {
+		if opt.Target == HomeConfigFilesConfigTargetLocal {
+			t.Error("local target should not be offered when WorkspaceUpdater is nil")
+		}
+	}
+}
+
+func TestHomeConfigFilesAutoconf_ProjectTargetNotOfferedWhenNoProjectID(t *testing.T) {
+	t.Parallel()
+
+	var capturedOptions []HomeConfigFilesConfigTargetOption
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: &fakeProjectUpdater{},
+		ProjectID:      "", // no project
+		Yes:            false,
+		Confirm:        confirmYes,
+		SelectTarget: func(opts []HomeConfigFilesConfigTargetOption) (HomeConfigFilesConfigTarget, error) {
+			capturedOptions = opts
+			return HomeConfigFilesConfigTargetGlobal, nil
+		},
+	})
+
+	var buf bytes.Buffer
+	if err := runner.Run(&buf); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, opt := range capturedOptions {
+		if opt.Target == HomeConfigFilesConfigTargetProject {
+			t.Error("project target should not be offered when ProjectID is empty")
+		}
+	}
+}
+
+func TestHomeConfigFilesAutoconf_LocalTargetMissingUpdater(t *testing.T) {
+	t.Parallel()
+
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:         &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater:   &fakeProjectUpdater{},
+		WorkspaceUpdater: nil,
+		Yes:              false,
+		Confirm:          confirmYes,
+		SelectTarget:     alwaysLocalHomeConfig,
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err == nil {
+		t.Error("expected error when local target selected but WorkspaceUpdater is nil")
+	}
+}
+
+func TestHomeConfigFilesAutoconf_ProjectTargetMissingProjectID(t *testing.T) {
+	t.Parallel()
+
+	runner := NewHomeConfigFilesAutoconf(HomeConfigFilesAutoconfOptions{
+		Detector:       &fakeHomeConfigFilesDetector{files: []DetectedHomeConfigFile{detectedGitconfig()}},
+		ProjectUpdater: &fakeProjectUpdater{},
+		ProjectID:      "",
+		Yes:            false,
+		Confirm:        confirmYes,
+		SelectTarget:   alwaysProjectHomeConfig,
+	})
+
+	if err := runner.Run(&bytes.Buffer{}); err == nil {
+		t.Error("expected error when project target selected but ProjectID is empty")
+	}
+}

--- a/pkg/autoconf/detecthomeconfigfiles.go
+++ b/pkg/autoconf/detecthomeconfigfiles.go
@@ -1,0 +1,112 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// homeConfigFileSpec defines a host home-directory config file to detect and auto-mount.
+type homeConfigFileSpec struct {
+	name string
+	// hostRelPath is the path relative to $HOME on the host where the file lives.
+	// It may differ from containerRelPath on Windows (e.g. "AppData/Roaming/tool/config"
+	// vs ".config/tool/config" in the container). Always use forward slashes.
+	hostRelPath string
+	// containerRelPath is the path relative to $HOME inside the workspace container.
+	// Containers are always Linux, so this is always a Unix-style forward-slash path.
+	containerRelPath string
+}
+
+// registeredHomeConfigFiles lists the home config files to auto-detect.
+// Add new entries here to extend the detection without any other code changes.
+var registeredHomeConfigFiles = []homeConfigFileSpec{
+	{name: "gitconfig", hostRelPath: ".gitconfig", containerRelPath: ".gitconfig"},
+}
+
+// DetectedHomeConfigFile holds information about a detected home config file.
+type DetectedHomeConfigFile struct {
+	// Name is the identifier for this config file (e.g. "gitconfig").
+	Name string
+	// HostPath is the mount source path expressed with the $HOME variable
+	// (e.g. "$HOME/.gitconfig"). Portable across machines.
+	HostPath string
+	// ContainerPath is the mount target path inside the workspace container,
+	// also expressed with $HOME (e.g. "$HOME/.gitconfig").
+	ContainerPath string
+}
+
+// HomeConfigFilesDetector detects home directory config files that exist on the host.
+type HomeConfigFilesDetector interface {
+	// Detect returns the list of registered config files that exist in the host
+	// home directory. Files that are absent are omitted from the result.
+	Detect() ([]DetectedHomeConfigFile, error)
+}
+
+type envHomeConfigFilesDetector struct {
+	homeDir  string
+	statFile func(string) error
+	specs    []homeConfigFileSpec
+}
+
+var _ HomeConfigFilesDetector = (*envHomeConfigFilesDetector)(nil)
+
+// NewHomeConfigFilesDetector returns a HomeConfigFilesDetector that reads from
+// the process environment. Returns an error only if the home directory cannot
+// be determined.
+func NewHomeConfigFilesDetector() (HomeConfigFilesDetector, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return newHomeConfigFilesDetectorWithInjection(homeDir, func(p string) error {
+		_, err := os.Stat(p)
+		return err
+	}, registeredHomeConfigFiles), nil
+}
+
+// newHomeConfigFilesDetectorWithInjection creates a detector with injectable
+// dependencies for testing.
+func newHomeConfigFilesDetectorWithInjection(homeDir string, statFile func(string) error, specs []homeConfigFileSpec) HomeConfigFilesDetector {
+	return &envHomeConfigFilesDetector{
+		homeDir:  homeDir,
+		statFile: statFile,
+		specs:    specs,
+	}
+}
+
+// Detect returns the registered home config files that exist on the host.
+func (d *envHomeConfigFilesDetector) Detect() ([]DetectedHomeConfigFile, error) {
+	var detected []DetectedHomeConfigFile
+	for _, spec := range d.specs {
+		hostAbsPath := filepath.Join(d.homeDir, filepath.FromSlash(spec.hostRelPath))
+		if err := d.statFile(hostAbsPath); err != nil {
+			continue
+		}
+		detected = append(detected, DetectedHomeConfigFile{
+			Name:          spec.name,
+			HostPath:      path.Join("$HOME", spec.hostRelPath),
+			ContainerPath: path.Join("$HOME", spec.containerRelPath),
+		})
+	}
+	return detected, nil
+}

--- a/pkg/autoconf/detecthomeconfigfiles_test.go
+++ b/pkg/autoconf/detecthomeconfigfiles_test.go
@@ -1,0 +1,203 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package autoconf
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHomeConfigFilesDetector_FileExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	gitconfigPath := filepath.Join(dir, ".gitconfig")
+	if err := os.WriteFile(gitconfigPath, []byte("[user]\n\tname = Test\n"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	specs := []homeConfigFileSpec{
+		{name: "gitconfig", hostRelPath: ".gitconfig", containerRelPath: ".gitconfig"},
+	}
+	d := newHomeConfigFilesDetectorWithInjection(dir, func(p string) error {
+		_, err := os.Stat(p)
+		return err
+	}, specs)
+
+	detected, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if len(detected) != 1 {
+		t.Fatalf("expected 1 detected file, got %d", len(detected))
+	}
+	f := detected[0]
+	if f.Name != "gitconfig" {
+		t.Errorf("Name = %q, want %q", f.Name, "gitconfig")
+	}
+	if f.HostPath != "$HOME/.gitconfig" {
+		t.Errorf("HostPath = %q, want %q", f.HostPath, "$HOME/.gitconfig")
+	}
+	if f.ContainerPath != "$HOME/.gitconfig" {
+		t.Errorf("ContainerPath = %q, want %q", f.ContainerPath, "$HOME/.gitconfig")
+	}
+}
+
+func TestHomeConfigFilesDetector_FileAbsent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specs := []homeConfigFileSpec{
+		{name: "gitconfig", hostRelPath: ".gitconfig", containerRelPath: ".gitconfig"},
+	}
+	d := newHomeConfigFilesDetectorWithInjection(dir, func(p string) error {
+		_, err := os.Stat(p)
+		return err
+	}, specs)
+
+	detected, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if len(detected) != 0 {
+		t.Errorf("expected 0 detected files, got %d: %v", len(detected), detected)
+	}
+}
+
+func TestHomeConfigFilesDetector_MultipleSpecs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Only create .gitconfig, not .npmrc
+	if err := os.WriteFile(filepath.Join(dir, ".gitconfig"), []byte(""), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	specs := []homeConfigFileSpec{
+		{name: "gitconfig", hostRelPath: ".gitconfig", containerRelPath: ".gitconfig"},
+		{name: "npmrc", hostRelPath: ".npmrc", containerRelPath: ".npmrc"},
+	}
+	d := newHomeConfigFilesDetectorWithInjection(dir, func(p string) error {
+		_, err := os.Stat(p)
+		return err
+	}, specs)
+
+	detected, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if len(detected) != 1 {
+		t.Fatalf("expected 1 detected file, got %d", len(detected))
+	}
+	if detected[0].Name != "gitconfig" {
+		t.Errorf("Name = %q, want %q", detected[0].Name, "gitconfig")
+	}
+}
+
+func TestHomeConfigFilesDetector_StatError(t *testing.T) {
+	t.Parallel()
+
+	statErr := errors.New("permission denied")
+	specs := []homeConfigFileSpec{
+		{name: "gitconfig", hostRelPath: ".gitconfig", containerRelPath: ".gitconfig"},
+	}
+	d := newHomeConfigFilesDetectorWithInjection("/home/user", func(string) error {
+		return statErr
+	}, specs)
+
+	detected, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	// stat errors (including permission denied) are treated as "not found" — skip silently
+	if len(detected) != 0 {
+		t.Errorf("expected 0 detected files on stat error, got %d", len(detected))
+	}
+}
+
+func TestHomeConfigFilesDetector_EmptySpecs(t *testing.T) {
+	t.Parallel()
+
+	d := newHomeConfigFilesDetectorWithInjection("/home/user", func(string) error {
+		return nil
+	}, nil)
+
+	detected, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if len(detected) != 0 {
+		t.Errorf("expected 0 detected files for empty specs, got %d", len(detected))
+	}
+}
+
+func TestHomeConfigFilesDetector_DivergentHostAndContainerPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Simulate a Windows-style host path that differs from the container path.
+	hostRelPath := "AppData/Roaming/tool/config"
+	containerRelPath := ".config/tool/config"
+	if err := os.MkdirAll(filepath.Join(dir, filepath.FromSlash(hostRelPath[:len(hostRelPath)-len("/config")])), 0700); err != nil {
+		t.Fatalf("setup mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(hostRelPath)), []byte(""), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	specs := []homeConfigFileSpec{
+		{name: "tool", hostRelPath: hostRelPath, containerRelPath: containerRelPath},
+	}
+	d := newHomeConfigFilesDetectorWithInjection(dir, func(p string) error {
+		_, err := os.Stat(p)
+		return err
+	}, specs)
+
+	detected, err := d.Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if len(detected) != 1 {
+		t.Fatalf("expected 1 detected file, got %d", len(detected))
+	}
+	f := detected[0]
+	if f.HostPath != "$HOME/AppData/Roaming/tool/config" {
+		t.Errorf("HostPath = %q, want %q", f.HostPath, "$HOME/AppData/Roaming/tool/config")
+	}
+	if f.ContainerPath != "$HOME/.config/tool/config" {
+		t.Errorf("ContainerPath = %q, want %q", f.ContainerPath, "$HOME/.config/tool/config")
+	}
+}
+
+func TestRegisteredHomeConfigFiles_ContainsGitconfig(t *testing.T) {
+	t.Parallel()
+
+	found := false
+	for _, spec := range registeredHomeConfigFiles {
+		if spec.name == "gitconfig" && spec.hostRelPath == ".gitconfig" && spec.containerRelPath == ".gitconfig" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("registeredHomeConfigFiles does not contain gitconfig spec")
+	}
+}

--- a/pkg/cmd/autoconf.go
+++ b/pkg/cmd/autoconf.go
@@ -50,6 +50,10 @@ type autoconfCmd struct {
 	agentLoader        config.AgentConfigLoader
 	workspaceCfg       config.Config
 	vertexSelectTarget func(options []autoconf.ClaudeVertexConfigTargetOption) (autoconf.ClaudeVertexConfigTarget, error)
+
+	homeConfigFilesDetector     autoconf.HomeConfigFilesDetector
+	projectLoader               config.ProjectConfigLoader
+	homeConfigFilesSelectTarget func(options []autoconf.HomeConfigFilesConfigTargetOption) (autoconf.HomeConfigFilesConfigTarget, error)
 }
 
 func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
@@ -76,6 +80,7 @@ func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create project config loader: %w", err)
 	}
+	a.projectLoader = loader
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -127,6 +132,14 @@ func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
 	}
 	a.workspaceUpdater = wu
 
+	if a.homeConfigFilesDetector == nil {
+		hd, hdErr := autoconf.NewHomeConfigFilesDetector()
+		if hdErr != nil {
+			return fmt.Errorf("failed to create home config files detector: %w", hdErr)
+		}
+		a.homeConfigFilesDetector = hd
+	}
+
 	if a.confirm == nil {
 		a.confirm = huhConfirm
 	}
@@ -135,6 +148,9 @@ func (a *autoconfCmd) preRun(cmd *cobra.Command, args []string) error {
 	}
 	if a.vertexSelectTarget == nil {
 		a.vertexSelectTarget = huhSelectVertexTarget
+	}
+	if a.homeConfigFilesSelectTarget == nil {
+		a.homeConfigFilesSelectTarget = huhSelectHomeConfigFilesTarget
 	}
 
 	return nil
@@ -163,6 +179,24 @@ func huhSelectVertexTarget(options []autoconf.ClaudeVertexConfigTargetOption) (a
 	var selected autoconf.ClaudeVertexConfigTarget
 	err := huh.NewSelect[autoconf.ClaudeVertexConfigTarget]().
 		Title("Add Vertex AI configuration to:").
+		Options(huhOptions...).
+		Value(&selected).
+		Run()
+	if errors.Is(err, huh.ErrUserAborted) {
+		return 0, autoconf.ErrSkipped
+	}
+	return selected, err
+}
+
+func huhSelectHomeConfigFilesTarget(options []autoconf.HomeConfigFilesConfigTargetOption) (autoconf.HomeConfigFilesConfigTarget, error) {
+	huhOptions := make([]huh.Option[autoconf.HomeConfigFilesConfigTarget], len(options))
+	for i, opt := range options {
+		huhOptions[i] = huh.NewOption(opt.Label, opt.Target)
+	}
+
+	var selected autoconf.HomeConfigFilesConfigTarget
+	err := huh.NewSelect[autoconf.HomeConfigFilesConfigTarget]().
+		Title("Add home config file mount to:").
 		Options(huhOptions...).
 		Value(&selected).
 		Run()
@@ -207,20 +241,37 @@ func (a *autoconfCmd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if a.vertexDetector == nil {
+	if a.vertexDetector != nil {
+		vertexRunner := autoconf.NewClaudeVertexAutoconf(autoconf.ClaudeVertexAutoconfOptions{
+			Detector:         a.vertexDetector,
+			AgentUpdater:     a.agentUpdater,
+			WorkspaceUpdater: a.workspaceUpdater,
+			AgentLoader:      a.agentLoader,
+			WorkspaceConfig:  a.workspaceCfg,
+			Yes:              a.yes,
+			Confirm:          a.confirm,
+			SelectTarget:     a.vertexSelectTarget,
+		})
+		if err := vertexRunner.Run(out); err != nil {
+			return err
+		}
+	}
+
+	if a.homeConfigFilesDetector == nil {
 		return nil
 	}
-	vertexRunner := autoconf.NewClaudeVertexAutoconf(autoconf.ClaudeVertexAutoconfOptions{
-		Detector:         a.vertexDetector,
-		AgentUpdater:     a.agentUpdater,
+	homeConfigRunner := autoconf.NewHomeConfigFilesAutoconf(autoconf.HomeConfigFilesAutoconfOptions{
+		Detector:         a.homeConfigFilesDetector,
+		ProjectUpdater:   a.projectUpdater,
 		WorkspaceUpdater: a.workspaceUpdater,
-		AgentLoader:      a.agentLoader,
+		ProjectLoader:    a.projectLoader,
 		WorkspaceConfig:  a.workspaceCfg,
+		ProjectID:        a.projectID,
 		Yes:              a.yes,
 		Confirm:          a.confirm,
-		SelectTarget:     a.vertexSelectTarget,
+		SelectTarget:     a.homeConfigFilesSelectTarget,
 	})
-	return vertexRunner.Run(out)
+	return homeConfigRunner.Run(out)
 }
 
 // NewAutoconfCmd returns the autoconf command.

--- a/pkg/cmd/autoconf_test.go
+++ b/pkg/cmd/autoconf_test.go
@@ -362,7 +362,8 @@ func (fakeAutoconfCmdStore) Get(_ string) (secret.ListItem, string, error) {
 // fakeAutoconfCmdUpdater satisfies config.ProjectConfigUpdater for cmd-level tests.
 type fakeAutoconfCmdUpdater struct{}
 
-func (f *fakeAutoconfCmdUpdater) AddSecret(_, _ string) error { return nil }
+func (f *fakeAutoconfCmdUpdater) AddSecret(_, _ string) error           { return nil }
+func (f *fakeAutoconfCmdUpdater) AddMount(_, _, _ string, _ bool) error { return nil }
 
 // fakeAutoconfCmdVertexDetector satisfies autoconf.VertexDetector for cmd-level tests.
 type fakeAutoconfCmdVertexDetector struct {

--- a/pkg/config/projectsupdater.go
+++ b/pkg/config/projectsupdater.go
@@ -33,6 +33,12 @@ type ProjectConfigUpdater interface {
 	// projectID is "" for the global configuration.
 	// The call is idempotent: if the secret is already present it is not duplicated.
 	AddSecret(projectID string, secretName string) error
+
+	// AddMount adds a mount entry to the given project's config.
+	// projectID is "" for the global configuration.
+	// The call is idempotent: if a mount with the same host and target already exists
+	// it is not duplicated.
+	AddMount(projectID, host, target string, ro bool) error
 }
 
 // projectConfigUpdater is the unexported implementation.
@@ -77,6 +83,37 @@ func (p *projectConfigUpdater) AddSecret(projectID string, secretName string) er
 			}
 		}
 		*cfg.Secrets = append(*cfg.Secrets, secretName)
+	}
+
+	projectsConfig[projectID] = cfg
+
+	return p.writeProjectsFile(configPath, projectsConfig)
+}
+
+// AddMount reads projects.json, adds a mount entry for projectID, and writes the file back.
+// The operation is idempotent: an existing mount with the same host and target is not duplicated.
+func (p *projectConfigUpdater) AddMount(projectID, host, target string, ro bool) error {
+	configPath := filepath.Join(p.storageDir, "config", ProjectsConfigFile)
+
+	projectsConfig, err := p.readProjectsFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	cfg := projectsConfig[projectID]
+
+	if cfg.Mounts == nil {
+		roVal := ro
+		mounts := []workspace.Mount{{Host: host, Target: target, Ro: &roVal}}
+		cfg.Mounts = &mounts
+	} else {
+		for _, m := range *cfg.Mounts {
+			if m.Host == host && m.Target == target {
+				return nil
+			}
+		}
+		roVal := ro
+		*cfg.Mounts = append(*cfg.Mounts, workspace.Mount{Host: host, Target: target, Ro: &roVal})
 	}
 
 	projectsConfig[projectID] = cfg

--- a/pkg/config/projectsupdater_test.go
+++ b/pkg/config/projectsupdater_test.go
@@ -254,6 +254,113 @@ func TestWriteProjectsFile_WriteFileFails(t *testing.T) {
 	}
 }
 
+func TestAddMount_CreatesFileWhenMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	updater, err := NewProjectConfigUpdater(dir)
+	if err != nil {
+		t.Fatalf("NewProjectConfigUpdater: %v", err)
+	}
+
+	if err := updater.AddMount("", "$HOME/.gitconfig", "$HOME/.gitconfig", true); err != nil {
+		t.Fatalf("AddMount: %v", err)
+	}
+
+	cfg := readProjectsFile(t, dir)
+	global := cfg[""]
+	if global.Mounts == nil || len(*global.Mounts) != 1 {
+		t.Fatalf("expected 1 mount, got %v", global.Mounts)
+	}
+	m := (*global.Mounts)[0]
+	if m.Host != "$HOME/.gitconfig" || m.Target != "$HOME/.gitconfig" || m.Ro == nil || !*m.Ro {
+		t.Errorf("unexpected mount: %+v", m)
+	}
+}
+
+func TestAddMount_Idempotent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	updater, err := NewProjectConfigUpdater(dir)
+	if err != nil {
+		t.Fatalf("NewProjectConfigUpdater: %v", err)
+	}
+
+	for range 3 {
+		if err := updater.AddMount("", "$HOME/.gitconfig", "$HOME/.gitconfig", true); err != nil {
+			t.Fatalf("AddMount: %v", err)
+		}
+	}
+
+	cfg := readProjectsFile(t, dir)
+	if n := len(*cfg[""].Mounts); n != 1 {
+		t.Errorf("expected exactly 1 mount, got %d", n)
+	}
+}
+
+func TestAddMount_ProjectSpecificKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	updater, err := NewProjectConfigUpdater(dir)
+	if err != nil {
+		t.Fatalf("NewProjectConfigUpdater: %v", err)
+	}
+
+	if err := updater.AddMount("my-project", "$HOME/.gitconfig", "$HOME/.gitconfig", true); err != nil {
+		t.Fatalf("AddMount: %v", err)
+	}
+
+	cfg := readProjectsFile(t, dir)
+	if _, ok := cfg[""]; ok {
+		t.Error("expected no global key")
+	}
+	mounts := *cfg["my-project"].Mounts
+	if len(mounts) != 1 || mounts[0].Target != "$HOME/.gitconfig" {
+		t.Errorf("unexpected mounts: %v", mounts)
+	}
+}
+
+func TestAddMount_AccumulatesMultiple(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	updater, err := NewProjectConfigUpdater(dir)
+	if err != nil {
+		t.Fatalf("NewProjectConfigUpdater: %v", err)
+	}
+
+	mounts := [][2]string{
+		{"$HOME/.gitconfig", "$HOME/.gitconfig"},
+		{"$HOME/.npmrc", "$HOME/.npmrc"},
+	}
+	for _, m := range mounts {
+		if err := updater.AddMount("", m[0], m[1], true); err != nil {
+			t.Fatalf("AddMount(%s): %v", m[0], err)
+		}
+	}
+
+	cfg := readProjectsFile(t, dir)
+	if n := len(*cfg[""].Mounts); n != 2 {
+		t.Errorf("expected 2 mounts, got %d", n)
+	}
+}
+
+func TestAddMount_ReadError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config", ProjectsConfigFile)
+	if err := os.MkdirAll(configPath, 0700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	updater, err := NewProjectConfigUpdater(dir)
+	if err != nil {
+		t.Fatalf("NewProjectConfigUpdater: %v", err)
+	}
+	if err := updater.AddMount("", "$HOME/.gitconfig", "$HOME/.gitconfig", true); err == nil {
+		t.Error("expected error when projects.json is a directory, got nil")
+	}
+}
+
 // readProjectsFile is a test helper that reads and parses the projects.json file.
 func readProjectsFile(t *testing.T, storageDir string) map[string]workspace.WorkspaceConfiguration {
 	t.Helper()


### PR DESCRIPTION
Adds a generic mechanism to detect and mount host home-directory config files read-only into workspace containers via `kdn autoconf`. Files are registered in a central list (starting with .gitconfig); adding a new one requires only a single entry. Host and container paths are kept separate to handle platform differences on Windows.

Users are offered three config targets (global, project, local), the same flow as for secrets. Already-mounted files are skipped. Fixes a bug where a mount present only in the global config was also reported as present in the project config, because the project loader merges global into its result.

Adds AddMount to ProjectConfigUpdater (idempotent by host+target pair).

Part of #377 