### PR TITLE
chore(build): remove darwin/amd64 from goreleaser targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: darwin
+        goarch: amd64
 
 notarize:
   macos:


### PR DESCRIPTION
Podman v6 dropped support for Mac Intel (darwin/amd64), making binaries for that platform non-functional. Exclude it via an ignore rule while keeping all other targets.

Closes #441