### PR TITLE
fix(openshell): remove supervisor image override

### DIFF
--- a/pkg/runtime/openshell/gateway.go
+++ b/pkg/runtime/openshell/gateway.go
@@ -37,7 +37,6 @@ const (
 	gatewayReadinessInterval = 3 * time.Second
 	gatewayPort              = "8080"
 	gatewayURL               = "http://127.0.0.1:" + gatewayPort
-	supervisorImage          = "quay.io/fbenoit/openshell-supervisor:2026-04-29"
 )
 
 // isGatewayReady checks whether the OpenShell gateway is reachable by
@@ -264,7 +263,6 @@ func (r *openshellRuntime) buildPodmanGatewayCommand(sshSecret string) *exec.Cmd
 		"--disable-tls",
 	)
 	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage),
 		fmt.Sprintf("OPENSHELL_SSH_HANDSHAKE_SECRET=%s", sshSecret),
 	)
 	return cmd

--- a/pkg/runtime/openshell/gateway_test.go
+++ b/pkg/runtime/openshell/gateway_test.go
@@ -114,17 +114,6 @@ func TestBuildGatewayCommand_Podman(t *testing.T) {
 		t.Errorf("Expected --db-url sqlite:<path>/openshell-podman.db in args: %v", args)
 	}
 
-	// Should have env vars set
-	hasEnv := false
-	for _, env := range cmd.Env {
-		if fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage) == env {
-			hasEnv = true
-			break
-		}
-	}
-	if !hasEnv {
-		t.Error("Expected OPENSHELL_SUPERVISOR_IMAGE env var for podman driver")
-	}
 }
 
 func TestBuildGatewayCommand_VM(t *testing.T) {
@@ -190,14 +179,6 @@ func TestBuildGatewayCommand_VM(t *testing.T) {
 	}
 	if !foundSecret {
 		t.Errorf("Expected --ssh-handshake-secret abc123 in args: %v", args)
-	}
-
-	// Should NOT have OPENSHELL_SUPERVISOR_IMAGE env var
-	for _, env := range cmd.Env {
-		if fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage) == env {
-			t.Error("VM driver should not set OPENSHELL_SUPERVISOR_IMAGE env var")
-			break
-		}
 	}
 
 	// Should have OPENSHELL_VM_DRIVER_STATE_DIR env var pointing to storage


### PR DESCRIPTION
Let the gateway use its own built-in default for the supervisor image instead of kdn hardcoding it via OPENSHELL_SUPERVISOR_IMAGE.


fixes #495 