### PR TITLE
feat(OpenShell): implement Experimental interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 - **Terminal**: Enables interactive terminal sessions with instances (auto-starts if needed)
 - **Dashboard**: Enables runtimes to expose a web dashboard URL (`GetURL(ctx, instanceID) (string, error)`)
 - **FlagProvider**: Enables runtimes to declare runtime-specific CLI flags (`Flags() []FlagDef`). Flag values flow through `AddOptions.RuntimeOptions` and `CreateParams.RuntimeOptions` as `map[string]string`, keeping the command layer runtime-agnostic. The `runtimesetup.ListFlags()` bridge discovers flags from all available runtimes for registration on cobra commands.
-- **Experimental**: Signals that a runtime's support is experimental. The `init` command detects this interface via `manager.GetRuntime()` and prints `⚠️  <name> runtime support is experimental` to stderr (suppressed in JSON output mode). No return value — presence of the interface is the signal.
+- **Experimental**: Signals that a runtime's support is experimental. The `init` command detects this interface via `manager.GetRuntime()` and prints `⚠️  <name> runtime support is experimental` to stderr (suppressed in JSON output mode). No return value — presence of the interface is the signal. Currently implemented by: `openshell`.
 
 **For detailed runtime implementation guidance, use:** `/working-with-runtime-system`
 

--- a/pkg/runtime/openshell/exec/exec_test.go
+++ b/pkg/runtime/openshell/exec/exec_test.go
@@ -38,21 +38,29 @@ func falseCommand() (string, []string) {
 	return "false", nil
 }
 
-func stderrFailScript(t *testing.T) string {
+func stderrFailCommand(t *testing.T) (string, []string) {
 	t.Helper()
-	dir := t.TempDir()
 	if runtime.GOOS == "windows" {
-		script := filepath.Join(dir, "fail.bat")
-		if err := os.WriteFile(script, []byte("@echo off\r\necho error message 1>&2\r\nexit /b 1\r\n"), 0755); err != nil {
-			t.Fatal(err)
-		}
-		return script
+		return "cmd", []string{"/c", "echo error message >&2 & exit /b 1"}
 	}
+	dir := t.TempDir()
 	script := filepath.Join(dir, "fail.sh")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 'error message' >&2\nexit 1\n"), 0755); err != nil {
+	f, err := os.OpenFile(script, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
 		t.Fatal(err)
 	}
-	return script
+	if _, err := f.Write([]byte("#!/bin/sh\necho 'error message' >&2\nexit 1\n")); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return script, nil
 }
 
 func TestNew(t *testing.T) {
@@ -258,10 +266,10 @@ func TestFakeExecutor_TracksCalls(t *testing.T) {
 func TestExecutor_Run_StderrInError(t *testing.T) {
 	t.Parallel()
 
-	script := stderrFailScript(t)
-	e := New(script)
+	bin, args := stderrFailCommand(t)
+	e := New(bin)
 	var stdout, stderr bytes.Buffer
-	err := e.Run(context.Background(), &stdout, &stderr)
+	err := e.Run(context.Background(), &stdout, &stderr, args...)
 	if err == nil {
 		t.Fatal("Expected error from failing script")
 	}
@@ -276,10 +284,10 @@ func TestExecutor_Run_StderrInError(t *testing.T) {
 func TestExecutor_Output_StderrInError(t *testing.T) {
 	t.Parallel()
 
-	script := stderrFailScript(t)
-	e := New(script)
+	bin, args := stderrFailCommand(t)
+	e := New(bin)
 	var stderr bytes.Buffer
-	_, err := e.Output(context.Background(), &stderr)
+	_, err := e.Output(context.Background(), &stderr, args...)
 	if err == nil {
 		t.Fatal("Expected error from failing script")
 	}

--- a/pkg/runtime/openshell/openshell.go
+++ b/pkg/runtime/openshell/openshell.go
@@ -61,6 +61,9 @@ var _ runtime.SecretServiceRegistryAware = (*openshellRuntime)(nil)
 // Ensure openshellRuntime implements runtime.FlagProvider at compile time.
 var _ runtime.FlagProvider = (*openshellRuntime)(nil)
 
+// Ensure openshellRuntime implements runtime.Experimental at compile time.
+var _ runtime.Experimental = (*openshellRuntime)(nil)
+
 // New creates a new OpenShell Gateway runtime instance.
 func New() runtime.Runtime {
 	return &openshellRuntime{}
@@ -79,6 +82,9 @@ func newWithDeps(executor exec.Executor, gatewayBinaryPath, storageDir string) *
 	rt.binariesOnce.Do(func() {})
 	return rt
 }
+
+// IsExperimental implements runtime.Experimental.
+func (r *openshellRuntime) IsExperimental() {}
 
 // Available reports whether the OpenShell Gateway runtime is supported on the current platform.
 func (r *openshellRuntime) Available() bool {

--- a/pkg/runtime/openshell/openshell_test.go
+++ b/pkg/runtime/openshell/openshell_test.go
@@ -81,6 +81,7 @@ func TestOpenshellRuntime_InterfaceCompliance(t *testing.T) {
 	var _ runtime.StorageAware = (*openshellRuntime)(nil)
 	var _ runtime.Terminal = (*openshellRuntime)(nil)
 	var _ runtime.FlagProvider = (*openshellRuntime)(nil)
+	var _ runtime.Experimental = (*openshellRuntime)(nil)
 }
 
 func TestOpenshellRuntime_Flags(t *testing.T) {


### PR DESCRIPTION
Mark the OpenShell runtime as experimental so the init command displays a warning when users select it.

fixes https://github.com/openkaiden/kdn/issues/437