### PR TITLE
feat(OpenShell): auto-provision providers from workspace secrets

### DIFF
--- a/pkg/runtime/openshell/create.go
+++ b/pkg/runtime/openshell/create.go
@@ -64,9 +64,18 @@ func (r *openshellRuntime) Create(ctx context.Context, params runtime.CreatePara
 	// Collect ports from workspace config and agent defaults
 	ports := collectPorts(params)
 
+	// Provision OpenShell providers for workspace secrets before sandbox creation,
+	// because providers must be attached via --provider flags at create time.
+	step.Start("Provisioning secret providers", "Secret providers provisioned")
+	providerNames, err := r.ensureProviders(ctx, params.WorkspaceConfig)
+	if err != nil {
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to provision providers: %w", err)
+	}
+
 	// Create the sandbox
 	step.Start(fmt.Sprintf("Creating sandbox: %s", name), "Sandbox created")
-	if err := r.createSandbox(ctx, name, params.Agent, l); err != nil {
+	if err := r.createSandbox(ctx, name, params.Agent, providerNames, l); err != nil {
 		step.Fail(err)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to create sandbox: %w", err)
 	}
@@ -169,7 +178,7 @@ func sandboxImage(agent string) (string, error) {
 	}
 }
 
-func (r *openshellRuntime) createSandbox(ctx context.Context, name string, agent string, l logger.Logger) error {
+func (r *openshellRuntime) createSandbox(ctx context.Context, name string, agent string, providers []string, l logger.Logger) error {
 	args := []string{"sandbox", "create", "--name", name}
 	if r.config.Driver != DriverVM {
 		image, err := sandboxImage(agent)
@@ -177,6 +186,9 @@ func (r *openshellRuntime) createSandbox(ctx context.Context, name string, agent
 			return err
 		}
 		args = append(args, "--from", image)
+	}
+	for _, p := range providers {
+		args = append(args, "--provider", p)
 	}
 	args = append(args, "--no-tty", "--no-bootstrap", "--", "true")
 	err := r.executor.Run(ctx, l.Stdout(), l.Stderr(), args...)

--- a/pkg/runtime/openshell/create_test.go
+++ b/pkg/runtime/openshell/create_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -121,7 +122,7 @@ func TestCreateSandbox_PodmanIncludesFromBase(t *testing.T) {
 	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
 	rt.config.Driver = DriverPodman
 
-	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", nil, noopLogger{})
 
 	if len(fakeExec.RunCalls) < 1 {
 		t.Fatal("Expected at least 1 Run call")
@@ -147,7 +148,7 @@ func TestCreateSandbox_PodmanUsesAgentImage(t *testing.T) {
 	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
 	rt.config.Driver = DriverPodman
 
-	_ = rt.createSandbox(context.Background(), "kdn-test", "gemini", noopLogger{})
+	_ = rt.createSandbox(context.Background(), "kdn-test", "gemini", nil, noopLogger{})
 
 	if len(fakeExec.RunCalls) < 1 {
 		t.Fatal("Expected at least 1 Run call")
@@ -166,6 +167,36 @@ func TestCreateSandbox_PodmanUsesAgentImage(t *testing.T) {
 	}
 }
 
+func TestCreateSandbox_WithProviders(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
+	rt.config.Driver = DriverPodman
+
+	providers := []string{"kdn-github-token", "kdn-anthropic-key"}
+	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", providers, noopLogger{})
+
+	if len(fakeExec.RunCalls) < 1 {
+		t.Fatal("Expected at least 1 Run call")
+	}
+
+	call := fakeExec.RunCalls[0]
+	providerCount := 0
+	for i, arg := range call {
+		if arg == "--provider" && i+1 < len(call) {
+			providerCount++
+		}
+	}
+	if providerCount != 2 {
+		t.Errorf("Expected 2 --provider flags, got %d in: %v", providerCount, call)
+	}
+
+	if !slices.Contains(call, "kdn-github-token") || !slices.Contains(call, "kdn-anthropic-key") {
+		t.Errorf("Expected provider names in create call: %v", call)
+	}
+}
+
 func TestCreateSandbox_PodmanRejectsUnknownAgent(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +204,7 @@ func TestCreateSandbox_PodmanRejectsUnknownAgent(t *testing.T) {
 	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
 	rt.config.Driver = DriverPodman
 
-	err := rt.createSandbox(context.Background(), "kdn-test", "unknown-agent", noopLogger{})
+	err := rt.createSandbox(context.Background(), "kdn-test", "unknown-agent", nil, noopLogger{})
 	if err == nil {
 		t.Error("Expected error for unsupported agent")
 	}
@@ -226,7 +257,7 @@ func TestCreateSandbox_VMOmitsFromBase(t *testing.T) {
 	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
 	rt.config.Driver = DriverVM
 
-	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+	_ = rt.createSandbox(context.Background(), "kdn-test", "claude", nil, noopLogger{})
 
 	if len(fakeExec.RunCalls) < 1 {
 		t.Fatal("Expected at least 1 Run call")
@@ -584,7 +615,7 @@ func TestCreateSandbox_ReadinessTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := rt.createSandbox(ctx, "kdn-test", "claude", noopLogger{})
+	err := rt.createSandbox(ctx, "kdn-test", "claude", nil, noopLogger{})
 	if err == nil {
 		t.Error("Expected error when context is cancelled")
 	}
@@ -604,7 +635,7 @@ func TestCreateSandbox_RetriesUntilReady(t *testing.T) {
 	}
 
 	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
-	err := rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+	err := rt.createSandbox(context.Background(), "kdn-test", "claude", nil, noopLogger{})
 	if err != nil {
 		t.Fatalf("createSandbox should succeed after retry: %v", err)
 	}
@@ -619,7 +650,7 @@ func TestCreateSandbox_SucceedsFirstTry(t *testing.T) {
 	fakeExec := exec.NewFake()
 	rt := newWithDeps(fakeExec, "/fake/openshell-gateway", t.TempDir())
 
-	err := rt.createSandbox(context.Background(), "kdn-test", "claude", noopLogger{})
+	err := rt.createSandbox(context.Background(), "kdn-test", "claude", nil, noopLogger{})
 	if err != nil {
 		t.Fatalf("createSandbox should succeed on first try: %v", err)
 	}

--- a/pkg/runtime/openshell/network_test.go
+++ b/pkg/runtime/openshell/network_test.go
@@ -516,14 +516,24 @@ func assertPolicyUpdateNotContains(t *testing.T, calls [][]string, endpoints ...
 
 // fakeSecretStore implements secret.Store for testing.
 type fakeSecretStore struct {
-	items []secret.ListItem
-	err   error
+	items  []secret.ListItem
+	values map[string]string
+	err    error
 }
 
 func (f *fakeSecretStore) Create(secret.CreateParams) error { return nil }
 func (f *fakeSecretStore) List() ([]secret.ListItem, error) { return f.items, f.err }
-func (f *fakeSecretStore) Get(string) (secret.ListItem, string, error) {
-	return secret.ListItem{}, "", nil
+func (f *fakeSecretStore) Get(name string) (secret.ListItem, string, error) {
+	for _, item := range f.items {
+		if item.Name == name {
+			val := ""
+			if f.values != nil {
+				val = f.values[name]
+			}
+			return item, val, nil
+		}
+	}
+	return secret.ListItem{}, "", fmt.Errorf("secret %q not found", name)
 }
 func (f *fakeSecretStore) Remove(string) error { return nil }
 
@@ -555,14 +565,15 @@ func (f *fakeSecretServiceRegistry) List() []string {
 
 // fakeSecretService implements secretservice.SecretService for testing.
 type fakeSecretService struct {
-	hosts []string
+	hosts   []string
+	envVars []string
 }
 
 func (f *fakeSecretService) Name() string            { return "fake" }
 func (f *fakeSecretService) Description() string     { return "" }
 func (f *fakeSecretService) HostsPatterns() []string { return f.hosts }
 func (f *fakeSecretService) Path() string            { return "" }
-func (f *fakeSecretService) EnvVars() []string       { return nil }
+func (f *fakeSecretService) EnvVars() []string       { return f.envVars }
 func (f *fakeSecretService) HeaderName() string      { return "" }
 func (f *fakeSecretService) HeaderTemplate() string  { return "" }
 

--- a/pkg/runtime/openshell/providers.go
+++ b/pkg/runtime/openshell/providers.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/secret"
+)
+
+const providerNamePrefix = "kdn-"
+
+var providerTypeMap = map[string]string{
+	"github":    "github",
+	"anthropic": "anthropic",
+}
+
+var providerNameRegex = regexp.MustCompile("[^a-z0-9]+")
+
+// providerName converts a kdn secret name into a deterministic OpenShell provider name.
+func providerName(secretName string) string {
+	s := strings.ToLower(secretName)
+	s = providerNameRegex.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	return providerNamePrefix + s
+}
+
+// providerType maps a kdn secret type to an OpenShell provider type.
+func providerType(kdnType string) string {
+	if pt, ok := providerTypeMap[kdnType]; ok {
+		return pt
+	}
+	return "generic"
+}
+
+// ensureProviders checks that OpenShell providers exist for all secrets
+// configured in the workspace. Missing providers are created automatically.
+// Returns the list of provider names that were created or already existed,
+// so the caller can pass them to sandbox create via --provider flags.
+func (r *openshellRuntime) ensureProviders(ctx context.Context, wsCfg *workspace.WorkspaceConfiguration) ([]string, error) {
+	if wsCfg == nil || wsCfg.Secrets == nil || len(*wsCfg.Secrets) == 0 {
+		return nil, nil
+	}
+	if r.secretStore == nil || r.secretServiceRegistry == nil {
+		return nil, nil
+	}
+
+	existing, err := r.listExistingProviders(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := r.secretStore.List()
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+
+	byName := make(map[string]secret.ListItem, len(items))
+	for _, item := range items {
+		byName[item.Name] = item
+	}
+
+	l := logger.FromContext(ctx)
+
+	var providerNames []string
+	for _, name := range *wsCfg.Secrets {
+		item, ok := byName[name]
+		if !ok {
+			continue
+		}
+
+		pName := providerName(name)
+
+		if existing[pName] {
+			providerNames = append(providerNames, pName)
+			continue
+		}
+
+		_, value, err := r.secretStore.Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("reading secret %q: %w", name, err)
+		}
+
+		var envVars []string
+		if item.Type == secret.TypeOther {
+			envVars = item.Envs
+		} else {
+			svc, svcErr := r.secretServiceRegistry.Get(item.Type)
+			if svcErr != nil {
+				continue
+			}
+			envVars = svc.EnvVars()
+		}
+
+		if len(envVars) == 0 {
+			continue
+		}
+
+		pType := providerType(item.Type)
+
+		args := []string{"provider", "create", "--name", pName, "--type", pType}
+		for _, envVar := range envVars {
+			args = append(args, "--credential", fmt.Sprintf("%s=%s", envVar, value))
+		}
+
+		fmt.Fprintf(l.Stderr(), "Creating provider %s (type=%s) for secret %q\n", pName, pType, name)
+		if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(), args...); err != nil {
+			return nil, fmt.Errorf("creating provider %s: %w", pName, err)
+		}
+
+		providerNames = append(providerNames, pName)
+	}
+
+	return providerNames, nil
+}
+
+// listExistingProviders returns the set of provider names currently registered
+// in the OpenShell gateway.
+func (r *openshellRuntime) listExistingProviders(ctx context.Context) (map[string]bool, error) {
+	l := logger.FromContext(ctx)
+
+	output, err := r.executor.Output(ctx, l.Stderr(), "provider", "list", "--names")
+	if err != nil {
+		return nil, fmt.Errorf("listing providers: %w", err)
+	}
+
+	providers := make(map[string]bool)
+	for _, line := range strings.Split(string(output), "\n") {
+		name := strings.TrimSpace(line)
+		if name != "" {
+			providers[name] = true
+		}
+	}
+	return providers, nil
+}

--- a/pkg/runtime/openshell/providers_test.go
+++ b/pkg/runtime/openshell/providers_test.go
@@ -1,0 +1,476 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+	"github.com/openkaiden/kdn/pkg/secret"
+	"github.com/openkaiden/kdn/pkg/secretservice"
+)
+
+func TestProviderName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"GitHub Token", "kdn-github-token"},
+		{"anthropic-key", "kdn-anthropic-key"},
+		{"My  Custom--API", "kdn-my-custom-api"},
+		{"  leading-trailing  ", "kdn-leading-trailing"},
+		{"simple", "kdn-simple"},
+		{"UPPER_CASE", "kdn-upper-case"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := providerName(tt.input)
+			if got != tt.want {
+				t.Errorf("providerName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProviderType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"github", "github"},
+		{"anthropic", "anthropic"},
+		{"gemini", "generic"},
+		{"other", "generic"},
+		{"unknown", "generic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := providerType(tt.input)
+			if got != tt.want {
+				t.Errorf("providerType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureProviders_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	names, err := rt.ensureProviders(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ensureProviders(nil) failed: %v", err)
+	}
+	if len(names) > 0 {
+		t.Errorf("Expected no provider names, got %v", names)
+	}
+	if len(fakeExec.RunCalls) > 0 || len(fakeExec.OutputCalls) > 0 {
+		t.Error("Expected no executor calls for nil config")
+	}
+}
+
+func TestEnsureProviders_EmptySecrets(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	cfg := &workspace.WorkspaceConfiguration{}
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders(empty) failed: %v", err)
+	}
+	if len(names) > 0 {
+		t.Errorf("Expected no provider names, got %v", names)
+	}
+	if len(fakeExec.RunCalls) > 0 || len(fakeExec.OutputCalls) > 0 {
+		t.Error("Expected no executor calls for empty secrets")
+	}
+}
+
+func TestEnsureProviders_NilStoreOrRegistry(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	secrets := []string{"my-secret"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+	if len(names) > 0 {
+		t.Errorf("Expected no provider names, got %v", names)
+	}
+	if len(fakeExec.RunCalls) > 0 || len(fakeExec.OutputCalls) > 0 {
+		t.Error("Expected no executor calls when store/registry are nil")
+	}
+}
+
+func TestEnsureProviders_CreatesGitHubProvider(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "my-github", Type: "github"},
+		},
+		values: map[string]string{"my-github": "ghp_abc123"},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"github": &fakeSecretService{
+				hosts:   []string{"api.github.com"},
+				envVars: []string{"GH_TOKEN", "GITHUB_TOKEN"},
+			},
+		},
+	}
+
+	secrets := []string{"my-github"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+
+	if len(names) != 1 || names[0] != "kdn-my-github" {
+		t.Errorf("Expected [kdn-my-github], got %v", names)
+	}
+
+	if len(fakeExec.OutputCalls) != 1 {
+		t.Fatalf("Expected 1 Output call, got %d", len(fakeExec.OutputCalls))
+	}
+	if !slices.Contains(fakeExec.OutputCalls[0], "provider") || !slices.Contains(fakeExec.OutputCalls[0], "--names") {
+		t.Errorf("Expected provider list --names call, got: %v", fakeExec.OutputCalls[0])
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+
+	createCall := fakeExec.RunCalls[0]
+	assertContainsAll(t, createCall, "provider", "create", "--name", "kdn-my-github", "--type", "github")
+	assertContainsAll(t, createCall, "--credential", "GH_TOKEN=ghp_abc123")
+	assertContainsAll(t, createCall, "GITHUB_TOKEN=ghp_abc123")
+}
+
+func TestEnsureProviders_SkipsExistingProvider(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-my-github\nother-provider\n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "my-github", Type: "github"},
+		},
+		values: map[string]string{"my-github": "ghp_abc123"},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"github": &fakeSecretService{
+				hosts:   []string{"api.github.com"},
+				envVars: []string{"GH_TOKEN", "GITHUB_TOKEN"},
+			},
+		},
+	}
+
+	secrets := []string{"my-github"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+
+	if len(names) != 1 || names[0] != "kdn-my-github" {
+		t.Errorf("Expected [kdn-my-github] for existing provider, got %v", names)
+	}
+
+	if len(fakeExec.RunCalls) > 0 {
+		t.Errorf("Expected no Run calls when provider already exists, got: %v", fakeExec.RunCalls)
+	}
+}
+
+func TestEnsureProviders_GenericFallback(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "custom-api", Type: secret.TypeOther, Envs: []string{"MY_TOKEN"}},
+		},
+		values: map[string]string{"custom-api": "tok_xyz"},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{}
+
+	secrets := []string{"custom-api"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+
+	if len(names) != 1 || names[0] != "kdn-custom-api" {
+		t.Errorf("Expected [kdn-custom-api], got %v", names)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	}
+
+	createCall := fakeExec.RunCalls[0]
+	assertContainsAll(t, createCall, "--type", "generic")
+	assertContainsAll(t, createCall, "--credential", "MY_TOKEN=tok_xyz")
+}
+
+func TestEnsureProviders_MultipleSecrets(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "gh-token", Type: "github"},
+			{Name: "claude-key", Type: "anthropic"},
+		},
+		values: map[string]string{
+			"gh-token":   "ghp_123",
+			"claude-key": "sk-ant-456",
+		},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"github":    &fakeSecretService{hosts: []string{"api.github.com"}, envVars: []string{"GITHUB_TOKEN"}},
+			"anthropic": &fakeSecretService{hosts: []string{"api.anthropic.com"}, envVars: []string{"ANTHROPIC_API_KEY"}},
+		},
+	}
+
+	secrets := []string{"gh-token", "claude-key"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+
+	if len(names) != 2 {
+		t.Errorf("Expected 2 provider names, got %v", names)
+	}
+
+	if len(fakeExec.RunCalls) != 2 {
+		t.Fatalf("Expected 2 Run calls (one per secret), got %d", len(fakeExec.RunCalls))
+	}
+}
+
+func TestEnsureProviders_SecretNotInStore(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{}
+
+	secrets := []string{"nonexistent"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+
+	if len(names) > 0 {
+		t.Errorf("Expected no provider names, got %v", names)
+	}
+
+	if len(fakeExec.RunCalls) > 0 {
+		t.Errorf("Expected no Run calls for missing secret, got: %v", fakeExec.RunCalls)
+	}
+}
+
+func TestEnsureProviders_ProviderCreateError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.RunFunc = func(_ context.Context, args ...string) error {
+		return fmt.Errorf("provider create failed")
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "my-github", Type: "github"},
+		},
+		values: map[string]string{"my-github": "ghp_abc123"},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"github": &fakeSecretService{hosts: []string{"api.github.com"}, envVars: []string{"GITHUB_TOKEN"}},
+		},
+	}
+
+	secrets := []string{"my-github"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	_, err := rt.ensureProviders(context.Background(), cfg)
+	if err == nil {
+		t.Error("Expected error when provider create fails")
+	}
+}
+
+func TestEnsureProviders_ListProviderError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("list failed")
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "my-github", Type: "github"},
+		},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{}
+
+	secrets := []string{"my-github"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	_, err := rt.ensureProviders(context.Background(), cfg)
+	if err == nil {
+		t.Error("Expected error when provider list fails")
+	}
+}
+
+func TestEnsureProviders_StoreListError(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{err: fmt.Errorf("store unavailable")}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{}
+
+	secrets := []string{"my-github"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	_, err := rt.ensureProviders(context.Background(), cfg)
+	if err == nil {
+		t.Error("Expected error when store.List() fails")
+	}
+}
+
+func TestEnsureProviders_NoEnvVars(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.secretStore = &fakeSecretStore{
+		items: []secret.ListItem{
+			{Name: "empty-svc", Type: "empty"},
+		},
+		values: map[string]string{"empty-svc": "val"},
+	}
+	rt.secretServiceRegistry = &fakeSecretServiceRegistry{
+		services: map[string]secretservice.SecretService{
+			"empty": &fakeSecretService{hosts: []string{"example.com"}, envVars: []string{}},
+		},
+	}
+
+	secrets := []string{"empty-svc"}
+	cfg := &workspace.WorkspaceConfiguration{Secrets: &secrets}
+
+	names, err := rt.ensureProviders(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ensureProviders() failed: %v", err)
+	}
+
+	if len(names) > 0 {
+		t.Errorf("Expected no provider names, got %v", names)
+	}
+
+	if len(fakeExec.RunCalls) > 0 {
+		t.Errorf("Expected no Run calls when service has no env vars, got: %v", fakeExec.RunCalls)
+	}
+}
+
+func TestListExistingProviders(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	fakeExec.OutputFunc = func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("kdn-github-token\nkdn-anthropic-key\n\n  other-provider  \n"), nil
+	}
+
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	got, err := rt.listExistingProviders(context.Background())
+	if err != nil {
+		t.Fatalf("listExistingProviders() failed: %v", err)
+	}
+
+	want := map[string]bool{
+		"kdn-github-token":  true,
+		"kdn-anthropic-key": true,
+		"other-provider":    true,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("listExistingProviders() returned %d providers, want %d: %v", len(got), len(want), got)
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("Missing provider %q in result", name)
+		}
+	}
+}
+
+// assertContainsAll checks that the slice contains all specified values.
+func assertContainsAll(t *testing.T, got []string, values ...string) {
+	t.Helper()
+
+	for _, v := range values {
+		if !slices.Contains(got, v) {
+			t.Errorf("Expected %q in %v", v, got)
+		}
+	}
+}


### PR DESCRIPTION
When a workspace has secrets configured, the OpenShell runtime now automatically creates corresponding OpenShell providers before sandbox creation. Provider names are passed via --provider flags to `sandbox create`, making credentials available inside the sandbox.

The mapping from kdn secret types to OpenShell provider types is: github→github, anthropic→anthropic, other/unknown→generic.

fixes https://github.com/openkaiden/kdn/issues/462