### PR TITLE
feat(agent): map vertexai provider to google-vertex-anthropic for OpenCode

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -129,6 +129,12 @@ var nativeProviders = map[string]bool{
 	"google":    true,
 }
 
+// vertexAIProviders lists providers that use Vertex AI native SDK in OpenCode.
+// These always need a provider block with empty model entries but no npm or name fields.
+var vertexAIProviders = map[string]bool{
+	"google-vertex-anthropic": true,
+}
+
 // configureProvider adds a provider block with the given base URL and registers the model.
 func configureProvider(config map[string]interface{}, provider, modelName, baseURL string) error {
 	providers, _ := config["provider"].(map[string]interface{})
@@ -139,10 +145,9 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 
 	providerEntry, _ := providers[provider].(map[string]interface{})
 	if providerEntry == nil {
-		providerEntry = map[string]interface{}{
-			"name": provider,
-		}
-		if !nativeProviders[provider] {
+		providerEntry = make(map[string]interface{})
+		if !nativeProviders[provider] && !vertexAIProviders[provider] {
+			providerEntry["name"] = provider
 			providerEntry["npm"] = "@ai-sdk/openai-compatible"
 		}
 	}
@@ -161,9 +166,13 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 		models = make(map[string]interface{})
 	}
 	if _, exists := models[modelName]; !exists {
-		models[modelName] = map[string]interface{}{
-			"_launch": true,
-			"name":    modelName,
+		if vertexAIProviders[provider] {
+			models[modelName] = map[string]interface{}{}
+		} else {
+			models[modelName] = map[string]interface{}{
+				"_launch": true,
+				"name":    modelName,
+			}
 		}
 	}
 	providerEntry["models"] = models
@@ -181,5 +190,6 @@ var defaultProviderBaseURLs = map[string]string{
 // names expected by OpenCode. For example, "gemini" maps to "google" because
 // OpenCode uses the "@ai-sdk/google" package under the "google" key.
 var providerAliases = map[string]string{
-	"gemini": "google",
+	"gemini":   "google",
+	"vertexai": "google-vertex-anthropic",
 }

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -493,6 +493,49 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
+	t.Run("vertexai provider is mapped to google-vertex-anthropic", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string]SettingsFile)
+
+		result, err := agent.SetModel(settings, "vertexai::claude-sonnet-4-5")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath].Content, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "google-vertex-anthropic/claude-sonnet-4-5" {
+			t.Errorf("model = %v, want %q", config["model"], "google-vertex-anthropic/claude-sonnet-4-5")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		vertexProvider, ok := providers["google-vertex-anthropic"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected google-vertex-anthropic provider block")
+		}
+
+		if _, hasName := vertexProvider["name"]; hasName {
+			t.Error("google-vertex-anthropic provider should not have name field")
+		}
+		if _, hasNpm := vertexProvider["npm"]; hasNpm {
+			t.Error("google-vertex-anthropic provider should not have npm field")
+		}
+
+		models := vertexProvider["models"].(map[string]interface{})
+		modelEntry, ok := models["claude-sonnet-4-5"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected claude-sonnet-4-5 model entry")
+		}
+		if len(modelEntry) != 0 {
+			t.Errorf("google-vertex-anthropic model entry should be empty, got %v", modelEntry)
+		}
+	})
+
 	t.Run("plain model ID without provider", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
When a vertexai::model ID is passed, OpenCode requires the google-vertex-anthropic provider key with empty model entries ({}) and no npm or name fields — matching OpenCode's native Vertex AI Anthropic SDK format.

Fixes #473

```
$ kdn init --agent opencode --model vertexai::claude-sonnet-4-5
or
$ kdn init --agent opencode --model google-vertex-anthropic::claude-sonnet-4-5
```

writes in opencode.json:
```
{
  "$schema": "https://opencode.ai/config.json",
  "model": "google-vertex-anthropic/claude-sonnet-4-5",
  "provider": {
    "google-vertex-anthropic": {
      "models": {
        "claude-sonnet-4-5": {}
      }
    }
  }
}
```