### PR TITLE
fix(podman): allow responses to port-forwarded connections on macOS

### DIFF
--- a/pkg/runtime/podman/network.go
+++ b/pkg/runtime/podman/network.go
@@ -339,6 +339,10 @@ func buildNftScript(agentUID int, hostGW string) string {
 	if hostGW != "" {
 		parts = append(parts, fmt.Sprintf("nft add rule ip filter output ip daddr %s accept", hostGW))
 	}
+	// Allow responses to inbound connections (e.g. port-forwarded traffic from
+	// the host). On macOS the Podman VM routes these through a non-loopback
+	// interface, so without this rule the gateway's response packets are dropped.
+	parts = append(parts, "nft add rule ip filter output ct state established,related accept")
 	parts = append(parts, fmt.Sprintf("nft add rule ip filter output meta skuid %d drop", agentUID))
 
 	// IPv6 rules — mirror
@@ -347,6 +351,7 @@ func buildNftScript(agentUID int, hostGW string) string {
 		"nft add table ip6 filter",
 		"nft add chain ip6 filter output '{ type filter hook output priority 0; policy accept; }'",
 		"nft add rule ip6 filter output oif lo accept",
+		"nft add rule ip6 filter output ct state established,related accept",
 		fmt.Sprintf("nft add rule ip6 filter output meta skuid %d drop", agentUID),
 	)
 

--- a/pkg/runtime/podman/network_test.go
+++ b/pkg/runtime/podman/network_test.go
@@ -357,6 +357,9 @@ func TestBuildNftScript(t *testing.T) {
 		if !strings.Contains(script, "oif lo accept") {
 			t.Error("expected loopback rule")
 		}
+		if !strings.Contains(script, "ct state established,related accept") {
+			t.Error("expected conntrack established rule")
+		}
 		if strings.Contains(script, "ip daddr") {
 			t.Error("expected no host-gateway rule when hostGW is empty")
 		}
@@ -381,6 +384,21 @@ func TestBuildNftScript(t *testing.T) {
 		dropIdx := strings.Index(script, "meta skuid 1000 drop")
 		if hostGWIdx >= dropIdx {
 			t.Error("host-gateway accept should come before agent drop rule")
+		}
+	})
+
+	t.Run("conntrack established rule comes before agent drop rule", func(t *testing.T) {
+		t.Parallel()
+
+		script := buildNftScript(1000, "")
+
+		ctIdx := strings.Index(script, "ct state established,related accept")
+		dropIdx := strings.Index(script, "meta skuid 1000 drop")
+		if ctIdx < 0 {
+			t.Fatal("conntrack established rule not found")
+		}
+		if ctIdx >= dropIdx {
+			t.Error("conntrack established accept should come before agent drop rule")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- On macOS, the nftables firewall inside the container drops the gateway's response packets for port-forwarded connections because traffic arrives through the Podman VM's non-loopback interface, hitting the agent UID drop rule
- Adds a `ct state established,related accept` rule before the UID drop rule so responses to inbound connections pass through
- No behavior change on Linux/Windows — port-forwarded traffic already uses loopback (pasta splice bypass) on those platforms

Fixes: https://github.com/openkaiden/kdn/issues/509

## Test plan
create a workspace using openclaw
run `kdn terminal openclawname` to start the terminal which runs the gateway in the backgroun
run `kdn workspace open openclawname` to launch the browser with the webui

it should work now before it did not this effected any agent or runtime like openshell that had support for the webui launching on mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)