### PR TITLE
fix(agent): map gemini provider to google for OpenCode

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -81,6 +81,9 @@ func (o *openCodeAgent) SetModel(settings map[string]SettingsFile, modelID strin
 		if modelName == "" {
 			return nil, fmt.Errorf("invalid model ID %q: expected provider::model or provider::model::baseURL", modelID)
 		}
+		if alias, ok := providerAliases[provider]; ok {
+			provider = alias
+		}
 		resolvedURL := baseURL
 		if resolvedURL == "" {
 			resolvedURL = defaultProviderBaseURLs[provider]
@@ -159,4 +162,11 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 var defaultProviderBaseURLs = map[string]string{
 	"ollama":   "http://" + containerurl.ContainerHost + ":11434/v1",
 	"ramalama": "http://" + containerurl.ContainerHost + ":8080/v1",
+}
+
+// providerAliases maps provider names used in kdn model IDs to the provider
+// names expected by OpenCode. For example, "gemini" maps to "google" because
+// OpenCode uses the "@ai-sdk/google" package under the "google" key.
+var providerAliases = map[string]string{
+	"gemini": "google",
 }

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -443,6 +443,42 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
+	t.Run("gemini provider is mapped to google", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string]SettingsFile)
+
+		result, err := agent.SetModel(settings, "gemini::gemini-2.0-flash")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath].Content, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "google/gemini-2.0-flash" {
+			t.Errorf("model = %v, want %q", config["model"], "google/gemini-2.0-flash")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		if _, ok := providers["gemini"]; ok {
+			t.Error("Provider key should be 'google', not 'gemini'")
+		}
+		google, ok := providers["google"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected 'google' provider entry")
+		}
+
+		models := google["models"].(map[string]interface{})
+		modelEntry := models["gemini-2.0-flash"].(map[string]interface{})
+		if name := modelEntry["name"].(string); name != "gemini-2.0-flash" {
+			t.Errorf("model name = %q, want %q", name, "gemini-2.0-flash")
+		}
+	})
+
 	t.Run("plain model ID without provider", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
OpenCode identifies Google's provider as "google", but kdn model IDs use "gemini" as the provider prefix. Add a providerAliases map to translate "gemini" → "google" before building the provider config, so "gemini::model" correctly produces model = "google/model".

Closes #470