### PR TITLE
fix: update openshell driver download location

### DIFF
--- a/pkg/runtime/openshell/create.go
+++ b/pkg/runtime/openshell/create.go
@@ -190,7 +190,7 @@ func (r *openshellRuntime) createSandbox(ctx context.Context, name string, agent
 	for _, p := range providers {
 		args = append(args, "--provider", p)
 	}
-	args = append(args, "--no-tty", "--no-bootstrap", "--", "true")
+	args = append(args, "--no-tty", "--", "true")
 	err := r.executor.Run(ctx, l.Stdout(), l.Stderr(), args...)
 	if err == nil {
 		return nil

--- a/pkg/runtime/openshell/download.go
+++ b/pkg/runtime/openshell/download.go
@@ -29,7 +29,7 @@ import (
 const (
 	openshellGatewayRelease  = "dev"
 	openshellRelease         = "dev"
-	openshellDriverVMRelease = "vm-dev"
+	openshellDriverVMRelease = "dev"
 	githubRepo               = "NVIDIA/OpenShell"
 )
 


### PR DESCRIPTION
The openshell-driver-vm assets are published under the "dev" release tag not the "vm-dev" tag.

The --no-bootstrap flag was also removed, so it is dropped from the sandbox invocation.

## Before

```bash
$ kdn init <path> --runtime openshell --agent claude
⚠️  OpenShell runtime support is experimental
Error: failed to create runtime instance: failed to ensure gateway is running: failed to ensure openshell-driver-vm binary: failed to download openshell-driver-vm: download failed with status 404 for https://github.com/NVIDIA/OpenShell/releases/download/vm-dev/openshell-driver-vm-aarch64-apple-darwin.tar.gz
```

## After

```bash
$ ./kdn init <path> --runtime openshell --agent claude
⚠️  OpenShell runtime support is experimental
✓ OpenShell Gateway started
✓ Secret providers provisioned
✓ Sandbox created
✓ Sources uploaded
✓ Agent settings uploaded
✓ Network policy configured
```