### PR TITLE
feat(workspace): expose runtime type in workspace list and JSON output

### DIFF
--- a/pkg/cmd/conversion.go
+++ b/pkg/cmd/conversion.go
@@ -42,6 +42,7 @@ func instanceToWorkspace(instance instances.Instance) api.Workspace {
 		Name:    instance.GetName(),
 		Project: instance.GetProject(),
 		Agent:   instance.GetAgent(),
+		Runtime: runtimeData.Type,
 		State:   runtimeData.State,
 		Paths: api.WorkspacePaths{
 			Configuration: instance.GetConfigDir(),

--- a/pkg/cmd/conversion_test.go
+++ b/pkg/cmd/conversion_test.go
@@ -99,10 +99,11 @@ func TestInstanceToWorkspace(t *testing.T) {
 			t.Fatalf("Failed to create instance: %v", err)
 		}
 
-		// Manually set ID and Project (in real usage, Manager sets these)
+		// Manually set ID, Project, and Runtime (in real usage, Manager sets these)
 		instanceData := instance.Dump()
 		instanceData.ID = "test-id-456"
 		instanceData.Project = "test-project"
+		instanceData.Runtime = instances.RuntimeData{Type: "podman"}
 		instance, _ = instances.NewInstanceFromData(instanceData)
 
 		result := instanceToWorkspace(instance)
@@ -117,6 +118,10 @@ func TestInstanceToWorkspace(t *testing.T) {
 
 		if result.Project != "test-project" {
 			t.Errorf("Expected project 'test-project', got '%s'", result.Project)
+		}
+
+		if result.Runtime != "podman" {
+			t.Errorf("Expected runtime 'podman', got '%s'", result.Runtime)
 		}
 
 		if result.Paths.Source != sourceDir {
@@ -254,6 +259,30 @@ func TestInstanceToWorkspace(t *testing.T) {
 		}
 	})
 
+	t.Run("maps runtime type from runtime data", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+
+		instanceData := instances.InstanceData{
+			ID:      "rt-test-id",
+			Name:    "rt-workspace",
+			Paths:   instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{Type: "openshell"},
+		}
+		instance, err := instances.NewInstanceFromData(instanceData)
+		if err != nil {
+			t.Fatalf("Failed to create instance from data: %v", err)
+		}
+
+		result := instanceToWorkspace(instance)
+
+		if result.Runtime != "openshell" {
+			t.Errorf("Expected runtime 'openshell', got '%s'", result.Runtime)
+		}
+	})
+
 	t.Run("includes all required fields", func(t *testing.T) {
 		t.Parallel()
 
@@ -269,10 +298,11 @@ func TestInstanceToWorkspace(t *testing.T) {
 			t.Fatalf("Failed to create instance: %v", err)
 		}
 
-		// Set ID and Agent
+		// Set ID, Agent, and Runtime
 		instanceData := instance.Dump()
 		instanceData.ID = "full-test-id"
 		instanceData.Agent = "claude"
+		instanceData.Runtime = instances.RuntimeData{Type: "podman"}
 		instance, _ = instances.NewInstanceFromData(instanceData)
 
 		result := instanceToWorkspace(instance)
@@ -300,6 +330,9 @@ func TestInstanceToWorkspace(t *testing.T) {
 		}
 		if _, exists := parsed["agent"]; !exists {
 			t.Error("Expected 'agent' field in JSON")
+		}
+		if _, exists := parsed["runtime"]; !exists {
+			t.Error("Expected 'runtime' field in JSON")
 		}
 		if _, exists := parsed["paths"]; !exists {
 			t.Error("Expected 'paths' field in JSON")

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -169,7 +169,7 @@ func (w *workspaceListCmd) displayTable(cmd *cobra.Command, instancesList []inst
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 	columnFmt := color.New(color.FgYellow).SprintfFunc()
 
-	tbl := table.New("NAME", "SHORT ID", "PROJECT", "SOURCES", "AGENT", "MODEL", "STATE")
+	tbl := table.New("NAME", "SHORT ID", "PROJECT", "SOURCES", "AGENT", "MODEL", "RUNTIME", "STATE")
 	tbl.WithWriter(out)
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
@@ -181,9 +181,10 @@ func (w *workspaceListCmd) displayTable(cmd *cobra.Command, instancesList []inst
 		sources := compactPath(instance.GetSourceDir())
 		agent := instance.GetAgent()
 		model := displayModelID(instance.GetModel())
+		runtime := instance.GetRuntimeData().Type
 		state := formatState(instance)
 
-		tbl.AddRow(name, shortID, project, sources, agent, model, state)
+		tbl.AddRow(name, shortID, project, sources, agent, model, runtime, state)
 	}
 
 	// Print the table


### PR DESCRIPTION
Include the runtime type (e.g. podman, openshell) in the workspace list table and in the JSON output from instanceToWorkspace conversion.

<img width="1053" height="59" alt="Captura de pantalla 2026-05-12 a las 13 30 49" src="https://github.com/user-attachments/assets/7a9381ab-88ec-40d0-844c-bce381620c94" />


Part of #1768