### PR TITLE
fix(agent): treat openai as non-native provider for OpenCode

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -124,7 +124,6 @@ func (o *openCodeAgent) SetMCPServers(settings map[string]SettingsFile, _ *works
 // These do not need the "npm": "@ai-sdk/openai-compatible" field.
 var nativeProviders = map[string]bool{
 	"anthropic": true,
-	"openai":    true,
 	"mistral":   true,
 	"google":    true,
 }


### PR DESCRIPTION
Remove openai from the nativeProviders list so it gets configured
with the @ai-sdk/openai-compatible npm package and doesn't require an open api key

fixes https://github.com/openkaiden/kaiden/issues/1755
