### PR TITLE
fix: revert "fix(podman): resolve host.containers.internal on WSL2 (#390)"

### DIFF
--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -306,91 +306,14 @@ func (p *podmanRuntime) clearFirewallRules(ctx context.Context, podName string) 
 
 // resolveHostGateway attempts to resolve host.containers.internal inside the
 // given container. Returns the IP string on success or empty string on failure.
-// On WSL2, host.containers.internal may not resolve because WSL2 does not
-// update /etc/hosts like podman machine does on macOS/Hyper-V. In that case,
-// the default gateway IP is used as a fallback.
 func (p *podmanRuntime) resolveHostGateway(ctx context.Context, container string) string {
 	out, err := p.executor.Output(ctx, io.Discard,
 		"exec", container, "sh", "-c", "getent hosts host.containers.internal | awk '{print $1}'",
 	)
-	if err == nil {
-		if ip := parseIPv4(strings.TrimSpace(string(out))); ip != "" && ip != "127.0.0.1" {
-			return ip
-		}
-	}
-
-	if p.isPodmanWSL(ctx) {
-		return p.resolveWSLHostIP(ctx)
-	}
-	return ""
-}
-
-// parseIPv4 validates and normalizes a string as an IPv4 address.
-// Returns the canonical form or empty string if invalid, multiline, or IPv6.
-func parseIPv4(s string) string {
-	if strings.ContainsAny(s, "\n\r") {
-		return ""
-	}
-	ip := net.ParseIP(s)
-	if ip == nil {
-		return ""
-	}
-	if ip.To4() == nil {
-		return ""
-	}
-	return ip.String()
-}
-
-// isPodmanWSL reports whether the podman machine uses the WSL2 provider.
-func (p *podmanRuntime) isPodmanWSL(ctx context.Context) bool {
-	out, err := p.executor.Output(ctx, io.Discard,
-		"machine", "info", "--format", "{{.Host.VMType}}",
-	)
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(out)) == "wsl"
-}
-
-// resolveWSLHostIP returns the default gateway IP from inside the podman
-// machine via SSH. On WSL2 this is the Windows host IP.
-func (p *podmanRuntime) resolveWSLHostIP(ctx context.Context) string {
-	out, err := p.executor.Output(ctx, io.Discard,
-		"machine", "ssh", "ip", "route", "show", "default",
-	)
 	if err != nil {
 		return ""
 	}
-	fields := strings.Fields(strings.TrimSpace(string(out)))
-	if len(fields) >= 3 {
-		return parseIPv4(fields[2])
-	}
-	return ""
-}
-
-// injectWSLHostEntry adds or updates a host.containers.internal entry in
-// /etc/hosts inside the workspace container, mapping it to the Windows
-// host IP read from the podman machine's /etc/resolv.conf via SSH.
-// Filters out any existing entry before appending so repeated Start()
-// calls don't accumulate stale lines.
-func (p *podmanRuntime) injectWSLHostEntry(ctx context.Context, containerID string) error {
-	hostIP := p.resolveWSLHostIP(ctx)
-	if hostIP == "" {
-		return fmt.Errorf("failed to resolve Windows host IP from podman machine")
-	}
-
-	// /etc/hosts is a mount in containers — sed -i fails because it tries to
-	// rename a temp file over the mount. Use grep + tee to modify in-place.
-	cmd := fmt.Sprintf(
-		"grep -v 'host\\.containers\\.internal' /etc/hosts > /tmp/hosts.tmp && cp /tmp/hosts.tmp /etc/hosts && rm /tmp/hosts.tmp && echo '%s host.containers.internal' >> /etc/hosts",
-		hostIP,
-	)
-	if err := p.executor.Run(ctx, io.Discard, io.Discard,
-		"exec", "--user", "root", containerID, "sh", "-c", cmd,
-	); err != nil {
-		return fmt.Errorf("failed to update /etc/hosts entry: %w", err)
-	}
-	return nil
+	return strings.TrimSpace(string(out))
 }
 
 // buildNftScript generates the shell script that sets up nftables OUTPUT rules.

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -417,7 +417,7 @@ func TestSetupFirewallRules(t *testing.T) {
 			return []byte{}, nil
 		}
 
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
+		rt := &podmanRuntime{executor: fakeExec}
 
 		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
 		if err != nil {
@@ -439,7 +439,7 @@ func TestSetupFirewallRules(t *testing.T) {
 		}
 	})
 
-	t.Run("skips host-gateway rule when resolution fails on non-WSL", func(t *testing.T) {
+	t.Run("skips host-gateway rule when resolution fails", func(t *testing.T) {
 		t.Parallel()
 
 		fakeExec := exec.NewFake()
@@ -447,7 +447,7 @@ func TestSetupFirewallRules(t *testing.T) {
 			return nil, fmt.Errorf("getent failed")
 		}
 
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
+		rt := &podmanRuntime{executor: fakeExec}
 
 		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
 		if err != nil {
@@ -457,85 +457,9 @@ func TestSetupFirewallRules(t *testing.T) {
 		for _, call := range fakeExec.RunCalls {
 			if len(call) >= 5 && call[0] == "exec" && call[2] == "sh" {
 				if strings.Contains(call[4], "ip daddr") {
-					t.Error("expected no host-gateway rule when resolution fails on non-WSL")
+					t.Error("expected no host-gateway rule when resolution fails")
 				}
 			}
-		}
-	})
-
-	t.Run("uses podman machine default gateway fallback on WSL2 when getent fails", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 5 && strings.Contains(args[4], "getent hosts") {
-				return nil, fmt.Errorf("getent failed")
-			}
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "info" {
-				return []byte("wsl\n"), nil
-			}
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return []byte("default via 192.168.1.1 dev eth0\n"), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-
-		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
-		if err != nil {
-			t.Fatalf("setupFirewallRules() error: %v", err)
-		}
-
-		found := false
-		for _, call := range fakeExec.RunCalls {
-			if len(call) >= 5 && call[0] == "exec" && call[2] == "sh" && call[3] == "-c" {
-				if strings.Contains(call[4], "ip daddr 192.168.1.1 accept") {
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			t.Error("expected host-gateway rule with nameserver IP on WSL2")
-		}
-	})
-
-	t.Run("uses podman machine default gateway fallback on WSL2 when getent returns 127.0.0.1", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 5 && strings.Contains(args[4], "getent hosts") {
-				return []byte("127.0.0.1\n"), nil
-			}
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "info" {
-				return []byte("wsl\n"), nil
-			}
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return []byte("default via 172.20.0.1 dev eth0\n"), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-
-		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
-		if err != nil {
-			t.Fatalf("setupFirewallRules() error: %v", err)
-		}
-
-		found := false
-		for _, call := range fakeExec.RunCalls {
-			if len(call) >= 5 && call[0] == "exec" && call[2] == "sh" && call[3] == "-c" {
-				if strings.Contains(call[4], "ip daddr 172.20.0.1 accept") {
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			t.Error("expected host-gateway rule with nameserver IP when getent returns 127.0.0.1")
 		}
 	})
 
@@ -547,7 +471,7 @@ func TestSetupFirewallRules(t *testing.T) {
 			return fmt.Errorf("exec failed")
 		}
 
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
+		rt := &podmanRuntime{executor: fakeExec}
 
 		err := rt.setupFirewallRules(context.Background(), "my-pod", 1000)
 		if err == nil {
@@ -804,186 +728,6 @@ func TestCollectSecretHosts(t *testing.T) {
 		_, err := collectSecretHosts(context.Background(), denyConfig([]string{"mykey"}), store, makeRegistry(t))
 		if err == nil {
 			t.Error("expected error from store.List(), got nil")
-		}
-	})
-}
-
-func TestIsPodmanWSL(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns true when VMType is wsl", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "info" {
-				return []byte("wsl\n"), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-		if !rt.isPodmanWSL(context.Background()) {
-			t.Error("expected isPodmanWSL() to return true for wsl VMType")
-		}
-	})
-
-	t.Run("returns false when VMType is not wsl", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "info" {
-				return []byte("qemu\n"), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-		if rt.isPodmanWSL(context.Background()) {
-			t.Error("expected isPodmanWSL() to return false for qemu VMType")
-		}
-	})
-
-	t.Run("returns false when machine info fails", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			return nil, fmt.Errorf("no machine")
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-		if rt.isPodmanWSL(context.Background()) {
-			t.Error("expected isPodmanWSL() to return false on error")
-		}
-	})
-}
-
-func TestInjectWSLHostEntry(t *testing.T) {
-	t.Parallel()
-
-	t.Run("adds /etc/hosts entry with nameserver IP from podman machine", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return []byte("default via 10.255.0.1 dev eth0\n"), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-
-		err := rt.injectWSLHostEntry(context.Background(), "test-container")
-		if err != nil {
-			t.Fatalf("injectWSLHostEntry() error: %v", err)
-		}
-
-		found := false
-		for _, call := range fakeExec.RunCalls {
-			if len(call) >= 7 && call[0] == "exec" && call[1] == "--user" && call[2] == "root" && call[3] == "test-container" && call[4] == "sh" && call[5] == "-c" {
-				script := call[6]
-				if strings.Contains(script, "grep -v") && strings.Contains(script, "10.255.0.1 host.containers.internal") {
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			t.Error("expected exec call with sed + echo writing host.containers.internal to /etc/hosts")
-		}
-	})
-
-	t.Run("returns error when host IP cannot be resolved", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return nil, fmt.Errorf("ssh failed")
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-
-		err := rt.injectWSLHostEntry(context.Background(), "test-container")
-		if err == nil {
-			t.Fatal("expected error when host IP resolution fails, got nil")
-		}
-	})
-
-	t.Run("returns error when default gateway cannot be determined", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return []byte(""), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-
-		err := rt.injectWSLHostEntry(context.Background(), "test-container")
-		if err == nil {
-			t.Fatal("expected error when default gateway cannot be determined, got nil")
-		}
-	})
-}
-
-func TestResolveWSLHostIP(t *testing.T) {
-	t.Parallel()
-
-	t.Run("extracts default gateway via podman machine ssh", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return []byte("default via 172.30.0.1 dev eth0\n"), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-		ip := rt.resolveWSLHostIP(context.Background())
-		if ip != "172.30.0.1" {
-			t.Errorf("got %q, want %q", ip, "172.30.0.1")
-		}
-	})
-
-	t.Run("returns empty when ssh fails", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			return nil, fmt.Errorf("ssh failed")
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-		if ip := rt.resolveWSLHostIP(context.Background()); ip != "" {
-			t.Errorf("got %q, want empty", ip)
-		}
-	})
-
-	t.Run("returns empty when no default route", func(t *testing.T) {
-		t.Parallel()
-
-		fakeExec := exec.NewFake()
-		fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-			if len(args) >= 4 && args[0] == "machine" && args[1] == "ssh" {
-				return []byte(""), nil
-			}
-			return []byte{}, nil
-		}
-
-		rt := &podmanRuntime{executor: fakeExec, system: &fakeSystem{}}
-		if ip := rt.resolveWSLHostIP(context.Background()); ip != "" {
-			t.Errorf("got %q, want empty", ip)
 		}
 	})
 }

--- a/pkg/runtime/podman/start.go
+++ b/pkg/runtime/podman/start.go
@@ -137,16 +137,6 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start network-guard container: %w", err)
 	}
 
-	// On WSL2, host.containers.internal does not resolve because the WSL2
-	// provider does not update /etc/hosts like macOS/Hyper-V VMs do. Patch
-	// the network-guard container so resolveHostGateway's getent succeeds.
-	isWSL := p.isPodmanWSL(ctx)
-	if isWSL {
-		if err := p.injectWSLHostEntry(ctx, networkGuardContainer); err != nil {
-			return runtime.RuntimeInfo{}, fmt.Errorf("failed to inject WSL host entry into network-guard: %w", err)
-		}
-	}
-
 	// Always connect to OneCLI so networking state is kept consistent across
 	// mode switches without recreating the workspace.
 	onecliBaseURL := p.onecliURL(tmplData.OnecliWebPort)
@@ -199,13 +189,6 @@ func (p *podmanRuntime) Start(ctx context.Context, id string) (runtime.RuntimeIn
 	if err := p.executor.Run(ctx, l.Stdout(), l.Stderr(), "pod", "start", podName); err != nil {
 		stepLogger.Fail(err)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to start pod: %w", err)
-	}
-
-	// Patch the workspace container's /etc/hosts on WSL2 as well.
-	if isWSL {
-		if err := p.injectWSLHostEntry(ctx, id); err != nil {
-			return runtime.RuntimeInfo{}, fmt.Errorf("failed to inject WSL host entry: %w", err)
-		}
 	}
 
 	// Install OneCLI CA certificate into system trust store if present


### PR DESCRIPTION
## Summary
- Reverts #390 which introduced WSL2-specific workarounds for `host.containers.internal` resolution
- Removes `isPodmanWSL`, `resolveWSLHostIP`, `injectWSLHostEntry`, and the WSL2 fallback in `resolveHostGateway`
- Removes associated tests

Fixes: https://github.com/openkaiden/kdn/issues/467

Reverts openkaiden/kdn#390