### PR TITLE
feat(runtime): auto-allow custom model endpoint host in deny-mode

### DIFF
--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -387,6 +387,7 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		SecretEnvVars:      secretEnvVars,
 		ProjectID:          project,
 		RuntimeOptions:     opts.RuntimeOptions,
+		Model:              opts.Model,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runtime instance: %w", err)

--- a/pkg/runtime/podman/create.go
+++ b/pkg/runtime/podman/create.go
@@ -58,6 +58,9 @@ type podTemplateData struct {
 	Agent              string
 	ApprovalHandlerDir string
 	Forwards           []api.WorkspaceForward
+	// Model is the model ID as provided by the user (e.g. "openai::gpt-4o::https://my.endpoint/v1").
+	// Persisted so Start() can extract the baseURL hostname for network allow-listing.
+	Model string
 }
 
 // validateCreateParams validates the create parameters.
@@ -514,6 +517,7 @@ func (p *podmanRuntime) Create(ctx context.Context, params runtime.CreateParams)
 		Agent:              params.Agent,
 		ApprovalHandlerDir: podmanSystem.HostPathToMachinePath(approvalHandlerDir),
 		Forwards:           forwards,
+		Model:              params.Model,
 	}
 
 	tmpPodDir := filepath.Join(instanceDir, "pod")

--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,6 +147,32 @@ func mergeHosts(a, b []string) []string {
 		}
 	}
 	return result
+}
+
+// collectModelHosts extracts the hostname from the baseURL embedded in a
+// "provider::model::baseURL" model ID and returns it as a single-element slice.
+// Returns nil when modelID is empty, has no baseURL component, the baseURL is
+// unparseable, or the host resolves to loopback (localhost / 127.x / ::1).
+func collectModelHosts(modelID string) []string {
+	if modelID == "" {
+		return nil
+	}
+	_, _, baseURL := config.ParseModelID(modelID)
+	if baseURL == "" {
+		return nil
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return nil
+	}
+	hostname := u.Hostname()
+	if hostname == "localhost" {
+		return nil
+	}
+	if ip := net.ParseIP(hostname); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return []string{hostname}
 }
 
 // approvalHandlerConfig is serialized to config.json in the approval-handler

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -1022,3 +1022,60 @@ func TestMergeHosts(t *testing.T) {
 		}
 	})
 }
+
+func TestCollectModelHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty model ID returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := collectModelHosts(""); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("plain model ID with no baseURL returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := collectModelHosts("claude-sonnet-4-20250514"); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("provider::model with no baseURL returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := collectModelHosts("openai::gpt-4o"); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("localhost baseURL returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := collectModelHosts("openai::gpt-4o::http://localhost:11434/v1"); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("loopback IP baseURL returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := collectModelHosts("openai::gpt-4o::http://127.0.0.1:8080/v1"); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("external https baseURL returns hostname", func(t *testing.T) {
+		t.Parallel()
+		got := collectModelHosts("openai::gpt-4o::https://my.endpoint.example.com/v1")
+		want := []string{"my.endpoint.example.com"}
+		if len(got) != 1 || got[0] != want[0] {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("external baseURL with port returns hostname without port", func(t *testing.T) {
+		t.Parallel()
+		got := collectModelHosts("openai::gpt-4o::https://api.example.com:8443/v1")
+		want := []string{"api.example.com"}
+		if len(got) != 1 || got[0] != want[0] {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -112,7 +112,11 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	// Automatically add host patterns from credentials that were configured at Create time.
 	// The credential directory acts as a signal that the credential was successfully set up.
 	credentialHosts := p.collectCredentialHosts(tmplData.Name, wsCfg)
-	allHosts := mergeHosts(explicitHosts, mergeHosts(secretHosts, credentialHosts))
+
+	// Automatically add the baseURL hostname from a custom model endpoint so
+	// the agent can reach the LLM API without manual network.hosts entries.
+	modelHosts := collectModelHosts(tmplData.Model)
+	allHosts := mergeHosts(explicitHosts, mergeHosts(secretHosts, mergeHosts(credentialHosts, modelHosts)))
 	fmt.Fprintf(l.Stderr(), "[network] allowed hosts for approval-handler: %v\n", allHosts)
 
 	// Networking rules are configured whenever mode is explicitly deny, regardless

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -114,6 +114,10 @@ type CreateParams struct {
 	// the CLI. Keys are flag names (matching FlagDef.Name), values are the
 	// user-provided strings. This map is nil when no runtime flags were set.
 	RuntimeOptions map[string]string
+
+	// Model is the model ID configured for the agent, in the form
+	// "provider::model::baseURL". Empty when no model was specified.
+	Model string
 }
 
 // RuntimeInfo contains information about a runtime instance.


### PR DESCRIPTION
When --model provider::model::baseURL is used and the baseURL is not
localhost/loopback, the hostname is automatically added to the network
allow-list at Start() time — same pattern as secrets and credentials.

- Add Model to runtime.CreateParams and podTemplateData (persisted)
- collectModelHosts() parses baseURL, skips loopback/localhost
- Start() merges model hosts into allHosts before networking config

Closes #465

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
