### PR TITLE
fix(instances): safe concurrent writes across parallel kdn  processes

### DIFF
--- a/pkg/instances/filelock_unix.go
+++ b/pkg/instances/filelock_unix.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package instances
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFileExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/pkg/instances/filelock_windows.go
+++ b/pkg/instances/filelock_windows.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package instances
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFileExclusive(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, ol)
+}
+
+func unlockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -421,8 +421,15 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		CreatedAt: m.now(),
 	}
 
-	instances = append(instances, instanceWithID)
-	if err := m.saveInstances(instances); err != nil {
+	// Re-read under the file lock and append, so a concurrent kdn process
+	// that added an instance between our initial load and now is not lost.
+	if err := m.withStorageLock(func() error {
+		current, err := m.loadInstances()
+		if err != nil {
+			return err
+		}
+		return m.saveInstances(append(current, instanceWithID))
+	}); err != nil {
 		return nil, err
 	}
 
@@ -441,12 +448,10 @@ func (m *manager) Start(ctx context.Context, id string) error {
 
 	// Find the instance
 	var instanceToStart Instance
-	var index int
 	found := false
-	for i, instance := range instances {
+	for _, instance := range instances {
 		if instance.GetID() == id {
 			instanceToStart = instance
-			index = i
 			found = true
 			break
 		}
@@ -505,8 +510,19 @@ func (m *manager) Start(ctx context.Context, id string) error {
 		StartedAt: startedAt,
 	}
 
-	instances[index] = updatedInstance
-	return m.saveInstances(instances)
+	return m.withStorageLock(func() error {
+		current, err := m.loadInstances()
+		if err != nil {
+			return err
+		}
+		for i, inst := range current {
+			if inst.GetID() == id {
+				current[i] = updatedInstance
+				break
+			}
+		}
+		return m.saveInstances(current)
+	})
 }
 
 // Stop stops a runtime instance by ID.
@@ -521,12 +537,10 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 
 	// Find the instance
 	var instanceToStop Instance
-	var index int
 	found := false
-	for i, instance := range instances {
+	for _, instance := range instances {
 		if instance.GetID() == id {
 			instanceToStop = instance
-			index = i
 			found = true
 			break
 		}
@@ -595,8 +609,19 @@ func (m *manager) Stop(ctx context.Context, id string) error {
 		// StartedAt is intentionally zero on stop: the instance is no longer running
 	}
 
-	instances[index] = updatedInstance
-	return m.saveInstances(instances)
+	return m.withStorageLock(func() error {
+		current, err := m.loadInstances()
+		if err != nil {
+			return err
+		}
+		for i, inst := range current {
+			if inst.GetID() == id {
+				current[i] = updatedInstance
+				break
+			}
+		}
+		return m.saveInstances(current)
+	})
 }
 
 // Terminal starts an interactive terminal session in a running instance.
@@ -719,46 +744,59 @@ func (m *manager) Get(nameOrID string) (Instance, error) {
 // Before removing from storage, it removes the runtime instance.
 // If runtime removal fails, the instance is NOT removed from storage and an error is returned.
 func (m *manager) Delete(ctx context.Context, id string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
+	// Step 1: read the runtime info needed for cleanup without holding the write
+	// lock, so that other goroutines can proceed while we look up the instance.
+	m.mu.RLock()
 	instances, err := m.loadInstances()
+	m.mu.RUnlock()
 	if err != nil {
 		return err
 	}
 
-	// Find the instance to delete
 	var instanceToDelete Instance
-	found := false
-	filtered := make([]Instance, 0, len(instances))
-	for _, instance := range instances {
-		if instance.GetID() != id {
-			filtered = append(filtered, instance)
-		} else {
-			instanceToDelete = instance
-			found = true
+	for _, inst := range instances {
+		if inst.GetID() == id {
+			instanceToDelete = inst
+			break
 		}
 	}
-
-	if !found {
+	if instanceToDelete == nil {
 		return ErrInstanceNotFound
 	}
 
-	// Runtime cleanup
+	// Step 2: runtime cleanup outside any lock — this can be slow.
+	// If it fails we return early and leave the storage entry intact.
 	runtimeInfo := instanceToDelete.GetRuntimeData()
 	if runtimeInfo.Type != "" && runtimeInfo.InstanceID != "" {
 		rt, err := m.runtimeRegistry.Get(runtimeInfo.Type)
 		if err != nil {
 			return fmt.Errorf("failed to get runtime: %w", err)
 		}
-		// Remove runtime instance (must succeed before removing from storage)
 		if err := rt.Remove(ctx, runtimeInfo.InstanceID); err != nil {
 			return fmt.Errorf("failed to remove runtime instance: %w", err)
 		}
 	}
 
-	// Remove from manager storage
-	return m.saveInstances(filtered)
+	// Step 3: re-read, filter, and save under the write lock + file lock.
+	// No slow operations between load and save — the window is minimal.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.withStorageLock(func() error {
+		instances, err = m.loadInstances()
+		if err != nil {
+			return err
+		}
+
+		filtered := make([]Instance, 0, len(instances))
+		for _, inst := range instances {
+			if inst.GetID() != id {
+				filtered = append(filtered, inst)
+			}
+		}
+
+		return m.saveInstances(filtered)
+	})
 }
 
 // Reconcile removes instances with inaccessible directories
@@ -767,29 +805,28 @@ func (m *manager) Reconcile() ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	instances, err := m.loadInstances()
-	if err != nil {
-		return nil, err
-	}
-
-	removed := []string{}
-	accessible := make([]Instance, 0, len(instances))
-
-	for _, instance := range instances {
-		if instance.IsAccessible() {
-			accessible = append(accessible, instance)
-		} else {
-			removed = append(removed, instance.GetID())
+	var removed []string
+	err := m.withStorageLock(func() error {
+		instances, err := m.loadInstances()
+		if err != nil {
+			return err
 		}
-	}
 
-	if len(removed) > 0 {
-		if err := m.saveInstances(accessible); err != nil {
-			return nil, err
+		accessible := make([]Instance, 0, len(instances))
+		for _, instance := range instances {
+			if instance.IsAccessible() {
+				accessible = append(accessible, instance)
+			} else {
+				removed = append(removed, instance.GetID())
+			}
 		}
-	}
 
-	return removed, nil
+		if len(removed) > 0 {
+			return m.saveInstances(accessible)
+		}
+		return nil
+	})
+	return removed, err
 }
 
 // GetDashboardURL returns the dashboard URL for a workspace instance by name or ID.
@@ -944,34 +981,55 @@ func (m *manager) mergeConfigurations(projectID string, workspaceConfig *workspa
 // timestamp using the injected clock, and writes the result back to disk so
 // subsequent loads see the authoritative value.
 func (m *manager) migrateTimestamps() error {
-	instances, err := m.loadInstances()
-	if err != nil {
-		return err
-	}
-
-	migrated := false
-	for i, inst := range instances {
-		if inst.GetCreatedAt().IsZero() {
-			data := inst.Dump()
-			data.CreatedAt = m.now()
-			updated, err := m.factory(data)
-			if err != nil {
-				return err
-			}
-			instances[i] = updated
-			migrated = true
+	return m.withStorageLock(func() error {
+		instances, err := m.loadInstances()
+		if err != nil {
+			return err
 		}
-	}
 
-	if migrated {
-		return m.saveInstances(instances)
-	}
-	return nil
+		migrated := false
+		for i, inst := range instances {
+			if inst.GetCreatedAt().IsZero() {
+				data := inst.Dump()
+				data.CreatedAt = m.now()
+				updated, err := m.factory(data)
+				if err != nil {
+					return err
+				}
+				instances[i] = updated
+				migrated = true
+			}
+		}
+
+		if migrated {
+			return m.saveInstances(instances)
+		}
+		return nil
+	})
 }
 
-// loadInstances reads instances from the storage file
+// withStorageLock acquires a cross-process exclusive lock on the storage lock
+// file, runs fn, then releases the lock. It serialises concurrent writes from
+// independent kdn processes sharing the same storage directory.
+// The in-process sync.RWMutex must be held by the caller for goroutine safety.
+func (m *manager) withStorageLock(fn func() error) error {
+	lockPath := m.storageFile + ".lock"
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open storage lock file: %w", err)
+	}
+	defer f.Close()
+
+	if err := lockFileExclusive(f); err != nil {
+		return fmt.Errorf("failed to acquire storage lock: %w", err)
+	}
+	defer unlockFile(f) //nolint:errcheck
+
+	return fn()
+}
+
+// loadInstances reads instances from the storage file.
 func (m *manager) loadInstances() ([]Instance, error) {
-	// If file doesn't exist, return empty list
 	if _, err := os.Stat(m.storageFile); os.IsNotExist(err) {
 		return []Instance{}, nil
 	}
@@ -981,21 +1039,18 @@ func (m *manager) loadInstances() ([]Instance, error) {
 		return nil, err
 	}
 
-	// Empty file case
 	if len(data) == 0 {
 		return []Instance{}, nil
 	}
 
-	// Unmarshal into InstanceData slice
 	var instancesData []InstanceData
 	if err := json.Unmarshal(data, &instancesData); err != nil {
 		return nil, err
 	}
 
-	// Convert to Instance slice using the factory
 	instances := make([]Instance, len(instancesData))
-	for i, data := range instancesData {
-		inst, err := m.factory(data)
+	for i, d := range instancesData {
+		inst, err := m.factory(d)
 		if err != nil {
 			return nil, err
 		}
@@ -1005,9 +1060,10 @@ func (m *manager) loadInstances() ([]Instance, error) {
 	return instances, nil
 }
 
-// saveInstances writes instances to the storage file
+// saveInstances marshals instances and writes them to the storage file.
+// The write strategy is platform-specific (see savefile_unix.go and
+// savefile_windows.go); callers must hold withStorageLock.
 func (m *manager) saveInstances(instances []Instance) error {
-	// Convert to InstanceData slice for marshaling
 	instancesData := make([]InstanceData, len(instances))
 	for i, inst := range instances {
 		instancesData[i] = inst.Dump()
@@ -1018,7 +1074,7 @@ func (m *manager) saveInstances(instances []Instance) error {
 		return err
 	}
 
-	return os.WriteFile(m.storageFile, data, 0644)
+	return writeStorageFile(m.storageFile, data)
 }
 
 // readAgentSettings reads all files from {storageDir}/config/{agentName}/ into a map.

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -1964,6 +1964,84 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 			t.Errorf("After concurrent reads, List() returned %d instances, want 5", len(instances))
 		}
 	})
+
+	t.Run("concurrent deletes via single manager leave no ghost instances", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		instanceTmpDir := t.TempDir()
+
+		mgr, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		numInstances := 5
+		ids := make([]string, 0, numInstances)
+		for i := range numInstances {
+			sourceDir := filepath.Join(instanceTmpDir, "source", string(rune('a'+i)))
+			configDir := filepath.Join(instanceTmpDir, "config", string(rune('a'+i)))
+			inst := newFakeInstance(newFakeInstanceParams{SourceDir: sourceDir, ConfigDir: configDir, Accessible: true})
+			added, err := mgr.Add(context.Background(), AddOptions{Instance: inst, RuntimeType: "fake"})
+			if err != nil {
+				t.Fatalf("Add failed: %v", err)
+			}
+			ids = append(ids, added.GetID())
+		}
+
+		var wg sync.WaitGroup
+		for _, id := range ids {
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				_ = mgr.Delete(context.Background(), id)
+			}(id)
+		}
+		wg.Wait()
+
+		remaining, _ := mgr.List()
+		if len(remaining) != 0 {
+			t.Errorf("After concurrent deletes (single manager), List() returned %d instances, want 0", len(remaining))
+		}
+	})
+
+	t.Run("concurrent deletes across independent managers leave no ghost instances", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		instanceTmpDir := t.TempDir()
+
+		// Use one manager to populate instances.
+		mgr, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		numInstances := 5
+		ids := make([]string, 0, numInstances)
+		for i := range numInstances {
+			sourceDir := filepath.Join(instanceTmpDir, "source", string(rune('a'+i)))
+			configDir := filepath.Join(instanceTmpDir, "config", string(rune('a'+i)))
+			inst := newFakeInstance(newFakeInstanceParams{SourceDir: sourceDir, ConfigDir: configDir, Accessible: true})
+			added, err := mgr.Add(context.Background(), AddOptions{Instance: inst, RuntimeType: "fake"})
+			if err != nil {
+				t.Fatalf("Add failed: %v", err)
+			}
+			ids = append(ids, added.GetID())
+		}
+
+		// Each goroutine creates its own independent manager, simulating a
+		// separate kdn process sharing the same storage directory.
+		var wg sync.WaitGroup
+		for _, id := range ids {
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				localMgr, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+				_ = localMgr.Delete(context.Background(), id)
+			}(id)
+		}
+		wg.Wait()
+
+		remaining, _ := mgr.List()
+		if len(remaining) != 0 {
+			t.Errorf("After concurrent deletes (independent managers), List() returned %d instances, want 0", len(remaining))
+		}
+	})
 }
 
 func TestSanitizeName(t *testing.T) {

--- a/pkg/instances/savefile_unix.go
+++ b/pkg/instances/savefile_unix.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package instances
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeStorageFile writes data to path atomically using a temp file + rename.
+// On POSIX systems rename(2) is atomic: readers always see either the old file
+// or the new file, never a partial write, and the rename succeeds even if
+// another process currently has the destination open.
+func writeStorageFile(path string, data []byte) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), ".instances-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath) // no-op once Rename succeeds
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}

--- a/pkg/instances/savefile_unix_test.go
+++ b/pkg/instances/savefile_unix_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package instances
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteStorageFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes content and leaves no temp files", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "instances.json")
+		data := []byte(`[{"id":"abc"}]`)
+
+		if err := writeStorageFile(path, data); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if string(got) != string(data) {
+			t.Errorf("got %q, want %q", got, data)
+		}
+
+		// Temp file must have been cleaned up.
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Errorf("expected 1 file in dir after write, got %d", len(entries))
+		}
+	})
+
+	t.Run("overwrites existing file atomically", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "instances.json")
+
+		if err := writeStorageFile(path, []byte("first")); err != nil {
+			t.Fatalf("first write: %v", err)
+		}
+		if err := writeStorageFile(path, []byte("second")); err != nil {
+			t.Fatalf("second write: %v", err)
+		}
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if string(got) != "second" {
+			t.Errorf("got %q, want %q", got, "second")
+		}
+	})
+
+	t.Run("fails when directory does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		// os.CreateTemp fails because the parent directory is missing.
+		err := writeStorageFile("/nonexistent/dir/instances.json", []byte("{}"))
+		if err == nil {
+			t.Error("expected error for missing directory, got nil")
+		}
+	})
+
+	t.Run("fails and cleans up temp file when rename fails", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// Place a subdirectory at the target path so os.Rename fails
+		// ("is a directory") while CreateTemp and Write both succeed.
+		target := filepath.Join(dir, "instances.json")
+		if err := os.Mkdir(target, 0755); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+
+		err := writeStorageFile(target, []byte("{}"))
+		if err == nil {
+			t.Error("expected error when rename target is a directory, got nil")
+		}
+
+		// Temp file must have been removed by the defer.
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Errorf("expected 1 entry (the directory) after failed write, got %d", len(entries))
+		}
+	})
+}

--- a/pkg/instances/savefile_windows.go
+++ b/pkg/instances/savefile_windows.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package instances
+
+import "os"
+
+// writeStorageFile writes data to path directly.
+// On Windows, MoveFileExW (used by os.Rename) fails with "Access is denied"
+// if another process has the destination file open without FILE_SHARE_DELETE,
+// which os.ReadFile does not request. Since withStorageLock already holds an
+// exclusive LockFileEx preventing concurrent writers, a plain WriteFile is
+// safe: only one writer runs at a time, and the write is fast enough that
+// readers calling loadInstances concurrently are unlikely to observe a partial
+// file.
+func writeStorageFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0644)
+}


### PR DESCRIPTION
Parallel kdn invocations sharing the same storage directory could corrupt instances.json: each process had its own in-process mutex with no cross-process synchronisation, so the last writer would win and resurrect instances that had already been deleted.

- All write operations (Add, Start, Stop, Delete, Reconcile, migrateTimestamps) now acquire a cross-process exclusive file lock (syscall.Flock on Linux/macOS, LockFileEx on Windows via golang.org/x/sys/windows) around the read-modify-write cycle.
- Slow runtime calls (rt.Create, rt.Start, rt.Stop, rt.Remove) are moved outside the lock so only the fast file I/O is serialised across processes. Delete() in particular uses an RLock to read the runtime info, calls rt.Remove() with no lock held, then re-reads and saves under the write lock + file lock.
- The write strategy is platform-specific: on Linux/macOS saveInstances() writes atomically via a temp file + rename(2) so readers never observe a partial write; on Windows os.Rename fails with "Access is denied" if a concurrent reader has the file open, so os.WriteFile is used instead (safe because the exclusive LockFileEx prevents concurrent writers).

Promotes golang.org/x/sys from indirect to direct dependency for the Windows LockFileEx implementation.

Fixes #480

To test it: 
- create at least 4 workspaces
- start / stop / create / remove instances quickly and check that the result in the `kdn list` is eventually correct

(tested on Windows and macOS)