### PR TITLE
chore(deps): bump kdn-api modules to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/devfile/alizer v1.9.6
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
-	github.com/openkaiden/kdn-api/cli/go v0.11.0
-	github.com/openkaiden/kdn-api/workspace-configuration/go v0.11.0
+	github.com/openkaiden/kdn-api/cli/go v0.12.0
+	github.com/openkaiden/kdn-api/workspace-configuration/go v0.12.0
 	github.com/rodaine/table v1.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -94,10 +94,10 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/openkaiden/kdn-api/cli/go v0.11.0 h1:A3flhomYV5kWlZU8uADAkInE7huVk5OgBijZPvHk6zg=
-github.com/openkaiden/kdn-api/cli/go v0.11.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.11.0 h1:kK0oCThTodWeJViUJKo2Jn2C2X/IphA8H+mOXN2mCig=
-github.com/openkaiden/kdn-api/workspace-configuration/go v0.11.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
+github.com/openkaiden/kdn-api/cli/go v0.12.0 h1:u42yJX8B/EGVsl9uTAKkyCr46yR6mrOJp1R9O6FAOQQ=
+github.com/openkaiden/kdn-api/cli/go v0.12.0/go.mod h1:shX38OALrjrGa6K54sBOGPqoOe45+YZDl8zpXbeQcdQ=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.12.0 h1:13WrD+fkIL4z4zKHj1mt7K9E12ALCiN+OZttu9HAR1o=
+github.com/openkaiden/kdn-api/workspace-configuration/go v0.12.0/go.mod h1:kSN89iJaJ4q5Go99LamjtDBMXMp7vbyqWuL142yC4/E=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
Update cli/go and workspace-configuration/go from v0.11.0 to v0.12.0.

Closes #514