### PR TITLE
chore(OpenShell): migrate to v0.0.39

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,9 @@ The runtime system provides a pluggable architecture for managing workspaces on 
 
 The OpenShell runtime downloads three binaries (`openshell`, `openshell-gateway`, `openshell-driver-vm`) from official GitHub releases at `https://github.com/NVIDIA/OpenShell/releases`.
 
-**Default version constant:** `pkg/runtime/openshell/version.go` defines `DefaultVersion` (currently `v0.0.37`). To bump the default, edit this single constant.
+**Default version constant:** `pkg/runtime/openshell/version.go` defines `DefaultVersion` (currently `v0.0.39`). To bump the default, update **both** files:
+1. `pkg/runtime/openshell/version.go` — change the `DefaultVersion` constant
+2. `AGENTS.md` — update the version mentioned in this section (the "currently `vX.Y.Z`" parenthetical above)
 
 **`--openshell-version` flag:** Users can override the version at `kdn init` time (e.g., `kdn init --openshell-version v0.1.0`). The flag value flows through `RuntimeOptions["openshell-version"]` and is read in `Create()` before binaries are downloaded.
 

--- a/pkg/runtime/openshell/version.go
+++ b/pkg/runtime/openshell/version.go
@@ -16,4 +16,4 @@ package openshell
 
 // DefaultVersion is the default OpenShell release tag used to download binaries.
 // Override at runtime with the --openshell-version flag on kdn init.
-const DefaultVersion = "v0.0.37"
+const DefaultVersion = "v0.0.39"


### PR DESCRIPTION
allows to start again vm sandboxes