### PR TITLE
fix(podman): allow removal of invalid/orphaned  workspaces

### DIFF
--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -556,7 +556,13 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 	// Get updated runtime info
 	runtimeInfo, err := rt.Info(ctx, runtimeData.InstanceID)
 	if err != nil {
-		return fmt.Errorf("failed to get runtime info: %w", err)
+		if errors.Is(err, runtime.ErrInstanceNotFound) {
+			// The runtime instance is gone (e.g., orphaned workspace from a different Podman
+			// machine). Treat it as stopped so the workspace can be removed.
+			runtimeInfo = runtime.RuntimeInfo{State: api.WorkspaceStateStopped}
+		} else {
+			return fmt.Errorf("failed to get runtime info: %w", err)
+		}
 	}
 
 	// Validate state at boundary

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -3817,6 +3817,94 @@ func TestManager_Stop_RejectsInvalidState(t *testing.T) {
 	}
 }
 
+func TestManager_Stop_OrphanedInstance(t *testing.T) {
+	t.Parallel()
+
+	// orphanedInstanceRuntime simulates a runtime whose resources have disappeared (e.g., a
+	// workspace from a different Podman machine): Stop() is a no-op, Info() returns ErrInstanceNotFound.
+	storageDir := t.TempDir()
+	manager, err := NewManager(storageDir)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	orphaned := &orphanedInstanceRuntime{}
+	if err := manager.RegisterRuntime(orphaned); err != nil {
+		t.Fatalf("Failed to register orphaned runtime: %v", err)
+	}
+
+	instanceTmpDir := t.TempDir()
+	sourceDir := filepath.Join(instanceTmpDir, "source")
+	configDir := filepath.Join(instanceTmpDir, "config")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("Failed to create config directory: %v", err)
+	}
+
+	inst, err := NewInstance(NewInstanceParams{SourceDir: sourceDir, ConfigDir: configDir})
+	if err != nil {
+		t.Fatalf("Failed to create instance: %v", err)
+	}
+
+	added, err := manager.Add(context.Background(), AddOptions{
+		Instance:    inst,
+		RuntimeType: orphaned.Type(),
+		Agent:       "test-agent",
+	})
+	if err != nil {
+		t.Fatalf("Failed to add instance: %v", err)
+	}
+
+	if err := manager.Start(context.Background(), added.GetID()); err != nil {
+		t.Fatalf("Failed to start instance: %v", err)
+	}
+
+	// Stop should succeed even though Info() returns ErrInstanceNotFound.
+	err = manager.Stop(context.Background(), added.GetID())
+	if err != nil {
+		t.Fatalf("Stop() expected nil for orphaned instance, got: %v", err)
+	}
+
+	// State should be updated to "stopped".
+	updated, err := manager.Get(added.GetID())
+	if err != nil {
+		t.Fatalf("Get() failed: %v", err)
+	}
+	if updated.GetRuntimeData().State != api.WorkspaceStateStopped {
+		t.Errorf("After Stop, state = %v, want %v", updated.GetRuntimeData().State, api.WorkspaceStateStopped)
+	}
+}
+
+// orphanedInstanceRuntime simulates a runtime whose resources have disappeared.
+// Stop() is a no-op, Info() returns ErrInstanceNotFound.
+type orphanedInstanceRuntime struct{}
+
+func (r *orphanedInstanceRuntime) Type() string                 { return "orphaned-runtime" }
+func (r *orphanedInstanceRuntime) DisplayName() string          { return "orphaned-runtime" }
+func (r *orphanedInstanceRuntime) Description() string          { return "orphaned runtime for testing" }
+func (r *orphanedInstanceRuntime) Local() bool                  { return true }
+func (r *orphanedInstanceRuntime) WorkspaceSourcesPath() string { return "/workspace/sources" }
+
+func (r *orphanedInstanceRuntime) Create(_ context.Context, _ runtime.CreateParams) (runtime.RuntimeInfo, error) {
+	return runtime.RuntimeInfo{ID: "orphaned-id", State: api.WorkspaceStateStopped, Info: map[string]string{}}, nil
+}
+
+func (r *orphanedInstanceRuntime) Start(_ context.Context, id string) (runtime.RuntimeInfo, error) {
+	return runtime.RuntimeInfo{ID: id, State: api.WorkspaceStateRunning, Info: map[string]string{}}, nil
+}
+
+func (r *orphanedInstanceRuntime) Stop(_ context.Context, _ string) error { return nil }
+
+func (r *orphanedInstanceRuntime) Remove(_ context.Context, _ string) error { return nil }
+
+func (r *orphanedInstanceRuntime) Info(_ context.Context, id string) (runtime.RuntimeInfo, error) {
+	return runtime.RuntimeInfo{}, fmt.Errorf("%w: %s", runtime.ErrInstanceNotFound, id)
+}
+
+var _ runtime.Runtime = (*orphanedInstanceRuntime)(nil)
+
 // spyRuntime is a test double for runtime.Runtime that captures the params passed to Create.
 type spyRuntime struct {
 	wrapped          runtime.Runtime

--- a/pkg/runtime/podman/info.go
+++ b/pkg/runtime/podman/info.go
@@ -62,6 +62,9 @@ func (p *podmanRuntime) getContainerInfo(ctx context.Context, id string) (runtim
 	l := logger.FromContext(ctx)
 	output, err := p.executor.Output(ctx, l.Stderr(), "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", id)
 	if err != nil {
+		if isNotFoundError(err) {
+			return runtime.RuntimeInfo{}, runtime.ErrInstanceNotFound
+		}
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to inspect container: %w", err)
 	}
 

--- a/pkg/runtime/podman/info_test.go
+++ b/pkg/runtime/podman/info_test.go
@@ -119,9 +119,9 @@ func TestInfo_InspectFailure(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
-	// Set up OutputFunc to return an error
+	// Set up OutputFunc to return a generic (non-not-found) error
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		return nil, fmt.Errorf("container not found")
+		return nil, fmt.Errorf("connection refused")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -130,9 +130,34 @@ func TestInfo_InspectFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error when inspect fails, got nil")
 	}
+	if errors.Is(err, runtime.ErrInstanceNotFound) {
+		t.Errorf("Expected generic error, got ErrInstanceNotFound for non-not-found failure")
+	}
 
 	// Verify Output was called
 	fakeExec.AssertOutputCalledWith(t, "inspect", "--format", "{{.Id}}|{{.State.Status}}|{{.ImageName}}", containerID)
+}
+
+func TestInfo_ContainerNotFound(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Simulate "podman inspect" failing with a "no such container" error (as Podman does).
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 125\nPodman stderr:\nError: no such container: %s", containerID)
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	_, err := p.Info(context.Background(), containerID)
+	if err == nil {
+		t.Fatal("Expected error when container not found, got nil")
+	}
+	if !errors.Is(err, runtime.ErrInstanceNotFound) {
+		t.Errorf("Expected ErrInstanceNotFound, got: %v", err)
+	}
 }
 
 func TestInfo_MalformedOutput(t *testing.T) {

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -16,6 +16,7 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func (p *podmanRuntime) Remove(ctx context.Context, id string) error {
 	stepLogger.Start("Checking container state", "Container state checked")
 	info, err := p.getContainerInfo(ctx, id)
 	if err != nil {
-		if isNotFoundError(err) {
+		if errors.Is(err, runtime.ErrInstanceNotFound) {
 			if podName, readErr := p.readPodName(id); readErr == nil {
 				p.cleanupWorkspaceTempDirs(podName)
 			}

--- a/pkg/runtime/podman/remove.go
+++ b/pkg/runtime/podman/remove.go
@@ -95,13 +95,14 @@ func (p *podmanRuntime) cleanupWorkspaceTempDirs(podName string) {
 	}
 }
 
-// isNotFoundError checks if an error indicates that a container was not found.
+// isNotFoundError checks if an error indicates that a container or pod was not found.
 func isNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
 	errMsg := err.Error()
 	return strings.Contains(errMsg, "no such container") ||
+		strings.Contains(errMsg, "no such pod") ||
 		strings.Contains(errMsg, "no such object") ||
 		strings.Contains(errMsg, "error getting container") ||
 		strings.Contains(errMsg, "failed to inspect container")

--- a/pkg/runtime/podman/remove_test.go
+++ b/pkg/runtime/podman/remove_test.go
@@ -239,6 +239,11 @@ func TestIsNotFoundError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "no such pod error",
+			err:      fmt.Errorf("Error: no such pod \"test1\""),
+			expected: true,
+		},
+		{
 			name:     "no such object error",
 			err:      fmt.Errorf("Error: no such object: abc123"),
 			expected: true,

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -16,7 +16,9 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/openkaiden/kdn/pkg/logger"
@@ -36,6 +38,11 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 	// Resolve the pod name from the stored mapping
 	podName, err := p.readPodName(id)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Pod name file is missing — the workspace has no live Podman resources
+			// (e.g., it was created on a different Podman machine). Nothing to stop.
+			return nil
+		}
 		return fmt.Errorf("failed to resolve pod name: %w", err)
 	}
 

--- a/pkg/runtime/podman/stop.go
+++ b/pkg/runtime/podman/stop.go
@@ -55,6 +55,10 @@ func (p *podmanRuntime) Stop(ctx context.Context, id string) error {
 	output, err := p.executor.Output(ctx, l.Stderr(),
 		"pod", "inspect", "--format", "{{range .Containers}}{{.Name}}\n{{end}}", podName)
 	if err != nil {
+		if isNotFoundError(err) {
+			// Pod was removed outside of kdn (e.g., manually deleted). Nothing to stop.
+			return nil
+		}
 		return fmt.Errorf("failed to inspect pod %s: %w", podName, err)
 	}
 	containerNames := strings.Fields(string(output))

--- a/pkg/runtime/podman/stop_test.go
+++ b/pkg/runtime/podman/stop_test.go
@@ -89,8 +89,9 @@ func TestStop_PodInspectFailure(t *testing.T) {
 	containerID := "abc123"
 	fakeExec := exec.NewFake()
 
+	// Generic (non-not-found) inspect error.
 	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
-		return nil, fmt.Errorf("pod not found")
+		return nil, fmt.Errorf("connection refused")
 	}
 
 	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
@@ -105,6 +106,30 @@ func TestStop_PodInspectFailure(t *testing.T) {
 
 	if len(fakeExec.RunCalls) != 0 {
 		t.Errorf("Expected no Run calls when inspect fails, got: %v", fakeExec.RunCalls)
+	}
+}
+
+func TestStop_PodManuallyDeleted(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Simulate `podman pod inspect` failing with "no such pod" (manually deleted pod).
+	fakeExec.OutputFunc = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 125\nPodman stderr:\nError: no such pod %q", "test-ws")
+	}
+
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+	setupPodFiles(t, p, containerID, "test-ws")
+
+	err := p.Stop(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Stop() expected nil for manually-deleted pod, got: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 0 {
+		t.Errorf("Expected no Run calls for missing pod, got: %v", fakeExec.RunCalls)
 	}
 }
 

--- a/pkg/runtime/podman/stop_test.go
+++ b/pkg/runtime/podman/stop_test.go
@@ -223,3 +223,26 @@ func TestStop_StepLogger_FailOnContainerStop(t *testing.T) {
 		t.Fatalf("Expected 1 Fail() call, got %d", len(fakeLogger.failCalls))
 	}
 }
+
+func TestStop_OrphanedWorkspace_MissingPodNameFile(t *testing.T) {
+	t.Parallel()
+
+	containerID := "abc123"
+	fakeExec := exec.NewFake()
+
+	// Do NOT set up pod files — simulate an orphaned workspace from a different machine.
+	p := newWithDeps(&fakeSystem{}, fakeExec).(*podmanRuntime)
+
+	err := p.Stop(context.Background(), containerID)
+	if err != nil {
+		t.Fatalf("Stop() expected nil for orphaned workspace (missing pod name file), got: %v", err)
+	}
+
+	// Verify no podman commands were issued.
+	if len(fakeExec.OutputCalls) != 0 {
+		t.Errorf("Expected no Output calls for orphaned workspace, got: %v", fakeExec.OutputCalls)
+	}
+	if len(fakeExec.RunCalls) != 0 {
+		t.Errorf("Expected no Run calls for orphaned workspace, got: %v", fakeExec.RunCalls)
+	}
+}


### PR DESCRIPTION
Workspaces created on a different Podman machine had their pod name file missing, making them impossible to stop or force-remove. Three fixes work together to handle this gracefully:
    
- Stop() returns nil when the pod name file is absent (nothing to stop for an orphaned workspace)
- getContainerInfo() returns runtime.ErrInstanceNotFound when Podman reports "no such container", giving callers a clean sentinel
- manager.Stop() treats ErrInstanceNotFound from Info() as stopped, allowing force-remove to complete
    
When a Podman pod is deleted outside of kdn (e.g. via podman pod rm), Stop() would fail on the pod inspect step with "no such pod". Extend isNotFoundError to match "no such pod" errors and treat a missing pod as nothing to stop, consistent with how a missing container is handled.

Fixes #384
