### PR TITLE
fix(network): register secret services in start command and add host collection logging

### DIFF
--- a/pkg/cmd/workspace_start.go
+++ b/pkg/cmd/workspace_start.go
@@ -25,9 +25,12 @@ import (
 	"path/filepath"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
+	"github.com/openkaiden/kdn/pkg/agentsetup"
+	"github.com/openkaiden/kdn/pkg/credentialsetup"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
+	"github.com/openkaiden/kdn/pkg/secretservicesetup"
 	"github.com/openkaiden/kdn/pkg/steplogger"
 	"github.com/spf13/cobra"
 )
@@ -80,6 +83,18 @@ func (w *workspaceStartCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Register all available runtimes
 	if err := runtimesetup.RegisterAll(manager); err != nil {
 		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register runtimes: %w", err))
+	}
+
+	if err := agentsetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register agents: %w", err))
+	}
+
+	if err := secretservicesetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register secret services: %w", err))
+	}
+
+	if err := credentialsetup.RegisterAll(manager); err != nil {
+		return outputErrorIfJSON(cmd, w.output, fmt.Errorf("failed to register credentials: %w", err))
 	}
 
 	w.manager = manager

--- a/pkg/cmd/workspace_start_test.go
+++ b/pkg/cmd/workspace_start_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/openkaiden/kdn/pkg/cmd/testutil"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/runtime/fake"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+	"github.com/openkaiden/kdn/pkg/secretservicesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -166,6 +168,31 @@ func TestWorkspaceStartCmd_PreRun(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "--show-logs") {
 			t.Errorf("Expected error to mention '--show-logs', got: %v", err)
+		}
+	})
+
+	t.Run("registers all secret services so known types resolve on start", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		c := &workspaceStartCmd{}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		if err := c.preRun(cmd, []string{"test-id"}); err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+
+		// All services from secretservices.json must already be registered.
+		// Attempting to re-register any of them must return an "already registered" error.
+		for _, name := range secretservicesetup.ListAvailable() {
+			svc := secretservice.NewSecretService(name, nil, "", nil, "", "", "")
+			err := c.manager.RegisterSecretService(svc)
+			if err == nil {
+				t.Errorf("secret service %q was not registered by preRun (re-registration succeeded)", name)
+			} else if !strings.Contains(err.Error(), "already registered") {
+				t.Errorf("secret service %q: unexpected error: %v", name, err)
+			}
 		}
 	})
 

--- a/pkg/cmd/workspace_terminal.go
+++ b/pkg/cmd/workspace_terminal.go
@@ -23,8 +23,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/openkaiden/kdn/pkg/agentsetup"
+	"github.com/openkaiden/kdn/pkg/credentialsetup"
 	"github.com/openkaiden/kdn/pkg/instances"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
+	"github.com/openkaiden/kdn/pkg/secretservicesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -67,6 +70,18 @@ func (w *workspaceTerminalCmd) preRun(cmd *cobra.Command, args []string) error {
 	// Register all available runtimes
 	if err := runtimesetup.RegisterAll(manager); err != nil {
 		return fmt.Errorf("failed to register runtimes: %w", err)
+	}
+
+	if err := agentsetup.RegisterAll(manager); err != nil {
+		return fmt.Errorf("failed to register agents: %w", err)
+	}
+
+	if err := secretservicesetup.RegisterAll(manager); err != nil {
+		return fmt.Errorf("failed to register secret services: %w", err)
+	}
+
+	if err := credentialsetup.RegisterAll(manager); err != nil {
+		return fmt.Errorf("failed to register credentials: %w", err)
 	}
 
 	w.manager = manager

--- a/pkg/cmd/workspace_terminal_test.go
+++ b/pkg/cmd/workspace_terminal_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/openkaiden/kdn/pkg/cmd/testutil"
 	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+	"github.com/openkaiden/kdn/pkg/secretservicesetup"
 	"github.com/spf13/cobra"
 )
 
@@ -74,6 +76,29 @@ func TestWorkspaceTerminalCmd_PreRun(t *testing.T) {
 		// The runtime will choose the agent's terminal command
 		if len(c.command) != 0 {
 			t.Errorf("Expected empty command [], got %v", c.command)
+		}
+	})
+
+	t.Run("registers all secret services so known types resolve on auto-start", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		c := &workspaceTerminalCmd{}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "test storage flag")
+
+		if err := c.preRun(cmd, []string{"test-id"}); err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+
+		for _, name := range secretservicesetup.ListAvailable() {
+			svc := secretservice.NewSecretService(name, nil, "", nil, "", "", "")
+			err := c.manager.RegisterSecretService(svc)
+			if err == nil {
+				t.Errorf("secret service %q was not registered by preRun (re-registration succeeded)", name)
+			} else if !strings.Contains(err.Error(), "already registered") {
+				t.Errorf("secret service %q: unexpected error: %v", name, err)
+			}
 		}
 	})
 

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -26,6 +26,7 @@ import (
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/config"
+	"github.com/openkaiden/kdn/pkg/logger"
 	"github.com/openkaiden/kdn/pkg/onecli"
 	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/openkaiden/kdn/pkg/secretservice"
@@ -74,13 +75,15 @@ func loadNetworkConfig(sourcePath, storageDir, projectID, agentName string) (*wo
 // listed in wsCfg. For known secret types, patterns come from the secret
 // service registry; for "other" secrets, they come from the stored metadata.
 // Returns nil when any required input is nil or when no secrets are configured.
-func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.Store, registry secretservice.Registry) ([]string, error) {
+func collectSecretHosts(ctx context.Context, wsCfg *workspace.WorkspaceConfiguration, store secret.Store, registry secretservice.Registry) ([]string, error) {
 	if wsCfg == nil || wsCfg.Secrets == nil || len(*wsCfg.Secrets) == 0 {
 		return nil, nil
 	}
 	if store == nil || registry == nil {
 		return nil, nil
 	}
+
+	l := logger.FromContext(ctx)
 
 	items, err := store.List()
 	if err != nil {
@@ -97,6 +100,7 @@ func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.St
 	for _, name := range *wsCfg.Secrets {
 		item, ok := byName[name]
 		if !ok {
+			fmt.Fprintf(l.Stderr(), "[network] secret %q listed in workspace config but not found in store — skipping\n", name)
 			continue
 		}
 		var itemHosts []string
@@ -105,10 +109,12 @@ func collectSecretHosts(wsCfg *workspace.WorkspaceConfiguration, store secret.St
 		} else {
 			svc, svcErr := registry.Get(item.Type)
 			if svcErr != nil {
+				fmt.Fprintf(l.Stderr(), "[network] secret %q has type %q not found in registry — skipping\n", name, item.Type)
 				continue
 			}
 			itemHosts = svc.HostsPatterns()
 		}
+		fmt.Fprintf(l.Stderr(), "[network] secret %q (type %q) contributes hosts: %v\n", name, item.Type, itemHosts)
 		for _, h := range itemHosts {
 			if !seen[h] {
 				seen[h] = true

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -646,7 +646,7 @@ func TestCollectSecretHosts(t *testing.T) {
 
 	t.Run("nil config returns nil", func(t *testing.T) {
 		t.Parallel()
-		got, err := collectSecretHosts(nil, &fakeSecretStore{}, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), nil, &fakeSecretStore{}, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -658,7 +658,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("nil secrets field returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := &workspace.WorkspaceConfiguration{}
-		got, err := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), cfg, &fakeSecretStore{}, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -670,7 +670,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("empty secrets list returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := denyConfig([]string{})
-		got, err := collectSecretHosts(cfg, &fakeSecretStore{}, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), cfg, &fakeSecretStore{}, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -682,7 +682,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("nil store returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := denyConfig([]string{"mysecret"})
-		got, err := collectSecretHosts(cfg, nil, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), cfg, nil, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -694,7 +694,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("nil registry returns nil", func(t *testing.T) {
 		t.Parallel()
 		cfg := denyConfig([]string{"mysecret"})
-		got, err := collectSecretHosts(cfg, &fakeSecretStore{}, nil)
+		got, err := collectSecretHosts(context.Background(), cfg, &fakeSecretStore{}, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -707,7 +707,7 @@ func TestCollectSecretHosts(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{items: []secret.ListItem{{Name: "mygithub", Type: "github"}}}
 		reg := makeRegistry(t, makeSecretService("github", []string{"api.github.com"}))
-		got, err := collectSecretHosts(denyConfig([]string{"mygithub"}), store, reg)
+		got, err := collectSecretHosts(context.Background(), denyConfig([]string{"mygithub"}), store, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -723,7 +723,7 @@ func TestCollectSecretHosts(t *testing.T) {
 				{Name: "mykey", Type: secret.TypeOther, Hosts: []string{"api.example.com", "api2.example.com"}},
 			},
 		}
-		got, err := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), denyConfig([]string{"mykey"}), store, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -741,7 +741,7 @@ func TestCollectSecretHosts(t *testing.T) {
 			},
 		}
 		reg := makeRegistry(t, makeSecretService("github", []string{"api.github.com"}))
-		got, err := collectSecretHosts(denyConfig([]string{"gh1", "gh2"}), store, reg)
+		got, err := collectSecretHosts(context.Background(), denyConfig([]string{"gh1", "gh2"}), store, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -759,7 +759,7 @@ func TestCollectSecretHosts(t *testing.T) {
 			},
 		}
 		reg := makeRegistry(t, makeSecretService("github", []string{"api.github.com"}))
-		got, err := collectSecretHosts(denyConfig([]string{"mygithub", "myother"}), store, reg)
+		got, err := collectSecretHosts(context.Background(), denyConfig([]string{"mygithub", "myother"}), store, reg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -777,7 +777,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("skips secrets not found in store", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{items: []secret.ListItem{}}
-		got, err := collectSecretHosts(denyConfig([]string{"missing"}), store, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), denyConfig([]string{"missing"}), store, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -789,7 +789,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("skips secrets with type not in registry", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{items: []secret.ListItem{{Name: "mykey", Type: "unknown-type"}}}
-		got, err := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry(t))
+		got, err := collectSecretHosts(context.Background(), denyConfig([]string{"mykey"}), store, makeRegistry(t))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -801,7 +801,7 @@ func TestCollectSecretHosts(t *testing.T) {
 	t.Run("store list error returns error", func(t *testing.T) {
 		t.Parallel()
 		store := &fakeSecretStore{err: errors.New("disk error")}
-		_, err := collectSecretHosts(denyConfig([]string{"mykey"}), store, makeRegistry(t))
+		_, err := collectSecretHosts(context.Background(), denyConfig([]string{"mykey"}), store, makeRegistry(t))
 		if err == nil {
 			t.Error("expected error from store.List(), got nil")
 		}

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -104,7 +104,7 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 
 	// Automatically add host patterns from secrets so users do not need to
 	// list them explicitly under network.hosts.
-	secretHosts, err := collectSecretHosts(wsCfg, p.secretStore, p.secretServiceRegistry)
+	secretHosts, err := collectSecretHosts(ctx, wsCfg, p.secretStore, p.secretServiceRegistry)
 	if err != nil {
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to collect secret hosts: %w", err)
 	}
@@ -113,6 +113,7 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	// The credential directory acts as a signal that the credential was successfully set up.
 	credentialHosts := p.collectCredentialHosts(tmplData.Name, wsCfg)
 	allHosts := mergeHosts(explicitHosts, mergeHosts(secretHosts, credentialHosts))
+	fmt.Fprintf(l.Stderr(), "[network] allowed hosts for approval-handler: %v\n", allHosts)
 
 	// Networking rules are configured whenever mode is explicitly deny, regardless
 	// of whether any hosts are allowed. An empty host list causes the


### PR DESCRIPTION
workspace start only called runtimesetup.RegisterAll, leaving
secretServiceRegistry empty. collectSecretHosts silently skipped all
known-type secrets, so their host patterns were never written to the
approval-handler config.json.

Also adds --show-logs diagnostics to collectSecretHosts (skipped secrets
with reasons) and logs the final allHosts list before networking is
configured.

Closes #455

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
