### PR TITLE
feat(schemas): provide JSON schemas for configuration  files

### DIFF
--- a/.agents/skills/working-with-kdn-api/SKILL.md
+++ b/.agents/skills/working-with-kdn-api/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: working-with-kdn-api
+description: Guide to updating the kdn-api Go modules, what to check afterwards, and how to keep schemas and the config merger in sync
+argument-hint: ""
+---
+
+# Working with kdn-api
+
+The `openkaiden/kdn-api` repository defines the OpenAPI specs and generated Go types that kdn depends on. This skill covers how to bump the modules, and what must be reviewed or updated afterwards.
+
+## Two Go modules
+
+kdn imports two Go modules from kdn-api:
+
+| Module path | Package alias | Purpose |
+|---|---|---|
+| `github.com/openkaiden/kdn-api/workspace-configuration/go` | `workspace` | `WorkspaceConfiguration` and all its sub-types (`Mount`, `EnvironmentVariable`, `McpConfiguration`, …) |
+| `github.com/openkaiden/kdn-api/cli/go` | `api` | CLI output types (`Workspace`, `WorkspaceId`, `WorkspacePaths`, …) used in `pkg/cmd/conversion.go` |
+
+Both modules are versioned together (same `vX.Y.Z` tag). Both must always be bumped at the same time.
+
+## Bumping the modules
+
+```bash
+go get github.com/openkaiden/kdn-api/workspace-configuration/go@vX.Y.Z
+go get github.com/openkaiden/kdn-api/cli/go@vX.Y.Z
+go mod tidy
+```
+
+Verify the bump compiled and tests pass:
+
+```bash
+make build
+make test
+```
+
+### Commit message convention
+
+```text
+chore(deps): bump kdn-api modules to vX.Y.Z
+```
+
+## Checklist after bumping
+
+Always work through this list after any kdn-api bump, regardless of how small the diff looks.
+
+### 1. Check the kdn-api release notes
+
+Read the GitHub release for the new tag to understand what changed:
+
+```bash
+gh api repos/openkaiden/kdn-api/releases/tags/vX.Y.Z --jq '.body'
+```
+
+### 2. If `WorkspaceConfiguration` or its sub-types changed
+
+`WorkspaceConfiguration` is defined in `workspace-configuration/openapi.yaml` and code-generated into `workspace-configuration/go/workspace.go`. When it gains new fields, renames fields, or changes field types:
+
+**a. Update `pkg/config/merger.go`**
+
+`Merge()` and `copyConfig()` must handle every field of `WorkspaceConfiguration` explicitly. Fields not wired in are silently dropped — there is no compile-time check. Add the new field to both functions following the pattern of existing fields. `mergeFeatures()` / `copyFeatures()` and `mergePorts()` are examples of how compound fields are handled.
+
+**b. Update all three JSON schemas in `schemas/`**
+
+The schemas are maintained manually, derived from the OpenAPI spec. All three files must stay in sync because they share the same `WorkspaceConfiguration` sub-schema:
+
+- `schemas/workspace.json` — per-workspace config (`.kaiden/workspace.json`)
+- `schemas/agents.json` — per-agent config (`~/.kdn/config/agents.json`)
+- `schemas/projects.json` — per-project config (`~/.kdn/config/projects.json`)
+
+The `$defs` section in each file is identical. Update all three at once. The source of truth is the OpenAPI spec:
+
+```bash
+gh api repos/openkaiden/kdn-api/contents/workspace-configuration/openapi.yaml --jq '.content' | base64 -d
+```
+
+**c. Check `pkg/config/config.go` validation**
+
+The `validate()` function may need updating if new fields introduce new constraints.
+
+**d. Check `pkg/config/workspaceupdater.go` and `projectsupdater.go`**
+
+These updaters manipulate specific fields. New fields exposed to users may warrant new updater methods.
+
+### 3. If CLI types (`api.*`) changed
+
+`api.*` types are used in `pkg/cmd/conversion.go`. Check that `instanceToWorkspace()` and related functions still produce valid output for any renamed or added fields:
+
+```bash
+grep -n "api\." pkg/cmd/conversion.go
+```
+
+### 4. If `WorkspaceConfiguration` type changes affect the config merger tests
+
+`pkg/config/merger_test.go` tests `Merge()` exhaustively. New fields need corresponding test cases.
+
+## Where `workspace.WorkspaceConfiguration` is used
+
+Every package that reads or writes workspace config imports `workspace-configuration/go`. To audit impact of a type change:
+
+```bash
+grep -rn "workspace\." pkg/ --include="*.go" | grep -v "_test.go" | grep -v "^Binary"
+```
+
+Key locations:
+- `pkg/config/` — loading, merging, and updating config files
+- `pkg/runtime/podman/create.go` — consuming config when creating containers
+- `pkg/runtime/openshell/create.go` — consuming config for OpenShell workspaces
+- `pkg/agent/*.go` — reading skills, MCP, and environment from config
+- `pkg/autoconf/` — writing config entries discovered from the environment

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,6 +76,8 @@ release:
   github:
     owner: openkaiden
     name: kdn
+  extra_files:
+    - glob: schemas/*.json
   footer: |
 
     ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,6 +564,22 @@ All markdown files (*.md) in this repository must follow these standards:
 - `text` - Plain text output, error messages, or generic content
 - `markdown` - Markdown examples
 
+## JSON Schemas
+
+JSON Schemas (Draft-07) for the configuration files are stored in `schemas/`:
+
+| File | Describes |
+|------|-----------|
+| `schemas/workspace.json` | `.kaiden/workspace.json` (per-workspace config) |
+| `schemas/agents.json` | `~/.kdn/config/agents.json` (per-agent overrides) |
+| `schemas/projects.json` | `~/.kdn/config/projects.json` (per-project overrides) |
+
+All three files are self-contained (no cross-file `$ref`) so editors and validators can use them without a resolver. They are published automatically to each GitHub release via the `extra_files` entry in `.goreleaser.yaml`.
+
+**Keep schemas in sync with the config model.** When `WorkspaceConfiguration` or any of its sub-types change in `kdn-api`, update all three schema files to match.
+
+**For the full kdn-api update workflow (bumping, merger, schemas, CLI types), use:** `/working-with-kdn-api`
+
 ## Copyright Headers
 
 All source files must include Apache License 2.0 copyright headers with Red Hat copyright. Use the `/copyright-headers` skill to add or update headers automatically. The current year is 2026.

--- a/README.md
+++ b/README.md
@@ -1806,6 +1806,13 @@ By default, workspace configuration is stored at:
 
 The configuration directory (containing `workspace.json`) can be customized using the `--workspace-configuration` flag when registering a workspace with `init`. The flag accepts a directory path, not the file path itself.
 
+A JSON Schema for `workspace.json` is published with each release and can be used for editor validation and auto-completion:
+```text
+https://github.com/openkaiden/kdn/releases/latest/download/workspace.json
+```
+
+When kdn creates `workspace.json` for the first time, it automatically adds a `"$schema"` entry pointing to this URL so editors (VS Code, JetBrains, etc.) pick up validation immediately.
+
 ### Configuration Structure
 
 The `workspace.json` file uses a nested JSON structure:
@@ -2403,6 +2410,14 @@ The storage directory contains:
 - `config/agents.json` - Agent-specific environment variables and mounts
 - `config/projects.json` - Project-specific and global environment variables and mounts
 - `config/<agent>/` - Agent default settings files (e.g., `config/claude/.claude.json`)
+
+JSON Schemas for `agents.json` and `projects.json` are published with each release:
+```text
+https://github.com/openkaiden/kdn/releases/latest/download/agents.json
+https://github.com/openkaiden/kdn/releases/latest/download/projects.json
+```
+
+When kdn creates either file for the first time, it automatically adds a `"$schema"` entry so editors pick up validation immediately.
 
 ### Agent Configuration File
 

--- a/pkg/config/agents.go
+++ b/pkg/config/agents.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -69,7 +68,7 @@ func NewAgentConfigUpdater(storageDir string) (AgentConfigUpdater, error) {
 func (a *agentConfigUpdater) AddEnvVar(agentName, name, value string) error {
 	configPath := filepath.Join(a.storageDir, "config", AgentsConfigFile)
 
-	agentsConfig, err := a.readAgentsFile(configPath)
+	agentsConfig, schemaURL, err := a.readAgentsFile(configPath)
 	if err != nil {
 		return err
 	}
@@ -87,7 +86,7 @@ func (a *agentConfigUpdater) AddEnvVar(agentName, name, value string) error {
 				(*cfg.Environment)[i].Value = &v
 				(*cfg.Environment)[i].Secret = nil
 				agentsConfig[agentName] = cfg
-				return a.writeAgentsFile(configPath, agentsConfig)
+				return a.writeAgentsFile(configPath, agentsConfig, schemaURL)
 			}
 		}
 		v := value
@@ -95,13 +94,13 @@ func (a *agentConfigUpdater) AddEnvVar(agentName, name, value string) error {
 	}
 
 	agentsConfig[agentName] = cfg
-	return a.writeAgentsFile(configPath, agentsConfig)
+	return a.writeAgentsFile(configPath, agentsConfig, schemaURL)
 }
 
 func (a *agentConfigUpdater) AddMount(agentName, host, target string, ro bool) error {
 	configPath := filepath.Join(a.storageDir, "config", AgentsConfigFile)
 
-	agentsConfig, err := a.readAgentsFile(configPath)
+	agentsConfig, schemaURL, err := a.readAgentsFile(configPath)
 	if err != nil {
 		return err
 	}
@@ -123,31 +122,33 @@ func (a *agentConfigUpdater) AddMount(agentName, host, target string, ro bool) e
 	}
 
 	agentsConfig[agentName] = cfg
-	return a.writeAgentsFile(configPath, agentsConfig)
+	return a.writeAgentsFile(configPath, agentsConfig, schemaURL)
 }
 
-func (a *agentConfigUpdater) readAgentsFile(configPath string) (map[string]workspace.WorkspaceConfiguration, error) {
+// readAgentsFile reads agents.json and returns the config map, the preserved
+// "$schema" URL (AgentsSchemaURL when the file is newly created), and any error.
+func (a *agentConfigUpdater) readAgentsFile(configPath string) (map[string]workspace.WorkspaceConfiguration, string, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return make(map[string]workspace.WorkspaceConfiguration), nil
+			return make(map[string]workspace.WorkspaceConfiguration), AgentsSchemaURL, nil
 		}
-		return nil, fmt.Errorf("failed to read agents config: %w", err)
+		return nil, "", fmt.Errorf("failed to read agents config: %w", err)
 	}
 
-	var agentsConfig map[string]workspace.WorkspaceConfiguration
-	if err := json.Unmarshal(data, &agentsConfig); err != nil {
-		return nil, fmt.Errorf("failed to parse agents config: %w", err)
+	agentsConfig, schemaURL, err := parseWorkspaceConfigMap(data)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to parse agents config: %w", err)
 	}
-	return agentsConfig, nil
+	return agentsConfig, schemaURL, nil
 }
 
-func (a *agentConfigUpdater) writeAgentsFile(configPath string, agentsConfig map[string]workspace.WorkspaceConfiguration) error {
+func (a *agentConfigUpdater) writeAgentsFile(configPath string, agentsConfig map[string]workspace.WorkspaceConfiguration, schemaURL string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(agentsConfig, "", "  ")
+	data, err := marshalWorkspaceConfigMap(agentsConfig, schemaURL)
 	if err != nil {
 		return fmt.Errorf("failed to marshal agents config: %w", err)
 	}
@@ -209,9 +210,9 @@ func (a *agentConfigLoader) Load(agentName string) (*workspace.WorkspaceConfigur
 		return nil, err
 	}
 
-	// Parse the JSON
-	var agentsConfig map[string]workspace.WorkspaceConfiguration
-	if err := json.Unmarshal(data, &agentsConfig); err != nil {
+	// Parse the JSON (handles optional "$schema" key alongside agent entries).
+	agentsConfig, _, err := parseWorkspaceConfigMap(data)
+	if err != nil {
 		return nil, fmt.Errorf("%w: failed to parse agents.json: %v", ErrInvalidAgentConfig, err)
 	}
 

--- a/pkg/config/agents_test.go
+++ b/pkg/config/agents_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -497,4 +498,74 @@ func TestAgentConfigUpdater_AddMount(t *testing.T) {
 			t.Errorf("expected 1 mount after duplicate, got %d", len(*cfg.Mounts))
 		}
 	})
+}
+
+// TestAgentConfigUpdater_Schema_AddedOnCreation verifies that $schema is written
+// when agents.json is created for the first time.
+func TestAgentConfigUpdater_Schema_AddedOnCreation(t *testing.T) {
+	t.Parallel()
+
+	u, _ := NewAgentConfigUpdater(t.TempDir())
+	if err := u.AddEnvVar("claude", "MY_VAR", "hello"); err != nil {
+		t.Fatalf("AddEnvVar: %v", err)
+	}
+
+	storageDir := u.(*agentConfigUpdater).storageDir
+	data, err := os.ReadFile(filepath.Join(storageDir, "config", AgentsConfigFile))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var schemaURL string
+	if err := json.Unmarshal(raw["$schema"], &schemaURL); err != nil {
+		t.Fatalf("$schema missing or not a string: %v", err)
+	}
+	if schemaURL != AgentsSchemaURL {
+		t.Errorf("expected %q, got %q", AgentsSchemaURL, schemaURL)
+	}
+}
+
+// TestAgentConfigUpdater_Schema_PreservedOnUpdate verifies that $schema survives
+// subsequent writes and is NOT added to files that were created without it.
+func TestAgentConfigUpdater_Schema_PreservedOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	// File created by kdn: $schema must survive a second write.
+	u, _ := NewAgentConfigUpdater(t.TempDir())
+	if err := u.AddEnvVar("claude", "A", "1"); err != nil {
+		t.Fatalf("AddEnvVar A: %v", err)
+	}
+	if err := u.AddEnvVar("claude", "B", "2"); err != nil {
+		t.Fatalf("AddEnvVar B: %v", err)
+	}
+
+	storageDir := u.(*agentConfigUpdater).storageDir
+	data, _ := os.ReadFile(filepath.Join(storageDir, "config", AgentsConfigFile))
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(data, &raw)
+	if _, ok := raw["$schema"]; !ok {
+		t.Error("$schema must be preserved after subsequent writes")
+	}
+
+	// Pre-existing file without $schema: must NOT gain $schema on update.
+	dir2 := t.TempDir()
+	configDir2 := filepath.Join(dir2, "config")
+	_ = os.MkdirAll(configDir2, 0700)
+	existing := []byte(`{"claude":{"environment":[{"name":"X","value":"1"}]}}`)
+	_ = os.WriteFile(filepath.Join(configDir2, AgentsConfigFile), existing, 0600)
+
+	u2, _ := NewAgentConfigUpdater(dir2)
+	if err := u2.AddEnvVar("claude", "Y", "2"); err != nil {
+		t.Fatalf("AddEnvVar on pre-existing: %v", err)
+	}
+
+	data2, _ := os.ReadFile(filepath.Join(dir2, "config", AgentsConfigFile))
+	var raw2 map[string]json.RawMessage
+	_ = json.Unmarshal(data2, &raw2)
+	if _, ok := raw2["$schema"]; ok {
+		t.Error("$schema must not be added to a pre-existing file")
+	}
 }

--- a/pkg/config/agents_test.go
+++ b/pkg/config/agents_test.go
@@ -562,9 +562,14 @@ func TestAgentConfigUpdater_Schema_PreservedOnUpdate(t *testing.T) {
 		t.Fatalf("AddEnvVar on pre-existing: %v", err)
 	}
 
-	data2, _ := os.ReadFile(filepath.Join(dir2, "config", AgentsConfigFile))
+	data2, err := os.ReadFile(filepath.Join(dir2, "config", AgentsConfigFile))
+	if err != nil {
+		t.Fatalf("reading pre-existing agents.json: %v", err)
+	}
 	var raw2 map[string]json.RawMessage
-	_ = json.Unmarshal(data2, &raw2)
+	if err := json.Unmarshal(data2, &raw2); err != nil {
+		t.Fatalf("parsing pre-existing agents.json: %v", err)
+	}
 	if _, ok := raw2["$schema"]; ok {
 		t.Error("$schema must not be added to a pre-existing file")
 	}

--- a/pkg/config/projects.go
+++ b/pkg/config/projects.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -86,9 +85,9 @@ func (p *projectConfigLoader) Load(projectID string) (*workspace.WorkspaceConfig
 		return nil, err
 	}
 
-	// Parse the JSON
-	var projectsConfig map[string]workspace.WorkspaceConfiguration
-	if err := json.Unmarshal(data, &projectsConfig); err != nil {
+	// Parse the JSON (handles optional "$schema" key alongside project entries).
+	projectsConfig, _, err := parseWorkspaceConfigMap(data)
+	if err != nil {
 		return nil, fmt.Errorf("%w: failed to parse projects.json: %v", ErrInvalidProjectConfig, err)
 	}
 

--- a/pkg/config/projectsupdater.go
+++ b/pkg/config/projectsupdater.go
@@ -19,7 +19,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,7 +65,7 @@ func NewProjectConfigUpdater(storageDir string) (ProjectConfigUpdater, error) {
 func (p *projectConfigUpdater) AddSecret(projectID string, secretName string) error {
 	configPath := filepath.Join(p.storageDir, "config", ProjectsConfigFile)
 
-	projectsConfig, err := p.readProjectsFile(configPath)
+	projectsConfig, schemaURL, err := p.readProjectsFile(configPath)
 	if err != nil {
 		return err
 	}
@@ -87,7 +86,7 @@ func (p *projectConfigUpdater) AddSecret(projectID string, secretName string) er
 
 	projectsConfig[projectID] = cfg
 
-	return p.writeProjectsFile(configPath, projectsConfig)
+	return p.writeProjectsFile(configPath, projectsConfig, schemaURL)
 }
 
 // AddMount reads projects.json, adds a mount entry for projectID, and writes the file back.
@@ -95,7 +94,7 @@ func (p *projectConfigUpdater) AddSecret(projectID string, secretName string) er
 func (p *projectConfigUpdater) AddMount(projectID, host, target string, ro bool) error {
 	configPath := filepath.Join(p.storageDir, "config", ProjectsConfigFile)
 
-	projectsConfig, err := p.readProjectsFile(configPath)
+	projectsConfig, schemaURL, err := p.readProjectsFile(configPath)
 	if err != nil {
 		return err
 	}
@@ -118,31 +117,33 @@ func (p *projectConfigUpdater) AddMount(projectID, host, target string, ro bool)
 
 	projectsConfig[projectID] = cfg
 
-	return p.writeProjectsFile(configPath, projectsConfig)
+	return p.writeProjectsFile(configPath, projectsConfig, schemaURL)
 }
 
-func (p *projectConfigUpdater) readProjectsFile(configPath string) (map[string]workspace.WorkspaceConfiguration, error) {
+// readProjectsFile reads projects.json and returns the config map, the preserved
+// "$schema" URL (ProjectsSchemaURL when the file is newly created), and any error.
+func (p *projectConfigUpdater) readProjectsFile(configPath string) (map[string]workspace.WorkspaceConfiguration, string, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return make(map[string]workspace.WorkspaceConfiguration), nil
+			return make(map[string]workspace.WorkspaceConfiguration), ProjectsSchemaURL, nil
 		}
-		return nil, fmt.Errorf("failed to read projects config: %w", err)
+		return nil, "", fmt.Errorf("failed to read projects config: %w", err)
 	}
 
-	var projectsConfig map[string]workspace.WorkspaceConfiguration
-	if err := json.Unmarshal(data, &projectsConfig); err != nil {
-		return nil, fmt.Errorf("failed to parse projects config: %w", err)
+	projectsConfig, schemaURL, err := parseWorkspaceConfigMap(data)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to parse projects config: %w", err)
 	}
-	return projectsConfig, nil
+	return projectsConfig, schemaURL, nil
 }
 
-func (p *projectConfigUpdater) writeProjectsFile(configPath string, projectsConfig map[string]workspace.WorkspaceConfiguration) error {
+func (p *projectConfigUpdater) writeProjectsFile(configPath string, projectsConfig map[string]workspace.WorkspaceConfiguration, schemaURL string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(projectsConfig, "", "  ")
+	data, err := marshalWorkspaceConfigMap(projectsConfig, schemaURL)
 	if err != nil {
 		return fmt.Errorf("failed to marshal projects config: %w", err)
 	}

--- a/pkg/config/projectsupdater_test.go
+++ b/pkg/config/projectsupdater_test.go
@@ -177,7 +177,7 @@ func TestReadProjectsFile_NonExistError(t *testing.T) {
 	}
 
 	p := &projectConfigUpdater{storageDir: dir}
-	_, err := p.readProjectsFile(configPath)
+	_, _, err := p.readProjectsFile(configPath)
 	if err == nil {
 		t.Error("expected error for directory-as-file, got nil")
 	}
@@ -198,7 +198,7 @@ func TestReadProjectsFile_InvalidJSON(t *testing.T) {
 	}
 
 	p := &projectConfigUpdater{storageDir: dir}
-	_, err := p.readProjectsFile(configPath)
+	_, _, err := p.readProjectsFile(configPath)
 	if err == nil {
 		t.Error("expected error for invalid JSON, got nil")
 	}
@@ -217,7 +217,7 @@ func TestWriteProjectsFile_MkdirAllFails(t *testing.T) {
 
 	p := &projectConfigUpdater{storageDir: dir}
 	configPath := filepath.Join(dir, "config", ProjectsConfigFile)
-	err := p.writeProjectsFile(configPath, map[string]workspace.WorkspaceConfiguration{})
+	err := p.writeProjectsFile(configPath, map[string]workspace.WorkspaceConfiguration{}, "")
 	if err == nil {
 		t.Error("expected error when config path is a file, got nil")
 	}
@@ -248,9 +248,80 @@ func TestWriteProjectsFile_WriteFileFails(t *testing.T) {
 
 	p := &projectConfigUpdater{storageDir: dir}
 	configPath := filepath.Join(configDir, ProjectsConfigFile)
-	err := p.writeProjectsFile(configPath, map[string]workspace.WorkspaceConfiguration{})
+	err := p.writeProjectsFile(configPath, map[string]workspace.WorkspaceConfiguration{}, "")
 	if err == nil {
 		t.Error("expected error writing to read-only directory, got nil")
+	}
+}
+
+// TestProjectsUpdater_Schema_AddedOnCreation verifies that $schema is written
+// when projects.json is created for the first time.
+func TestProjectsUpdater_Schema_AddedOnCreation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	updater, _ := NewProjectConfigUpdater(dir)
+	if err := updater.AddSecret("", "anthropic"); err != nil {
+		t.Fatalf("AddSecret: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config", ProjectsConfigFile))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var schemaURL string
+	if err := json.Unmarshal(raw["$schema"], &schemaURL); err != nil {
+		t.Fatalf("$schema missing or not a string: %v", err)
+	}
+	if schemaURL != ProjectsSchemaURL {
+		t.Errorf("expected %q, got %q", ProjectsSchemaURL, schemaURL)
+	}
+}
+
+// TestProjectsUpdater_Schema_PreservedOnUpdate verifies that $schema survives
+// subsequent writes and is NOT added to files that were created without it.
+func TestProjectsUpdater_Schema_PreservedOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	// File created by kdn: $schema must survive a second write.
+	dir := t.TempDir()
+	updater, _ := NewProjectConfigUpdater(dir)
+	if err := updater.AddSecret("", "first"); err != nil {
+		t.Fatalf("AddSecret first: %v", err)
+	}
+	if err := updater.AddSecret("", "second"); err != nil {
+		t.Fatalf("AddSecret second: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "config", ProjectsConfigFile))
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(data, &raw)
+	if _, ok := raw["$schema"]; !ok {
+		t.Error("$schema must be preserved after subsequent writes")
+	}
+
+	// Pre-existing file without $schema: must NOT gain $schema on update.
+	dir2 := t.TempDir()
+	configDir2 := filepath.Join(dir2, "config")
+	_ = os.MkdirAll(configDir2, 0700)
+	existing := map[string]workspace.WorkspaceConfiguration{"": {}}
+	existingData, _ := json.MarshalIndent(existing, "", "  ")
+	_ = os.WriteFile(filepath.Join(configDir2, ProjectsConfigFile), existingData, 0600)
+
+	updater2, _ := NewProjectConfigUpdater(dir2)
+	if err := updater2.AddSecret("", "anthropic"); err != nil {
+		t.Fatalf("AddSecret on pre-existing: %v", err)
+	}
+
+	data2, _ := os.ReadFile(filepath.Join(dir2, "config", ProjectsConfigFile))
+	var raw2 map[string]json.RawMessage
+	_ = json.Unmarshal(data2, &raw2)
+	if _, ok := raw2["$schema"]; ok {
+		t.Error("$schema must not be added to a pre-existing file")
 	}
 }
 
@@ -361,7 +432,8 @@ func TestAddMount_ReadError(t *testing.T) {
 	}
 }
 
-// readProjectsFile is a test helper that reads and parses the projects.json file.
+// readProjectsFile is a test helper that reads and parses the projects.json file,
+// filtering out the "$schema" key so callers only see workspace configuration entries.
 func readProjectsFile(t *testing.T, storageDir string) map[string]workspace.WorkspaceConfiguration {
 	t.Helper()
 	path := filepath.Join(storageDir, "config", ProjectsConfigFile)
@@ -369,8 +441,8 @@ func readProjectsFile(t *testing.T, storageDir string) map[string]workspace.Work
 	if err != nil {
 		t.Fatalf("read projects file: %v", err)
 	}
-	var cfg map[string]workspace.WorkspaceConfiguration
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	cfg, _, err := parseWorkspaceConfigMap(data)
+	if err != nil {
 		t.Fatalf("parse projects file: %v", err)
 	}
 	return cfg

--- a/pkg/config/projectsupdater_test.go
+++ b/pkg/config/projectsupdater_test.go
@@ -317,9 +317,14 @@ func TestProjectsUpdater_Schema_PreservedOnUpdate(t *testing.T) {
 		t.Fatalf("AddSecret on pre-existing: %v", err)
 	}
 
-	data2, _ := os.ReadFile(filepath.Join(dir2, "config", ProjectsConfigFile))
+	data2, err := os.ReadFile(filepath.Join(dir2, "config", ProjectsConfigFile))
+	if err != nil {
+		t.Fatalf("reading pre-existing projects.json: %v", err)
+	}
 	var raw2 map[string]json.RawMessage
-	_ = json.Unmarshal(data2, &raw2)
+	if err := json.Unmarshal(data2, &raw2); err != nil {
+		t.Fatalf("parsing pre-existing projects.json: %v", err)
+	}
 	if _, ok := raw2["$schema"]; ok {
 		t.Error("$schema must not be added to a pre-existing file")
 	}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+)
+
+const (
+	// WorkspaceSchemaURL is the JSON Schema URL for .kaiden/workspace.json.
+	WorkspaceSchemaURL = "https://github.com/openkaiden/kdn/releases/latest/download/workspace.json"
+	// AgentsSchemaURL is the JSON Schema URL for ~/.kdn/config/agents.json.
+	AgentsSchemaURL = "https://github.com/openkaiden/kdn/releases/latest/download/agents.json"
+	// ProjectsSchemaURL is the JSON Schema URL for ~/.kdn/config/projects.json.
+	ProjectsSchemaURL = "https://github.com/openkaiden/kdn/releases/latest/download/projects.json"
+)
+
+// parseWorkspaceConfigMap parses a JSON object that may contain a "$schema" key
+// alongside workspace configuration entries. The "$schema" value is returned
+// separately; all other keys are parsed as workspace.WorkspaceConfiguration values.
+func parseWorkspaceConfigMap(data []byte) (map[string]workspace.WorkspaceConfiguration, string, error) {
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return nil, "", err
+	}
+
+	var schemaURL string
+	if s, ok := rawMap["$schema"]; ok {
+		_ = json.Unmarshal(s, &schemaURL)
+		delete(rawMap, "$schema")
+	}
+
+	result := make(map[string]workspace.WorkspaceConfiguration, len(rawMap))
+	for k, v := range rawMap {
+		var cfg workspace.WorkspaceConfiguration
+		if err := json.Unmarshal(v, &cfg); err != nil {
+			return nil, "", fmt.Errorf("key %q: %w", k, err)
+		}
+		result[k] = cfg
+	}
+	return result, schemaURL, nil
+}
+
+// marshalWorkspaceConfigMap marshals the map with an optional "$schema" key.
+// Because Go sorts map keys alphabetically and "$" sorts before all lowercase
+// letters, "$schema" always appears first in the output.
+func marshalWorkspaceConfigMap(configs map[string]workspace.WorkspaceConfiguration, schemaURL string) ([]byte, error) {
+	if schemaURL == "" {
+		return json.MarshalIndent(configs, "", "  ")
+	}
+
+	rawMap := make(map[string]json.RawMessage, len(configs)+1)
+	schemaRaw, _ := json.Marshal(schemaURL)
+	rawMap["$schema"] = schemaRaw
+	for k, v := range configs {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("key %q: %w", k, err)
+		}
+		rawMap[k] = raw
+	}
+	return json.MarshalIndent(rawMap, "", "  ")
+}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -65,6 +65,7 @@ func marshalWorkspaceConfigMap(configs map[string]workspace.WorkspaceConfigurati
 	}
 
 	rawMap := make(map[string]json.RawMessage, len(configs)+1)
+	// json.Marshal never fails for a plain string value, so the error is ignored.
 	schemaRaw, _ := json.Marshal(schemaURL)
 	rawMap["$schema"] = schemaRaw
 	for k, v := range configs {

--- a/pkg/config/workspaceupdater.go
+++ b/pkg/config/workspaceupdater.go
@@ -28,6 +28,14 @@ import (
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
+// workspaceConfigFile is the on-disk representation of workspace.json. Embedding
+// workspace.WorkspaceConfiguration promotes all its fields so callers can access
+// them directly, while Schema carries the optional JSON Schema URL.
+type workspaceConfigFile struct {
+	Schema string `json:"$schema,omitempty"`
+	workspace.WorkspaceConfiguration
+}
+
 // WorkspaceConfigUpdater manages the local workspace configuration file.
 type WorkspaceConfigUpdater interface {
 	// AddSecret appends secretName to the Secrets list of the workspace config,
@@ -75,7 +83,7 @@ func NewWorkspaceConfigUpdater(configDir string) (WorkspaceConfigUpdater, error)
 func (w *workspaceConfigUpdater) AddEnvVar(name, value string) error {
 	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
 
-	cfg, err := w.readConfig(configPath)
+	cfg, isNew, err := w.readConfig(configPath)
 	if err != nil {
 		return err
 	}
@@ -90,20 +98,20 @@ func (w *workspaceConfigUpdater) AddEnvVar(name, value string) error {
 				v := value
 				(*cfg.Environment)[i].Value = &v
 				(*cfg.Environment)[i].Secret = nil
-				return w.writeConfig(configPath, cfg)
+				return w.writeConfig(configPath, cfg, isNew)
 			}
 		}
 		v := value
 		*cfg.Environment = append(*cfg.Environment, workspace.EnvironmentVariable{Name: name, Value: &v})
 	}
 
-	return w.writeConfig(configPath, cfg)
+	return w.writeConfig(configPath, cfg, isNew)
 }
 
 func (w *workspaceConfigUpdater) AddMount(host, target string, ro bool) error {
 	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
 
-	cfg, err := w.readConfig(configPath)
+	cfg, isNew, err := w.readConfig(configPath)
 	if err != nil {
 		return err
 	}
@@ -122,13 +130,13 @@ func (w *workspaceConfigUpdater) AddMount(host, target string, ro bool) error {
 		*cfg.Mounts = append(*cfg.Mounts, workspace.Mount{Host: host, Target: target, Ro: &roVal})
 	}
 
-	return w.writeConfig(configPath, cfg)
+	return w.writeConfig(configPath, cfg, isNew)
 }
 
 func (w *workspaceConfigUpdater) AddSecret(secretName string) error {
 	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
 
-	cfg, err := w.readConfig(configPath)
+	cfg, isNew, err := w.readConfig(configPath)
 	if err != nil {
 		return err
 	}
@@ -145,33 +153,33 @@ func (w *workspaceConfigUpdater) AddSecret(secretName string) error {
 		*cfg.Secrets = append(*cfg.Secrets, secretName)
 	}
 
-	return w.writeConfig(configPath, cfg)
+	return w.writeConfig(configPath, cfg, isNew)
 }
 
-func (w *workspaceConfigUpdater) readConfig(configPath string) (*workspace.WorkspaceConfiguration, error) {
+func (w *workspaceConfigUpdater) readConfig(configPath string) (*workspaceConfigFile, bool, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &workspace.WorkspaceConfiguration{}, nil
+			return &workspaceConfigFile{}, true, nil
 		}
-		return nil, fmt.Errorf("failed to read workspace config: %w", err)
+		return nil, false, fmt.Errorf("failed to read workspace config: %w", err)
 	}
 
 	if len(bytes.TrimSpace(data)) == 0 {
-		return &workspace.WorkspaceConfiguration{}, nil
+		return &workspaceConfigFile{}, false, nil
 	}
 
-	var cfg workspace.WorkspaceConfiguration
+	var cfg workspaceConfigFile
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse workspace config: %w", err)
+		return nil, false, fmt.Errorf("failed to parse workspace config: %w", err)
 	}
-	return &cfg, nil
+	return &cfg, false, nil
 }
 
 func (w *workspaceConfigUpdater) AddPort(port int) error {
 	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
 
-	cfg, err := w.readConfig(configPath)
+	cfg, isNew, err := w.readConfig(configPath)
 	if err != nil {
 		return err
 	}
@@ -188,13 +196,13 @@ func (w *workspaceConfigUpdater) AddPort(port int) error {
 		*cfg.Ports = append(*cfg.Ports, port)
 	}
 
-	return w.writeConfig(configPath, cfg)
+	return w.writeConfig(configPath, cfg, isNew)
 }
 
 func (w *workspaceConfigUpdater) AddFeature(featureID string, options map[string]interface{}) error {
 	configPath := filepath.Join(w.configDir, WorkspaceConfigFile)
 
-	cfg, err := w.readConfig(configPath)
+	cfg, isNew, err := w.readConfig(configPath)
 	if err != nil {
 		return err
 	}
@@ -209,10 +217,14 @@ func (w *workspaceConfigUpdater) AddFeature(featureID string, options map[string
 		(*cfg.Features)[featureID] = options
 	}
 
-	return w.writeConfig(configPath, cfg)
+	return w.writeConfig(configPath, cfg, isNew)
 }
 
-func (w *workspaceConfigUpdater) writeConfig(configPath string, cfg *workspace.WorkspaceConfiguration) error {
+func (w *workspaceConfigUpdater) writeConfig(configPath string, cfg *workspaceConfigFile, isNew bool) error {
+	if isNew {
+		cfg.Schema = WorkspaceSchemaURL
+	}
+
 	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}

--- a/pkg/config/workspaceupdater_test.go
+++ b/pkg/config/workspaceupdater_test.go
@@ -168,7 +168,7 @@ func TestWorkspaceUpdater_ReadConfig_NonExistError(t *testing.T) {
 	}
 
 	w := &workspaceConfigUpdater{configDir: dir}
-	if _, err := w.readConfig(configPath); err == nil {
+	if _, _, err := w.readConfig(configPath); err == nil {
 		t.Error("expected error for directory-as-file, got nil")
 	}
 }
@@ -185,7 +185,7 @@ func TestWorkspaceUpdater_ReadConfig_InvalidJSON(t *testing.T) {
 	}
 
 	w := &workspaceConfigUpdater{configDir: dir}
-	if _, err := w.readConfig(configPath); err == nil {
+	if _, _, err := w.readConfig(configPath); err == nil {
 		t.Error("expected error for invalid JSON, got nil")
 	}
 }
@@ -203,7 +203,7 @@ func TestWorkspaceUpdater_WriteConfig_MkdirAllFails(t *testing.T) {
 
 	w := &workspaceConfigUpdater{configDir: filepath.Join(dir, "kaiden")}
 	configPath := filepath.Join(dir, "kaiden", WorkspaceConfigFile)
-	if err := w.writeConfig(configPath, &workspace.WorkspaceConfiguration{}); err == nil {
+	if err := w.writeConfig(configPath, &workspaceConfigFile{}, false); err == nil {
 		t.Error("expected error when config path is a file, got nil")
 	}
 }
@@ -228,8 +228,83 @@ func TestWorkspaceUpdater_WriteConfig_WriteFileFails(t *testing.T) {
 
 	w := &workspaceConfigUpdater{configDir: dir}
 	configPath := filepath.Join(dir, WorkspaceConfigFile)
-	if err := w.writeConfig(configPath, &workspace.WorkspaceConfiguration{}); err == nil {
+	if err := w.writeConfig(configPath, &workspaceConfigFile{}, false); err == nil {
 		t.Error("expected error writing to read-only directory, got nil")
+	}
+}
+
+// TestWorkspaceUpdater_Schema_AddedOnCreation verifies that $schema is written
+// when workspace.json is created for the first time.
+func TestWorkspaceUpdater_Schema_AddedOnCreation(t *testing.T) {
+	t.Parallel()
+
+	u, _ := NewWorkspaceConfigUpdater(t.TempDir())
+	if err := u.AddSecret("github"); err != nil {
+		t.Fatalf("AddSecret: %v", err)
+	}
+
+	dir := u.(*workspaceConfigUpdater).configDir
+	data, err := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var schemaURL string
+	if err := json.Unmarshal(raw["$schema"], &schemaURL); err != nil {
+		t.Fatalf("$schema missing or not a string: %v", err)
+	}
+	if schemaURL != WorkspaceSchemaURL {
+		t.Errorf("expected %q, got %q", WorkspaceSchemaURL, schemaURL)
+	}
+}
+
+// TestWorkspaceUpdater_Schema_PreservedOnUpdate verifies that $schema survives
+// subsequent writes and is NOT added to files that were created without it.
+func TestWorkspaceUpdater_Schema_PreservedOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create a file manually without $schema (simulates a pre-existing user file).
+	existing := workspace.WorkspaceConfiguration{}
+	s := []string{"existing-secret"}
+	existing.Secrets = &s
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, WorkspaceConfigFile), data, 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	u, _ := NewWorkspaceConfigUpdater(dir)
+	if err := u.AddSecret("new-secret"); err != nil {
+		t.Fatalf("AddSecret: %v", err)
+	}
+
+	// $schema must NOT be injected into a pre-existing file.
+	updated, _ := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(updated, &raw)
+	if _, ok := raw["$schema"]; ok {
+		t.Error("$schema must not be added to a pre-existing file")
+	}
+
+	// Create a fresh file via kdn and then update it: $schema must be preserved.
+	dir2 := t.TempDir()
+	u2, _ := NewWorkspaceConfigUpdater(dir2)
+	if err := u2.AddSecret("first"); err != nil {
+		t.Fatalf("AddSecret first: %v", err)
+	}
+	if err := u2.AddSecret("second"); err != nil {
+		t.Fatalf("AddSecret second: %v", err)
+	}
+
+	updated2, _ := os.ReadFile(filepath.Join(dir2, WorkspaceConfigFile))
+	var raw2 map[string]json.RawMessage
+	_ = json.Unmarshal(updated2, &raw2)
+	if _, ok := raw2["$schema"]; !ok {
+		t.Error("$schema must be preserved after subsequent writes")
 	}
 }
 

--- a/pkg/config/workspaceupdater_test.go
+++ b/pkg/config/workspaceupdater_test.go
@@ -283,9 +283,14 @@ func TestWorkspaceUpdater_Schema_PreservedOnUpdate(t *testing.T) {
 	}
 
 	// $schema must NOT be injected into a pre-existing file.
-	updated, _ := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	updated, err := os.ReadFile(filepath.Join(dir, WorkspaceConfigFile))
+	if err != nil {
+		t.Fatalf("reading updated workspace.json: %v", err)
+	}
 	var raw map[string]json.RawMessage
-	_ = json.Unmarshal(updated, &raw)
+	if err := json.Unmarshal(updated, &raw); err != nil {
+		t.Fatalf("parsing updated workspace.json: %v", err)
+	}
 	if _, ok := raw["$schema"]; ok {
 		t.Error("$schema must not be added to a pre-existing file")
 	}

--- a/schemas/agents.json
+++ b/schemas/agents.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Agents Configuration",
+  "description": "Per-agent workspace configuration overrides (~/.kdn/config/agents.json). Keys are agent names (e.g. \"claude\", \"goose\").",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/WorkspaceConfiguration" },
+  "$defs": {
+    "WorkspaceConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mounts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Mount" },
+          "description": "List of directories to mount in the workspace. Supports $SOURCES (workspace sources directory) and $HOME (user home directory) variables."
+        },
+        "environment": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EnvironmentVariable" }
+        },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of folders containing skills (SKILL.md and related files) to be provided to the agent."
+        },
+        "mcp": { "$ref": "#/$defs/McpConfiguration" },
+        "network": { "$ref": "#/$defs/NetworkConfiguration" },
+        "ports": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "description": "List of TCP ports to expose from the workspace."
+        },
+        "secrets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of secret names to inject into the workspace."
+        },
+        "features": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Features to add to the workspace, compatible with devcontainers features (https://containers.dev/implementors/features/). Keys are feature identifiers (e.g. OCI image references), values are feature-specific options."
+        }
+      }
+    },
+    "NetworkConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["allow", "deny"],
+          "default": "deny",
+          "description": "Network access mode. 'allow' permits all. 'deny' blocks everything except the specified hosts/CIDRs. Defaults to 'deny'."
+        },
+        "hosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of hostnames to allow in deny mode."
+        }
+      }
+    },
+    "McpConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "servers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/McpServer" },
+          "description": "List of URL-based MCP servers."
+        },
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/McpCommand" },
+          "description": "List of command-based MCP servers."
+        }
+      }
+    },
+    "McpServer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the MCP server."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the MCP server."
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "HTTP headers to send with requests to the MCP server."
+        }
+      }
+    },
+    "McpCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the MCP server."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command to run to start the MCP server."
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments to pass to the command."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables to set for the command."
+        }
+      }
+    },
+    "Mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "target"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Path in the host filesystem. Can use $SOURCES or $HOME variables (e.g., \"$SOURCES/../main\", \"$HOME/.gitconfig\", \"/absolute/path\")."
+        },
+        "target": {
+          "type": "string",
+          "description": "Path in the workspace filesystem where the host path will be mounted. Can use $SOURCES or $HOME variables."
+        },
+        "ro": {
+          "type": "boolean",
+          "default": false,
+          "description": "Mount as read-only. Defaults to false (read-write)."
+        }
+      }
+    },
+    "EnvironmentVariable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the environment variable."
+        },
+        "value": {
+          "type": "string",
+          "description": "Value of the environment variable (mutually exclusive with secret)."
+        },
+        "secret": {
+          "type": "string",
+          "description": "Name of the secret containing the value (mutually exclusive with value)."
+        }
+      }
+    }
+  }
+}

--- a/schemas/agents.json
+++ b/schemas/agents.json
@@ -152,6 +152,16 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["name"],
+      "oneOf": [
+        {
+          "required": ["value"],
+          "not": { "required": ["secret"] }
+        },
+        {
+          "required": ["secret"],
+          "not": { "required": ["value"] }
+        }
+      ],
       "properties": {
         "name": {
           "type": "string",

--- a/schemas/projects.json
+++ b/schemas/projects.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Projects Configuration",
+  "description": "Per-project workspace configuration overrides (~/.kdn/config/projects.json). Keys are project identifiers; use \"\" (empty string) for the global entry applied to all projects.",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/WorkspaceConfiguration" },
+  "$defs": {
+    "WorkspaceConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mounts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Mount" },
+          "description": "List of directories to mount in the workspace. Supports $SOURCES (workspace sources directory) and $HOME (user home directory) variables."
+        },
+        "environment": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EnvironmentVariable" }
+        },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of folders containing skills (SKILL.md and related files) to be provided to the agent."
+        },
+        "mcp": { "$ref": "#/$defs/McpConfiguration" },
+        "network": { "$ref": "#/$defs/NetworkConfiguration" },
+        "ports": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "description": "List of TCP ports to expose from the workspace."
+        },
+        "secrets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of secret names to inject into the workspace."
+        },
+        "features": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Features to add to the workspace, compatible with devcontainers features (https://containers.dev/implementors/features/). Keys are feature identifiers (e.g. OCI image references), values are feature-specific options."
+        }
+      }
+    },
+    "NetworkConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["allow", "deny"],
+          "default": "deny",
+          "description": "Network access mode. 'allow' permits all. 'deny' blocks everything except the specified hosts/CIDRs. Defaults to 'deny'."
+        },
+        "hosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of hostnames to allow in deny mode."
+        }
+      }
+    },
+    "McpConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "servers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/McpServer" },
+          "description": "List of URL-based MCP servers."
+        },
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/McpCommand" },
+          "description": "List of command-based MCP servers."
+        }
+      }
+    },
+    "McpServer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the MCP server."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the MCP server."
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "HTTP headers to send with requests to the MCP server."
+        }
+      }
+    },
+    "McpCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the MCP server."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command to run to start the MCP server."
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments to pass to the command."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables to set for the command."
+        }
+      }
+    },
+    "Mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "target"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Path in the host filesystem. Can use $SOURCES or $HOME variables (e.g., \"$SOURCES/../main\", \"$HOME/.gitconfig\", \"/absolute/path\")."
+        },
+        "target": {
+          "type": "string",
+          "description": "Path in the workspace filesystem where the host path will be mounted. Can use $SOURCES or $HOME variables."
+        },
+        "ro": {
+          "type": "boolean",
+          "default": false,
+          "description": "Mount as read-only. Defaults to false (read-write)."
+        }
+      }
+    },
+    "EnvironmentVariable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the environment variable."
+        },
+        "value": {
+          "type": "string",
+          "description": "Value of the environment variable (mutually exclusive with secret)."
+        },
+        "secret": {
+          "type": "string",
+          "description": "Name of the secret containing the value (mutually exclusive with value)."
+        }
+      }
+    }
+  }
+}

--- a/schemas/projects.json
+++ b/schemas/projects.json
@@ -152,6 +152,16 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["name"],
+      "oneOf": [
+        {
+          "required": ["value"],
+          "not": { "required": ["secret"] }
+        },
+        {
+          "required": ["secret"],
+          "not": { "required": ["value"] }
+        }
+      ],
       "properties": {
         "name": {
           "type": "string",

--- a/schemas/workspace.json
+++ b/schemas/workspace.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Workspace Configuration",
+  "$ref": "#/$defs/WorkspaceConfiguration",
+  "$defs": {
+    "WorkspaceConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mounts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Mount" },
+          "description": "List of directories to mount in the workspace. Supports $SOURCES (workspace sources directory) and $HOME (user home directory) variables."
+        },
+        "environment": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EnvironmentVariable" }
+        },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of folders containing skills (SKILL.md and related files) to be provided to the agent."
+        },
+        "mcp": { "$ref": "#/$defs/McpConfiguration" },
+        "network": { "$ref": "#/$defs/NetworkConfiguration" },
+        "ports": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "description": "List of TCP ports to expose from the workspace."
+        },
+        "secrets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of secret names to inject into the workspace."
+        },
+        "features": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Features to add to the workspace, compatible with devcontainers features (https://containers.dev/implementors/features/). Keys are feature identifiers (e.g. OCI image references), values are feature-specific options."
+        }
+      }
+    },
+    "NetworkConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["allow", "deny"],
+          "default": "deny",
+          "description": "Network access mode. 'allow' permits all. 'deny' blocks everything except the specified hosts/CIDRs. Defaults to 'deny'."
+        },
+        "hosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of hostnames to allow in deny mode."
+        }
+      }
+    },
+    "McpConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "servers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/McpServer" },
+          "description": "List of URL-based MCP servers."
+        },
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/McpCommand" },
+          "description": "List of command-based MCP servers."
+        }
+      }
+    },
+    "McpServer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the MCP server."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the MCP server."
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "HTTP headers to send with requests to the MCP server."
+        }
+      }
+    },
+    "McpCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the MCP server."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command to run to start the MCP server."
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments to pass to the command."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables to set for the command."
+        }
+      }
+    },
+    "Mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "target"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Path in the host filesystem. Can use $SOURCES or $HOME variables (e.g., \"$SOURCES/../main\", \"$HOME/.gitconfig\", \"/absolute/path\")."
+        },
+        "target": {
+          "type": "string",
+          "description": "Path in the workspace filesystem where the host path will be mounted. Can use $SOURCES or $HOME variables."
+        },
+        "ro": {
+          "type": "boolean",
+          "default": false,
+          "description": "Mount as read-only. Defaults to false (read-write)."
+        }
+      }
+    },
+    "EnvironmentVariable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the environment variable."
+        },
+        "value": {
+          "type": "string",
+          "description": "Value of the environment variable (mutually exclusive with secret)."
+        },
+        "secret": {
+          "type": "string",
+          "description": "Name of the secret containing the value (mutually exclusive with value)."
+        }
+      }
+    }
+  }
+}

--- a/schemas/workspace.json
+++ b/schemas/workspace.json
@@ -150,6 +150,16 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["name"],
+      "oneOf": [
+        {
+          "required": ["value"],
+          "not": { "required": ["secret"] }
+        },
+        {
+          "required": ["secret"],
+          "not": { "required": ["value"] }
+        }
+      ],
       "properties": {
         "name": {
           "type": "string",


### PR DESCRIPTION
Add JSON Schema (Draft-07) files for workspace.json, agents.json, and projects.json, published automatically with each release via goreleaser's extra_files.

When kdn creates a config file for the first time it injects a "$schema" entry pointing to the latest release URL, so editors (VS Code, JetBrains, etc.) pick up validation without manual setup. Subsequent updates preserve an existing "$schema" and never add one to pre-existing files.

Also adds a working-with-kdn-api skill documenting the full module bump workflow.

Closes #482