### PR TITLE
fix(openshell): use official supervisor image from GHCR (#503)

### DIFF
--- a/pkg/runtime/openshell/gateway.go
+++ b/pkg/runtime/openshell/gateway.go
@@ -39,6 +39,8 @@ const (
 	gatewayURL               = "http://127.0.0.1:" + gatewayPort
 )
 
+var supervisorImage = "ghcr.io/nvidia/openshell/supervisor:" + strings.TrimPrefix(DefaultVersion, "v")
+
 // isGatewayReady checks whether the OpenShell gateway is reachable by
 // attempting to list sandboxes. This validates the full stack: gateway running
 // and responding to sandbox operations.
@@ -264,6 +266,7 @@ func (r *openshellRuntime) buildPodmanGatewayCommand(sshSecret string) *exec.Cmd
 	)
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("OPENSHELL_SSH_HANDSHAKE_SECRET=%s", sshSecret),
+		fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage),
 	)
 	return cmd
 }

--- a/pkg/runtime/openshell/gateway_test.go
+++ b/pkg/runtime/openshell/gateway_test.go
@@ -114,6 +114,17 @@ func TestBuildGatewayCommand_Podman(t *testing.T) {
 		t.Errorf("Expected --db-url sqlite:<path>/openshell-podman.db in args: %v", args)
 	}
 
+	expectedEnv := fmt.Sprintf("OPENSHELL_SUPERVISOR_IMAGE=%s", supervisorImage)
+	foundEnv := false
+	for _, env := range cmd.Env {
+		if env == expectedEnv {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Errorf("Expected %s in env, got: %v", expectedEnv, cmd.Env)
+	}
 }
 
 func TestBuildGatewayCommand_VM(t *testing.T) {


### PR DESCRIPTION
Switch from custom quay.io/fbenoit/openshell-supervisor image to the official release at ghcr.io/nvidia/openshell/supervisor, using the OpenShell DefaultVersion (without the v prefix) as the tag.

fixes https://github.com/openkaiden/kdn/issues/503