### PR TITLE
fix(agent): treat real OpenAI endpoint as native in OpenCode

### DIFF
--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -21,6 +21,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	kdnconfig "github.com/openkaiden/kdn/pkg/config"
@@ -91,7 +93,8 @@ func (o *openCodeAgent) SetModel(settings map[string]SettingsFile, modelID strin
 			resolvedURL = containerurl.RewriteURL(resolvedURL)
 		}
 		config["model"] = provider + "/" + modelName
-		if !nativeProviders[provider] || resolvedURL != "" {
+		realOpenAI := isRealOpenAI(provider, resolvedURL)
+		if (!nativeProviders[provider] && !realOpenAI) || (resolvedURL != "" && !realOpenAI) {
 			if err := configureProvider(config, provider, modelName, resolvedURL); err != nil {
 				return nil, err
 			}
@@ -177,6 +180,22 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 	providerEntry["models"] = models
 
 	return nil
+}
+
+// isRealOpenAI returns true when the provider is "openai" pointing at the
+// real OpenAI API (api.openai.com) rather than an openai-compatible endpoint.
+func isRealOpenAI(provider, baseURL string) bool {
+	if provider != "openai" {
+		return false
+	}
+	if baseURL == "" {
+		return true
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Hostname(), "api.openai.com")
 }
 
 // defaultProviderBaseURLs maps known provider names to their default base URLs.

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -92,10 +92,19 @@ func (o *openCodeAgent) SetModel(settings map[string]SettingsFile, modelID strin
 		} else {
 			resolvedURL = containerurl.RewriteURL(resolvedURL)
 		}
-		config["model"] = provider + "/" + modelName
 		realOpenAI := isRealOpenAI(provider, resolvedURL)
+		if provider == "openai" && !realOpenAI {
+			provider = "custom"
+		}
+		config["model"] = provider + "/" + modelName
 		if (!nativeProviders[provider] && !realOpenAI) || (resolvedURL != "" && !realOpenAI) {
-			if err := configureProvider(config, provider, modelName, resolvedURL); err != nil {
+			providerName := provider
+			if provider == "custom" && resolvedURL != "" {
+				if parsed, err := url.Parse(resolvedURL); err == nil && parsed.Hostname() != "" {
+					providerName = parsed.Hostname()
+				}
+			}
+			if err := configureProvider(config, provider, providerName, modelName, resolvedURL); err != nil {
 				return nil, err
 			}
 		}
@@ -138,7 +147,8 @@ var vertexAIProviders = map[string]bool{
 }
 
 // configureProvider adds a provider block with the given base URL and registers the model.
-func configureProvider(config map[string]interface{}, provider, modelName, baseURL string) error {
+// providerName is used as the display name in the provider entry.
+func configureProvider(config map[string]interface{}, provider, providerName, modelName, baseURL string) error {
 	providers, _ := config["provider"].(map[string]interface{})
 	if providers == nil {
 		providers = make(map[string]interface{})
@@ -148,10 +158,10 @@ func configureProvider(config map[string]interface{}, provider, modelName, baseU
 	providerEntry, _ := providers[provider].(map[string]interface{})
 	if providerEntry == nil {
 		providerEntry = make(map[string]interface{})
-		if !nativeProviders[provider] && !vertexAIProviders[provider] {
-			providerEntry["name"] = provider
-			providerEntry["npm"] = "@ai-sdk/openai-compatible"
-		}
+	}
+	if !nativeProviders[provider] && !vertexAIProviders[provider] {
+		providerEntry["name"] = providerName
+		providerEntry["npm"] = "@ai-sdk/openai-compatible"
 	}
 	if baseURL != "" {
 		options, _ := providerEntry["options"].(map[string]interface{})

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -586,7 +586,7 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
-	t.Run("openai provider with custom baseURL configures openai-compatible", func(t *testing.T) {
+	t.Run("openai provider with custom baseURL uses custom provider with hostname", func(t *testing.T) {
 		t.Parallel()
 
 		agent := NewOpenCode()
@@ -602,18 +602,21 @@ func TestOpenCode_SetModel(t *testing.T) {
 			t.Fatalf("Failed to parse result JSON: %v", err)
 		}
 
-		if config["model"] != "openai/gpt-4o" {
-			t.Errorf("model = %v, want %q", config["model"], "openai/gpt-4o")
+		if config["model"] != "custom/gpt-4o" {
+			t.Errorf("model = %v, want %q", config["model"], "custom/gpt-4o")
 		}
 
 		providers := config["provider"].(map[string]interface{})
-		openai := providers["openai"].(map[string]interface{})
+		custom := providers["custom"].(map[string]interface{})
 
-		if openai["npm"] != "@ai-sdk/openai-compatible" {
-			t.Errorf("npm = %v, want %q", openai["npm"], "@ai-sdk/openai-compatible")
+		if custom["npm"] != "@ai-sdk/openai-compatible" {
+			t.Errorf("npm = %v, want %q", custom["npm"], "@ai-sdk/openai-compatible")
+		}
+		if custom["name"] != "my-proxy.example.com" {
+			t.Errorf("name = %v, want %q", custom["name"], "my-proxy.example.com")
 		}
 
-		options := openai["options"].(map[string]interface{})
+		options := custom["options"].(map[string]interface{})
 		if got := options["baseURL"].(string); got != "https://my-proxy.example.com/v1" {
 			t.Errorf("baseURL = %q, want %q", got, "https://my-proxy.example.com/v1")
 		}

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -536,6 +536,89 @@ func TestOpenCode_SetModel(t *testing.T) {
 		}
 	})
 
+	t.Run("openai provider without baseURL skips provider config", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string]SettingsFile)
+
+		result, err := agent.SetModel(settings, "openai::gpt-4o")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath].Content, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "openai/gpt-4o" {
+			t.Errorf("model = %v, want %q", config["model"], "openai/gpt-4o")
+		}
+
+		if _, hasProvider := config["provider"]; hasProvider {
+			t.Error("Real OpenAI provider should not create provider block")
+		}
+	})
+
+	t.Run("openai provider with api.openai.com baseURL skips provider config", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string]SettingsFile)
+
+		result, err := agent.SetModel(settings, "openai::gpt-4o::https://api.openai.com/v1")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath].Content, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "openai/gpt-4o" {
+			t.Errorf("model = %v, want %q", config["model"], "openai/gpt-4o")
+		}
+
+		if _, hasProvider := config["provider"]; hasProvider {
+			t.Error("OpenAI with api.openai.com URL should not create provider block")
+		}
+	})
+
+	t.Run("openai provider with custom baseURL configures openai-compatible", func(t *testing.T) {
+		t.Parallel()
+
+		agent := NewOpenCode()
+		settings := make(map[string]SettingsFile)
+
+		result, err := agent.SetModel(settings, "openai::gpt-4o::https://my-proxy.example.com/v1")
+		if err != nil {
+			t.Fatalf("SetModel() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := json.Unmarshal(result[OpenCodeConfigPath].Content, &config); err != nil {
+			t.Fatalf("Failed to parse result JSON: %v", err)
+		}
+
+		if config["model"] != "openai/gpt-4o" {
+			t.Errorf("model = %v, want %q", config["model"], "openai/gpt-4o")
+		}
+
+		providers := config["provider"].(map[string]interface{})
+		openai := providers["openai"].(map[string]interface{})
+
+		if openai["npm"] != "@ai-sdk/openai-compatible" {
+			t.Errorf("npm = %v, want %q", openai["npm"], "@ai-sdk/openai-compatible")
+		}
+
+		options := openai["options"].(map[string]interface{})
+		if got := options["baseURL"].(string); got != "https://my-proxy.example.com/v1" {
+			t.Errorf("baseURL = %q, want %q", got, "https://my-proxy.example.com/v1")
+		}
+	})
+
 	t.Run("plain model ID without provider", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
When the openai provider points at api.openai.com (or no URL is
specified), skip configuring the provider block so OpenCode uses its
bundled OpenAI SDK instead of @ai-sdk/openai-compatible.

Partially fixes https://github.com/openkaiden/kaiden/issues/1781

When the openai provider points at a non-OpenAI endpoint, remap the
provider key to "custom" with the endpoint hostname as the display
name. This avoids overriding native OpenAI settings in OpenCode.

Fixes https://github.com/openkaiden/kaiden/issues/1830