### PR TITLE
fix(agent): skip provider configuration for native OpenCode providers

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -115,6 +115,21 @@ func (o *openCodeAgent) SetMCPServers(settings map[string]SettingsFile, _ *works
 	return settings, nil
 }
 
+// nativeProviders lists providers that OpenCode supports natively via bundled SDKs.
+// These do not need the "npm": "@ai-sdk/openai-compatible" field.
+var nativeProviders = map[string]bool{
+	"anthropic":      true,
+	"openai":         true,
+	"google-vertex":  true,
+	"amazon-bedrock": true,
+	"azure":          true,
+	"cerebras":       true,
+	"groq":           true,
+	"huggingface":    true,
+	"mistral":        true,
+	"together":       true,
+}
+
 // configureProvider adds a provider block with the given base URL and registers the model.
 func configureProvider(config map[string]interface{}, provider, modelName, baseURL string) error {
 	providers, _ := config["provider"].(map[string]interface{})
@@ -127,7 +142,9 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 	if providerEntry == nil {
 		providerEntry = map[string]interface{}{
 			"name": provider,
-			"npm":  "@ai-sdk/openai-compatible",
+		}
+		if !nativeProviders[provider] {
+			providerEntry["npm"] = "@ai-sdk/openai-compatible"
 		}
 	}
 	if baseURL != "" {

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -57,8 +57,8 @@ func (o *openCodeAgent) SkipOnboarding(settings map[string]SettingsFile, _ strin
 // SetModel configures the model ID in OpenCode settings.
 // The modelID supports three formats:
 //   - "model" — sets the model directly
-//   - "provider::model" — sets provider/model; uses default base URL for known providers (ollama, ramalama),
-//     omits baseURL for others so the provider resolves its own endpoint
+//   - "provider::model" — sets provider/model; for native providers only sets the model field;
+//     for non-native providers adds a provider block (with default baseURL for ollama/ramalama)
 //   - "provider::model::baseURL" — sets provider/model and configures the provider with the given base URL
 //
 // All other fields in .config/opencode/opencode.json are preserved.
@@ -88,8 +88,10 @@ func (o *openCodeAgent) SetModel(settings map[string]SettingsFile, modelID strin
 			resolvedURL = containerurl.RewriteURL(resolvedURL)
 		}
 		config["model"] = provider + "/" + modelName
-		if err := configureProvider(config, provider, modelName, resolvedURL); err != nil {
-			return nil, err
+		if !nativeProviders[provider] || resolvedURL != "" {
+			if err := configureProvider(config, provider, modelName, resolvedURL); err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		config["model"] = modelID
@@ -118,16 +120,10 @@ func (o *openCodeAgent) SetMCPServers(settings map[string]SettingsFile, _ *works
 // nativeProviders lists providers that OpenCode supports natively via bundled SDKs.
 // These do not need the "npm": "@ai-sdk/openai-compatible" field.
 var nativeProviders = map[string]bool{
-	"anthropic":      true,
-	"openai":         true,
-	"google-vertex":  true,
-	"amazon-bedrock": true,
-	"azure":          true,
-	"cerebras":       true,
-	"groq":           true,
-	"huggingface":    true,
-	"mistral":        true,
-	"together":       true,
+	"anthropic": true,
+	"openai":    true,
+	"mistral":   true,
+	"google":    true,
 }
 
 // configureProvider adds a provider block with the given base URL and registers the model.

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -364,6 +364,35 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
+	t.Run("anthropic native provider does not set npm field", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string]SettingsFile)
+
+		result, err := agent.SetModel(settings, "anthropic::claude-opus-4-7")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath].Content, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		anthropic := providers["anthropic"].(map[string]interface{})
+
+		if _, hasNPM := anthropic["npm"]; hasNPM {
+			t.Error("Native anthropic provider should not have npm field")
+		}
+
+		models := anthropic["models"].(map[string]interface{})
+		if _, exists := models["claude-opus-4-7"]; !exists {
+			t.Error("Expected model entry for claude-opus-4-7")
+		}
+	})
+
 	t.Run("provider with empty model name returns error", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -364,7 +364,7 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
-	t.Run("anthropic native provider does not set npm field", func(t *testing.T) {
+	t.Run("anthropic native provider only sets model field", func(t *testing.T) {
 		t.Parallel()
 
 		agent := NewOpenCode()
@@ -380,16 +380,12 @@ func TestOpenCode_SetModel(t *testing.T) {
 			t.Fatalf("Failed to parse result JSON: %v", err)
 		}
 
-		providers := config["provider"].(map[string]interface{})
-		anthropic := providers["anthropic"].(map[string]interface{})
-
-		if _, hasNPM := anthropic["npm"]; hasNPM {
-			t.Error("Native anthropic provider should not have npm field")
+		if config["model"] != "anthropic/claude-opus-4-7" {
+			t.Errorf("model = %v, want %q", config["model"], "anthropic/claude-opus-4-7")
 		}
 
-		models := anthropic["models"].(map[string]interface{})
-		if _, exists := models["claude-opus-4-7"]; !exists {
-			t.Error("Expected model entry for claude-opus-4-7")
+		if _, hasProvider := config["provider"]; hasProvider {
+			t.Error("Native provider without custom baseURL should not create provider block")
 		}
 	})
 


### PR DESCRIPTION
OpenCode bundles its own SDK for providers like anthropic, openai, groq, mistral, etc. Setting "npm": "@ai-sdk/openai-compatible" for these providers caused failures (e.g. missing endpoint for Anthropic).

The npm field is now only added for unknown/custom providers that require an OpenAI-compatible bridge.

Also, the provider entry is not necessary for such providers, only "model": "providerId/model" is necessary.

Fixes #413

To test it:

1.
```
$ kdn init --agent opencode --model anthropic::claude-sonnet-4-5 // should work
$ kdn init --agent opencode --model google::gemini-flash-lite-latest // should work
```

and (this is part of #471) 
```
$ kdn init --agent opencode --model gemini::gemini-flash-lite-latest // will not work yet (related to another issue)
```

2. Test that there is no regression on ollama/ramalama/...
