### PR TITLE
feat(runtime): add DisplayName() to Runtime interface

### DIFF
--- a/.agents/skills/add-runtime/SKILL.md
+++ b/.agents/skills/add-runtime/SKILL.md
@@ -63,6 +63,11 @@ func (r *<runtime-name>Runtime) Type() string {
     return "<runtime-name>"
 }
 
+// DisplayName returns the human-readable display name (e.g., "Podman", "OpenShell").
+func (r *<runtime-name>Runtime) DisplayName() string {
+    return "<Pretty Runtime Name>"
+}
+
 // Description returns a human-readable description of the runtime.
 func (r *<runtime-name>Runtime) Description() string {
     return "<short description of what this runtime provides>"
@@ -325,6 +330,10 @@ func TestNew(t *testing.T) {
     if rt.Type() != "<runtime-name>" {
         t.Errorf("Expected type '<runtime-name>', got %s", rt.Type())
     }
+
+    if rt.DisplayName() != "<Pretty Runtime Name>" {
+        t.Errorf("DisplayName() = %q, want %q", rt.DisplayName(), "<Pretty Runtime Name>")
+    }
 }
 
 func TestCreate(t *testing.T) {
@@ -419,6 +428,7 @@ All runtimes MUST implement:
 ```go
 type Runtime interface {
     Type() string
+    DisplayName() string
     Description() string
     Local() bool
     WorkspaceSourcesPath() string

--- a/.agents/skills/working-with-runtime-system/SKILL.md
+++ b/.agents/skills/working-with-runtime-system/SKILL.md
@@ -237,8 +237,10 @@ type Experimental interface {
 When the `init` command runs, it calls `manager.GetRuntime(runtimeType)` and checks for this interface. If present, it prints a warning to stderr before creating the workspace:
 
 ```text
-⚠️  <name> runtime support is experimental
+⚠️  <DisplayName> runtime support is experimental
 ```
+
+The `<DisplayName>` comes from the runtime's `DisplayName()` method, not its `Type()` identifier.
 
 The warning is suppressed in JSON output mode (`--output json`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 - **Terminal**: Enables interactive terminal sessions with instances (auto-starts if needed)
 - **Dashboard**: Enables runtimes to expose a web dashboard URL (`GetURL(ctx, instanceID) (string, error)`)
 - **FlagProvider**: Enables runtimes to declare runtime-specific CLI flags (`Flags() []FlagDef`). Flag values flow through `AddOptions.RuntimeOptions` and `CreateParams.RuntimeOptions` as `map[string]string`, keeping the command layer runtime-agnostic. The `runtimesetup.ListFlags()` bridge discovers flags from all available runtimes for registration on cobra commands.
-- **Experimental**: Signals that a runtime's support is experimental. The `init` command detects this interface via `manager.GetRuntime()` and prints `⚠️  <name> runtime support is experimental` to stderr (suppressed in JSON output mode). No return value — presence of the interface is the signal. Currently implemented by: `openshell`.
+- **Experimental**: Signals that a runtime's support is experimental. The `init` command detects this interface via `manager.GetRuntime()` and prints `⚠️  <DisplayName> runtime support is experimental` to stderr using the runtime's `DisplayName()` (suppressed in JSON output mode). No return value — presence of the interface is the signal. Currently implemented by: `openshell`.
 
 **For detailed runtime implementation guidance, use:** `/working-with-runtime-system`
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -230,7 +230,7 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 	// Warn when the selected runtime is experimental
 	if rt, err := i.manager.GetRuntime(i.runtime); err == nil {
 		if _, ok := rt.(runtime.Experimental); ok && i.output != "json" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  %s runtime support is experimental\n", i.runtime)
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  %s runtime support is experimental\n", rt.DisplayName())
 		}
 	}
 

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -2662,6 +2662,49 @@ func TestInitCmd_ExperimentalWarning(t *testing.T) {
 			t.Errorf("Expected no experimental warning in JSON mode, got: %q", stderrStr)
 		}
 	})
+
+	t.Run("uses DisplayName not Type in warning", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.NewWithExperimentalAndDisplayName("My Runtime")); err != nil {
+			t.Fatalf("Failed to register experimental runtime: %v", err)
+		}
+
+		c := &initCmd{
+			runtime:        "fake",
+			agent:          "test-agent",
+			absSourcesDir:  sourcesDir,
+			absConfigDir:   filepath.Join(sourcesDir, ".kaiden"),
+			manager:        manager,
+			runtimeOptions: map[string]string{},
+		}
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		if err := c.run(cmd, nil); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		stderrStr := stderr.String()
+		if !strings.Contains(stderrStr, "My Runtime runtime support is experimental") {
+			t.Errorf("Expected display name in warning, got: %q", stderrStr)
+		}
+		if strings.Contains(stderrStr, "fake runtime support is experimental") {
+			t.Errorf("Expected display name (not type ID) in warning, got: %q", stderrStr)
+		}
+	})
 }
 
 func TestRegisterRuntimeFlags(t *testing.T) {

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -2888,6 +2888,7 @@ type invalidStateRuntime struct {
 }
 
 func (r *invalidStateRuntime) Type() string        { return "invalid-state-runtime" }
+func (r *invalidStateRuntime) DisplayName() string { return "invalid-state-runtime" }
 func (r *invalidStateRuntime) Description() string { return "invalid state runtime for testing" }
 func (r *invalidStateRuntime) Local() bool         { return true }
 
@@ -3830,6 +3831,7 @@ func newSpyRuntime(wrapped runtime.Runtime) *spyRuntime {
 }
 
 func (s *spyRuntime) Type() string                 { return s.wrapped.Type() }
+func (s *spyRuntime) DisplayName() string          { return s.wrapped.DisplayName() }
 func (s *spyRuntime) Description() string          { return s.wrapped.Description() }
 func (s *spyRuntime) Local() bool                  { return s.wrapped.Local() }
 func (s *spyRuntime) WorkspaceSourcesPath() string { return s.wrapped.WorkspaceSourcesPath() }

--- a/pkg/runtime/fake/experimental.go
+++ b/pkg/runtime/fake/experimental.go
@@ -35,3 +35,25 @@ func NewWithExperimental() runtime.Runtime {
 
 // IsExperimental implements runtime.Experimental.
 func (r *runtimeWithExperimental) IsExperimental() {}
+
+// runtimeWithExperimentalAndDisplayName wraps runtimeWithExperimental and overrides DisplayName.
+type runtimeWithExperimentalAndDisplayName struct {
+	*runtimeWithExperimental
+	displayName string
+}
+
+// NewWithExperimentalAndDisplayName creates a fake experimental runtime with a custom DisplayName.
+// Use this in tests that need to verify DisplayName is used separately from Type.
+func NewWithExperimentalAndDisplayName(displayName string) runtime.Runtime {
+	return &runtimeWithExperimentalAndDisplayName{
+		runtimeWithExperimental: &runtimeWithExperimental{
+			fakeRuntime: New().(*fakeRuntime),
+		},
+		displayName: displayName,
+	}
+}
+
+// DisplayName overrides the embedded runtime's DisplayName.
+func (r *runtimeWithExperimentalAndDisplayName) DisplayName() string {
+	return r.displayName
+}

--- a/pkg/runtime/fake/fake.go
+++ b/pkg/runtime/fake/fake.go
@@ -161,6 +161,11 @@ func (f *fakeRuntime) saveToDisk() error {
 	return nil
 }
 
+// DisplayName returns the display name of the fake runtime.
+func (f *fakeRuntime) DisplayName() string {
+	return "fake"
+}
+
 // Type returns the runtime type identifier.
 func (f *fakeRuntime) Type() string {
 	return "fake"

--- a/pkg/runtime/fake/fake_test.go
+++ b/pkg/runtime/fake/fake_test.go
@@ -36,6 +36,15 @@ func TestFakeRuntime_Type(t *testing.T) {
 	}
 }
 
+func TestFakeRuntime_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	rt := New()
+	if rt.DisplayName() != "fake" {
+		t.Errorf("DisplayName() = %q, want %q", rt.DisplayName(), "fake")
+	}
+}
+
 func TestFakeRuntime_WorkspaceSourcesPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/openshell/openshell.go
+++ b/pkg/runtime/openshell/openshell.go
@@ -163,6 +163,11 @@ func (r *openshellRuntime) downloadBinaries() error {
 	return nil
 }
 
+// DisplayName returns the display name of the OpenShell runtime.
+func (r *openshellRuntime) DisplayName() string {
+	return "OpenShell"
+}
+
 // Type returns the runtime type identifier.
 func (r *openshellRuntime) Type() string {
 	return "openshell"

--- a/pkg/runtime/openshell/openshell_test.go
+++ b/pkg/runtime/openshell/openshell_test.go
@@ -74,6 +74,15 @@ func TestOpenshellRuntime_Type(t *testing.T) {
 	}
 }
 
+func TestOpenshellRuntime_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	rt := newWithDeps(exec.NewFake(), "/fake/openshell-gateway", t.TempDir())
+	if rt.DisplayName() != "OpenShell" {
+		t.Errorf("DisplayName() = %q, want %q", rt.DisplayName(), "OpenShell")
+	}
+}
+
 func TestOpenshellRuntime_InterfaceCompliance(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -257,6 +257,11 @@ func (p *podmanRuntime) ListAgents() ([]string, error) {
 	return p.config.ListAgents()
 }
 
+// DisplayName returns the display name of the Podman runtime.
+func (p *podmanRuntime) DisplayName() string {
+	return "Podman"
+}
+
 // Type returns the runtime type identifier.
 func (p *podmanRuntime) Type() string {
 	return "podman"

--- a/pkg/runtime/podman/podman_test.go
+++ b/pkg/runtime/podman/podman_test.go
@@ -416,6 +416,15 @@ func TestFindFreePorts(t *testing.T) {
 	})
 }
 
+func TestPodmanRuntime_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	rt := New()
+	if rt.DisplayName() != "Podman" {
+		t.Errorf("DisplayName() = %q, want %q", rt.DisplayName(), "Podman")
+	}
+}
+
 func TestPodmanRuntime_WorkspaceSourcesPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/registry_test.go
+++ b/pkg/runtime/registry_test.go
@@ -29,6 +29,7 @@ type fakeRuntime struct {
 }
 
 func (f *fakeRuntime) Type() string        { return f.typeID }
+func (f *fakeRuntime) DisplayName() string { return f.typeID }
 func (f *fakeRuntime) Description() string { return "fake runtime for testing" }
 func (f *fakeRuntime) Local() bool         { return true }
 func (f *fakeRuntime) WorkspaceSourcesPath() string {
@@ -350,6 +351,7 @@ type storageAwareRuntime struct {
 }
 
 func (s *storageAwareRuntime) Type() string        { return s.typeID }
+func (s *storageAwareRuntime) DisplayName() string { return s.typeID }
 func (s *storageAwareRuntime) Description() string { return "storage-aware runtime for testing" }
 func (s *storageAwareRuntime) Local() bool         { return true }
 func (s *storageAwareRuntime) WorkspaceSourcesPath() string {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -34,6 +34,10 @@ type Runtime interface {
 	// Type returns the runtime type identifier (e.g., "podman", "docker", "process", "fake").
 	Type() string
 
+	// DisplayName returns a human-readable name for the runtime (e.g., "Podman", "OpenShell").
+	// Unlike Type(), this is suitable for display in UI messages and warnings.
+	DisplayName() string
+
 	// Description returns a human-readable description of the runtime.
 	Description() string
 

--- a/pkg/runtimesetup/register_test.go
+++ b/pkg/runtimesetup/register_test.go
@@ -47,6 +47,8 @@ type testRuntime struct {
 
 func (t *testRuntime) Type() string { return t.runtimeType }
 
+func (t *testRuntime) DisplayName() string { return t.runtimeType }
+
 func (t *testRuntime) Description() string { return t.description }
 
 func (t *testRuntime) Local() bool { return t.local }


### PR DESCRIPTION
Runtimes previously only exposed a machine-readable Type() identifier (e.g. "openshell"), with no way to display a human-friendly name in CLI output. DisplayName() fills that gap: the init command now uses it in the experimental warning instead of the raw type string, so users see "OpenShell" rather than "openshell".

Closes #447