### PR TITLE
fix(runtime): allow responses on port-forwarded connections on macOS/WSL2

### DIFF
--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -406,7 +406,10 @@ func buildNftScript(agentUID int, hostGW string) string {
 	// Ensure nftables is installed before applying rules.
 	parts = append(parts, "command -v nft >/dev/null 2>&1 || dnf install -y nftables >/dev/null 2>&1")
 
-	// IPv4 rules — default accept, block agent UID (except loopback + host gateway)
+	// IPv4 rules — default accept, block agent UID (except loopback + host gateway).
+	// The established/related rule allows response packets for inbound connections
+	// (e.g. port-forwarded requests via gvproxy on macOS) while still blocking the
+	// agent from initiating new outbound connections.
 	parts = append(parts,
 		"nft delete table ip filter 2>/dev/null || true",
 		"nft add table ip filter",
@@ -416,7 +419,10 @@ func buildNftScript(agentUID int, hostGW string) string {
 	if hostGW != "" {
 		parts = append(parts, fmt.Sprintf("nft add rule ip filter output ip daddr %s accept", hostGW))
 	}
-	parts = append(parts, fmt.Sprintf("nft add rule ip filter output meta skuid %d drop", agentUID))
+	parts = append(parts,
+		"nft add rule ip filter output ct state established,related accept",
+		fmt.Sprintf("nft add rule ip filter output meta skuid %d drop", agentUID),
+	)
 
 	// IPv6 rules — mirror
 	parts = append(parts,
@@ -424,6 +430,7 @@ func buildNftScript(agentUID int, hostGW string) string {
 		"nft add table ip6 filter",
 		"nft add chain ip6 filter output '{ type filter hook output priority 0; policy accept; }'",
 		"nft add rule ip6 filter output oif lo accept",
+		"nft add rule ip6 filter output ct state established,related accept",
 		fmt.Sprintf("nft add rule ip6 filter output meta skuid %d drop", agentUID),
 	)
 

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -357,6 +357,9 @@ func TestBuildNftScript(t *testing.T) {
 		if !strings.Contains(script, "oif lo accept") {
 			t.Error("expected loopback rule")
 		}
+		if !strings.Contains(script, "ct state established,related accept") {
+			t.Error("expected conntrack established/related rule")
+		}
 		if strings.Contains(script, "ip daddr") {
 			t.Error("expected no host-gateway rule when hostGW is empty")
 		}
@@ -381,6 +384,18 @@ func TestBuildNftScript(t *testing.T) {
 		dropIdx := strings.Index(script, "meta skuid 1000 drop")
 		if hostGWIdx >= dropIdx {
 			t.Error("host-gateway accept should come before agent drop rule")
+		}
+	})
+
+	t.Run("conntrack rule comes before agent drop rule", func(t *testing.T) {
+		t.Parallel()
+
+		script := buildNftScript(1000, "")
+
+		ctIdx := strings.Index(script, "ct state established,related accept")
+		dropIdx := strings.Index(script, "meta skuid 1000 drop")
+		if ctIdx >= dropIdx {
+			t.Error("conntrack established/related rule should come before agent drop rule")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- The nftables firewall in the network-guard sidecar was dropping HTTP response packets for inbound port-forwarded connections on macOS and WSL2
- On macOS (gvproxy) and WSL2, port-forwarded traffic enters the pod through a non-loopback interface, so the agent UID drop rule killed responses before they reached the host
- Adds a `ct state established,related accept` conntrack rule before the UID drop rule, allowing response packets for externally-initiated connections while still blocking the agent from initiating new outbound connections
- No-op on Linux where port forwarding already uses loopback

Fixes: https://github.com/openkaiden/kdn/issues/477

## Test plan
- [x] Unit tests for `buildNftScript` updated and passing
- [ ] Verify port forwarding works on macOS after recreating workspace
- [ ] Verify port forwarding still works on Linux (no regression)
- [ ] Verify agent cannot bypass proxy by initiating direct outbound connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)