### PR TITLE
chore(build): add git hooks for format checking and sign-off

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -124,15 +124,17 @@ Using the pre-fetched context above:
 
 2. **Summarize**: Identify the nature of the change (new feature, enhancement, bug fix, refactoring, etc.) and the motivation behind it. This summary becomes the commit body.
 
-3. **Scoped changes check**: If you have been working on specific files during this session (active context), ask the user:
+3. **Format check**: Run `make check-fmt` to verify code formatting. If it fails, run `make fmt` to fix formatting automatically, then show the user which files were reformatted before proceeding.
+
+4. **Scoped changes check**: If you have been working on specific files during this session (active context), ask the user:
    - Do you want to commit **all changes** in the working tree?
    - Or only the **scoped changes** related to the current work?
 
    This prevents accidentally committing unrelated changes that happen to be in the working tree.
 
-4. **Suggest commit message**: Based on the project's commit style and the changes, suggest a commit message following the conventional commit format.
+5. **Suggest commit message**: Based on the project's commit style and the changes, suggest a commit message following the conventional commit format.
 
-5. **Co-Authored-By**: If the project's commit history shows usage of `Co-Authored-By`, include this trailer with the current agent information:
+6. **Co-Authored-By**: If the project's commit history shows usage of `Co-Authored-By`, include this trailer with the current agent information:
    - **If agent metadata is available**: Use the agent name and noreply email from the runtime metadata (e.g., available through agent context or environment variables)
    - **If agent metadata is unavailable**: Prompt the user to confirm or enter the co-author information
 
@@ -146,7 +148,7 @@ Using the pre-fetched context above:
    Co-Authored-By: Claude Code (Claude Sonnet 4.5) <noreply@anthropic.com>
    ```
 
-6. **Commit**: Once approved, stage and commit with sign-off.
+7. **Commit**: Once approved, stage and commit with sign-off.
 
    **IMPORTANT: Always use SEPARATE Bash tool calls for staging and committing (never chain with `&&`).** This ensures proper confirmation before the commit is created.
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -u
+
+if test "$#" != 1; then
+  echo "$0 requires an argument."
+  exit 1
+fi
+
+if test ! -f "$1"; then
+  echo "file does not exist: $1"
+  exit 1
+fi
+
+SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+grep -qs "^$SOB" "$1" || echo "$SOB" >>"$1"
+
+# Catches duplicate Signed-off-by lines.
+test "" = "$(grep '^Signed-off-by: ' "$1" |
+sort | uniq -c | sed -e '/^[[:space:]]*1[[:space:]]/d')" || {
+  echo >&2 Duplicate Signed-off-by lines.
+  exit 1
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+exec make check-fmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@ make check-fmt
 
 Code should be formatted before committing. Run `make fmt` to ensure consistent style across the codebase.
 
+### Git Hooks
+
+The project includes pre-commit and commit-msg hooks in `.githooks/` that enforce formatting checks (`make check-fmt`) and signed-off commits. Activate them once after cloning:
+
+```bash
+make setup-hooks
+```
+
 ### Integration Tests
 ```bash
 # Run integration tests (requires Podman)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: help build test test-integration test-coverage fmt vet clean install check-fmt check-vet ci-checks all
+.PHONY: help build test test-integration test-coverage fmt vet clean install check-fmt check-vet ci-checks setup-hooks all
 
 # Binary name
 BINARY_NAME=kdn
@@ -80,6 +80,9 @@ check-fmt: ## Check if code is formatted (for CI)
 check-vet: ## Run go vet and fail on issues (for CI)
 	@echo "Running go vet..."
 	@$(GO) vet ./... || (echo "go vet found issues. Please fix them."; exit 1)
+
+setup-hooks: ## Configure git to use project hooks
+	git config core.hooksPath .githooks
 
 ci-checks: check-fmt check-vet test ## Run all CI checks
 	@echo "All CI checks passed!"


### PR DESCRIPTION
Add pre-commit and commit-msg hooks under .githooks/ to enforce code formatting (`make check-fmt`) and signed-off commits. Add a `make setup-hooks` target to activate them. Update the commit skill to include a formatting verification step before staging changes.

fixes https://github.com/openkaiden/kdn/issues/497