### PR TITLE
feat(init): add --dump-config flag to inspect merged configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2965,7 +2965,7 @@ kdn init [sources-directory] [flags]
 - `--verbose, -v` - Show detailed output including all workspace information
 - `--output, -o <format>` - Output format (supported: `json`)
 - `--show-logs` - Show stdout and stderr from runtime commands (cannot be combined with `--output json`)
-- `--dump-config` - Print the merged workspace configuration as JSON and exit without creating the workspace; `--start`, `--name`, `--verbose`, `--output`, `--show-logs`, and runtime-specific flags are ignored
+- `--dump-config` - Print the merged workspace configuration as JSON and exit without creating the workspace; only `--agent`, `--project`, and `--workspace-configuration` affect the output — all other flags (`--start`, `--name`, `--verbose`, `--output`, `--show-logs`, and runtime-specific flags) are ignored
 - `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -2965,6 +2965,7 @@ kdn init [sources-directory] [flags]
 - `--verbose, -v` - Show detailed output including all workspace information
 - `--output, -o <format>` - Output format (supported: `json`)
 - `--show-logs` - Show stdout and stderr from runtime commands (cannot be combined with `--output json`)
+- `--dump-config` - Print the merged workspace configuration as JSON and exit without creating the workspace; `--start`, `--name`, `--verbose`, `--output`, `--show-logs`, and runtime-specific flags are ignored
 - `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
 
 #### Examples
@@ -3117,6 +3118,21 @@ kdn init -r fake -a claude -o json -v
 kdn init --runtime podman --agent claude --show-logs
 ```
 
+**Inspect the merged configuration without creating the workspace:**
+```bash
+kdn init --runtime podman --agent claude --dump-config
+```
+Output (example showing a global `.gitconfig` mount and a GitHub token secret merged from `~/.kdn/config/projects.json` with a port defined in the `workspace.json` file):
+```json
+{
+  "secrets": ["my-github-token"],
+  "mounts": [
+    { "host": "$HOME/.gitconfig", "target": "$HOME/.gitconfig", "ro": true }
+  ],
+  "ports": [3000]
+}
+```
+
 #### Workspace Naming
 
 - If `--name` is not provided, the name is automatically generated from the last component of the sources directory path
@@ -3233,6 +3249,7 @@ kdn init /tmp/workspace --runtime podman --agent claude
 - Without `--verbose`, JSON output returns only the workspace ID
 - With `--verbose`, JSON output includes full workspace details (ID, name, agent, model, paths); the `model` field is only present when a model was explicitly set with `--model`
 - Use `--show-logs` to display the full stdout and stderr from runtime commands (e.g., `podman build` output during image creation)
+- **Dry-run / config inspection**: Use `--dump-config` to print the merged workspace configuration (from all config levels: workspace, project, global, agent) as JSON without creating the workspace. The flag can be combined with any other `init` flags; only `--agent`, `--project`, and `--workspace-configuration` affect the output — all other flags are ignored
 - **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure
 
 ### `workspace list` - List All Registered Workspaces

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -56,6 +56,7 @@ type initCmd struct {
 	output             string
 	showLogs           bool
 	start              bool
+	dumpConfig         bool
 	runtimeOptions     map[string]string
 }
 
@@ -254,9 +255,24 @@ func (i *initCmd) run(cmd *cobra.Command, args []string) error {
 		Agent:           i.agent,
 		Model:           i.model,
 		RuntimeOptions:  i.runtimeOptions,
+		DumpConfig:      i.dumpConfig,
 	})
 	if err != nil {
 		return outputErrorIfJSON(cmd, i.output, err)
+	}
+
+	// DumpConfig mode: output the merged config as JSON and return early.
+	if i.dumpConfig {
+		mergedConfig := addedInstance.GetMergedConfig()
+		if mergedConfig == nil {
+			mergedConfig = &workspace.WorkspaceConfiguration{}
+		}
+		jsonData, err := json.MarshalIndent(mergedConfig, "", "  ")
+		if err != nil {
+			return outputErrorIfJSON(cmd, i.output, fmt.Errorf("failed to marshal config to JSON: %w", err))
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+		return nil
 	}
 
 	// Start the workspace if auto-start is enabled
@@ -338,6 +354,9 @@ The workspace configuration directory defaults to .kaiden/ inside the sources di
 		Example: `# Register current directory as workspace
 kdn init --runtime podman --agent claude
 
+# Dump the merged configuration without creating the workspace
+kdn init --runtime podman --agent claude --dump-config
+
 # Register specific directory as workspace
 kdn init --runtime podman --agent claude /path/to/project
 
@@ -396,6 +415,9 @@ kdn init --runtime podman --agent claude --show-logs`,
 
 	// Add start flag
 	cmd.Flags().BoolVar(&c.start, "start", false, "Start the workspace after registration (can also be set via KDN_INIT_AUTO_START environment variable)")
+
+	// Add dump-config flag
+	cmd.Flags().BoolVar(&c.dumpConfig, "dump-config", false, "Print the merged workspace configuration as JSON and exit without creating the workspace; --start, --name, --verbose, --output, --show-logs, and runtime-specific flags are ignored")
 
 	// Add verbose flag
 	cmd.Flags().BoolVarP(&c.verbose, "verbose", "v", false, "Show detailed output")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -417,7 +417,7 @@ kdn init --runtime podman --agent claude --show-logs`,
 	cmd.Flags().BoolVar(&c.start, "start", false, "Start the workspace after registration (can also be set via KDN_INIT_AUTO_START environment variable)")
 
 	// Add dump-config flag
-	cmd.Flags().BoolVar(&c.dumpConfig, "dump-config", false, "Print the merged workspace configuration as JSON and exit without creating the workspace; --start, --name, --verbose, --output, --show-logs, and runtime-specific flags are ignored")
+	cmd.Flags().BoolVar(&c.dumpConfig, "dump-config", false, "Print the merged workspace configuration as JSON and exit without creating the workspace; only --agent, --project, and --workspace-configuration affect the output — all other flags (--start, --name, --verbose, --output, --show-logs, and runtime-specific flags) are ignored")
 
 	// Add verbose flag
 	cmd.Flags().BoolVarP(&c.verbose, "verbose", "v", false, "Show detailed output")

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -2508,6 +2508,123 @@ func TestInitCmd_E2E_SpacesInPathSanitizesName(t *testing.T) {
 	}
 }
 
+func TestInitCmd_DumpConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("outputs merged config as JSON without storing instance", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", "--agent", "test-agent", "--dump-config", sourcesDir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Output must be valid JSON
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput was: %s", err, buf.String())
+		}
+
+		// No instance should be stored
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		runtimesetup.RegisterAll(manager) //nolint:errcheck
+		instancesList, err := manager.List()
+		if err != nil {
+			t.Fatalf("Failed to list instances: %v", err)
+		}
+		if len(instancesList) != 0 {
+			t.Errorf("Expected 0 stored instances after --dump-config, got %d", len(instancesList))
+		}
+	})
+
+	t.Run("reflects workspace config in output", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		// Write workspace.json with an env var
+		configDir := filepath.Join(sourcesDir, ".kaiden")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config dir: %v", err)
+		}
+		workspaceJSON := `{"environment":[{"name":"MY_VAR","value":"my-value"}]}`
+		if err := os.WriteFile(filepath.Join(configDir, "workspace.json"), []byte(workspaceJSON), 0644); err != nil {
+			t.Fatalf("Failed to write workspace.json: %v", err)
+		}
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", "--agent", "test-agent", "--dump-config", sourcesDir})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput was: %s", err, buf.String())
+		}
+
+		envVars, ok := result["environment"].([]any)
+		if !ok || len(envVars) == 0 {
+			t.Fatalf("Expected environment field in output, got %v", result)
+		}
+		envVar, ok := envVars[0].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected environment entry to be an object, got %T", envVars[0])
+		}
+		if envVar["name"] != "MY_VAR" {
+			t.Errorf("Expected MY_VAR, got %v", envVar["name"])
+		}
+	})
+
+	t.Run("can be combined with --start (start is silently skipped)", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		rootCmd := NewRootCmd()
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetArgs([]string{"--storage", storageDir, "init", "--runtime", "fake", "--agent", "test-agent", "--dump-config", "--start", sourcesDir})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Output must be valid JSON (dump-config wins, start is ignored)
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output is not valid JSON: %v\nOutput was: %s", err, buf.String())
+		}
+
+		// No instance should be stored
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		runtimesetup.RegisterAll(manager) //nolint:errcheck
+		instancesList, _ := manager.List()
+		if len(instancesList) != 0 {
+			t.Errorf("Expected 0 stored instances, got %d", len(instancesList))
+		}
+	})
+}
+
 func TestInitCmd_Examples(t *testing.T) {
 	t.Parallel()
 
@@ -2526,7 +2643,7 @@ func TestInitCmd_Examples(t *testing.T) {
 	}
 
 	// Verify we have the expected number of examples
-	expectedCount := 12
+	expectedCount := 13
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/instances/instance.go
+++ b/pkg/instances/instance.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	api "github.com/openkaiden/kdn-api/cli/go"
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 )
 
 var (
@@ -116,6 +117,9 @@ type Instance interface {
 	GetCreatedAt() time.Time
 	// GetStartedAt returns when the instance was last started; zero value means not started
 	GetStartedAt() time.Time
+	// GetMergedConfig returns the merged workspace configuration computed by Add.
+	// Returns nil for instances loaded from storage, as the merged config is not persisted.
+	GetMergedConfig() *workspace.WorkspaceConfiguration
 	// Dump returns the serializable data of the instance
 	Dump() InstanceData
 }
@@ -144,6 +148,9 @@ type instance struct {
 	CreatedAt time.Time
 	// StartedAt is when the instance was last started; zero value means not started
 	StartedAt time.Time
+	// MergedConfig holds the merged workspace configuration when the instance was created
+	// in DumpConfig mode. Nil for normally created instances.
+	MergedConfig *workspace.WorkspaceConfiguration
 }
 
 // Compile-time check to ensure instance implements Instance interface
@@ -220,6 +227,11 @@ func (i *instance) GetCreatedAt() time.Time {
 // GetStartedAt returns when the instance was last started; zero value means not started
 func (i *instance) GetStartedAt() time.Time {
 	return i.StartedAt
+}
+
+// GetMergedConfig returns the merged workspace configuration set during DumpConfig mode.
+func (i *instance) GetMergedConfig() *workspace.WorkspaceConfiguration {
+	return i.MergedConfig
 }
 
 // Dump returns the serializable data of the instance

--- a/pkg/instances/instance.go
+++ b/pkg/instances/instance.go
@@ -148,8 +148,9 @@ type instance struct {
 	CreatedAt time.Time
 	// StartedAt is when the instance was last started; zero value means not started
 	StartedAt time.Time
-	// MergedConfig holds the merged workspace configuration when the instance was created
-	// in DumpConfig mode. Nil for normally created instances.
+	// MergedConfig holds the merged workspace configuration computed by Add().
+	// Set in both normal and DumpConfig mode; nil for instances loaded from storage
+	// because MergedConfig is not persisted by Dump().
 	MergedConfig *workspace.WorkspaceConfiguration
 }
 

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -228,6 +228,31 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		return nil, err
 	}
 
+	// Use custom project identifier if provided, otherwise auto-detect
+	project := opts.Project
+	if project == "" {
+		project = m.projectDetector.DetectProject(ctx, inst.GetSourceDir())
+	}
+
+	// Merge configurations from all levels: workspace -> project (global + specific) -> agent
+	mergedConfig, err := m.mergeConfigurations(project, opts.WorkspaceConfig, opts.Agent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge configurations: %w", err)
+	}
+
+	// DumpConfig mode: return the merged config without creating or storing anything.
+	// Checked before ID/name generation to avoid unnecessary work.
+	if opts.DumpConfig {
+		return &instance{
+			SourceDir:    inst.GetSourceDir(),
+			ConfigDir:    inst.GetConfigDir(),
+			Project:      project,
+			Agent:        opts.Agent,
+			Model:        opts.Model,
+			MergedConfig: mergedConfig,
+		}, nil
+	}
+
 	// Generate a unique ID for the instance
 	var uniqueID string
 	for {
@@ -252,30 +277,6 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 	} else {
 		// Ensure the provided name is sanitized and unique
 		name = m.ensureUniqueName(sanitizeName(name), instances)
-	}
-
-	// Use custom project identifier if provided, otherwise auto-detect
-	project := opts.Project
-	if project == "" {
-		project = m.projectDetector.DetectProject(ctx, inst.GetSourceDir())
-	}
-
-	// Merge configurations from all levels: workspace -> project (global + specific) -> agent
-	mergedConfig, err := m.mergeConfigurations(project, opts.WorkspaceConfig, opts.Agent)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge configurations: %w", err)
-	}
-
-	// DumpConfig mode: return the merged config without creating or storing anything.
-	if opts.DumpConfig {
-		return &instance{
-			SourceDir:    inst.GetSourceDir(),
-			ConfigDir:    inst.GetConfigDir(),
-			Project:      project,
-			Agent:        opts.Agent,
-			Model:        opts.Model,
-			MergedConfig: mergedConfig,
-		}, nil
 	}
 
 	// Get the runtime

--- a/pkg/instances/manager.go
+++ b/pkg/instances/manager.go
@@ -69,6 +69,9 @@ type AddOptions struct {
 	Model string
 	// RuntimeOptions contains runtime-specific flag values from the CLI.
 	RuntimeOptions map[string]string
+	// DumpConfig when true causes Add to return early with only the merged configuration,
+	// without creating a runtime instance or persisting to storage.
+	DumpConfig bool
 }
 
 // Manager handles instance storage and operations
@@ -263,6 +266,18 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 		return nil, fmt.Errorf("failed to merge configurations: %w", err)
 	}
 
+	// DumpConfig mode: return the merged config without creating or storing anything.
+	if opts.DumpConfig {
+		return &instance{
+			SourceDir:    inst.GetSourceDir(),
+			ConfigDir:    inst.GetConfigDir(),
+			Project:      project,
+			Agent:        opts.Agent,
+			Model:        opts.Model,
+			MergedConfig: mergedConfig,
+		}, nil
+	}
+
 	// Get the runtime
 	rt, err := m.runtimeRegistry.Get(opts.RuntimeType)
 	if err != nil {
@@ -415,10 +430,11 @@ func (m *manager) Add(ctx context.Context, opts AddOptions) (Instance, error) {
 			State:      runtimeInfo.State,
 			Info:       runtimeInfo.Info,
 		},
-		Project:   project,
-		Agent:     opts.Agent,
-		Model:     opts.Model,
-		CreatedAt: m.now(),
+		Project:      project,
+		Agent:        opts.Agent,
+		Model:        opts.Model,
+		CreatedAt:    m.now(),
+		MergedConfig: mergedConfig,
 	}
 
 	// Re-read under the file lock and append, so a concurrent kdn process

--- a/pkg/instances/manager_test.go
+++ b/pkg/instances/manager_test.go
@@ -38,17 +38,18 @@ import (
 
 // fakeInstance is a test double for the Instance interface
 type fakeInstance struct {
-	id         string
-	name       string
-	sourceDir  string
-	configDir  string
-	accessible bool
-	runtime    RuntimeData
-	project    string
-	agent      string
-	model      string
-	createdAt  time.Time
-	startedAt  time.Time
+	id           string
+	name         string
+	sourceDir    string
+	configDir    string
+	accessible   bool
+	runtime      RuntimeData
+	project      string
+	agent        string
+	model        string
+	createdAt    time.Time
+	startedAt    time.Time
+	mergedConfig *workspace.WorkspaceConfiguration
 }
 
 // Compile-time check to ensure fakeInstance implements Instance interface
@@ -100,6 +101,10 @@ func (f *fakeInstance) GetCreatedAt() time.Time {
 
 func (f *fakeInstance) GetStartedAt() time.Time {
 	return f.startedAt
+}
+
+func (f *fakeInstance) GetMergedConfig() *workspace.WorkspaceConfiguration {
+	return f.mergedConfig
 }
 
 func (f *fakeInstance) Dump() InstanceData {
@@ -5055,6 +5060,199 @@ func TestManager_GetRuntime(t *testing.T) {
 		}
 		if _, ok := rt.(runtime.Experimental); !ok {
 			t.Error("GetRuntime() returned runtime does not implement runtime.Experimental")
+		}
+	})
+}
+
+func TestManager_Add_DumpConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns merged config without storing instance", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		instanceTmpDir := t.TempDir()
+		inst, _ := NewInstance(NewInstanceParams{
+			SourceDir: instanceTmpDir,
+			ConfigDir: filepath.Join(instanceTmpDir, ".kaiden"),
+		})
+
+		envValue := "hello"
+		cfg := &workspace.WorkspaceConfiguration{
+			Environment: &[]workspace.EnvironmentVariable{
+				{Name: "MY_VAR", Value: &envValue},
+			},
+		}
+
+		added, err := manager.Add(context.Background(), AddOptions{
+			Instance:        inst,
+			RuntimeType:     "fake",
+			WorkspaceConfig: cfg,
+			DumpConfig:      true,
+		})
+		if err != nil {
+			t.Fatalf("Add() unexpected error = %v", err)
+		}
+
+		mergedConfig := added.GetMergedConfig()
+		if mergedConfig == nil {
+			t.Fatal("GetMergedConfig() returned nil")
+		}
+		if mergedConfig.Environment == nil || len(*mergedConfig.Environment) != 1 {
+			t.Fatalf("Expected 1 environment variable, got %v", mergedConfig.Environment)
+		}
+		if (*mergedConfig.Environment)[0].Name != "MY_VAR" {
+			t.Errorf("Expected MY_VAR, got %s", (*mergedConfig.Environment)[0].Name)
+		}
+
+		// Instance must NOT be stored
+		instances, _ := manager.List()
+		if len(instances) != 0 {
+			t.Errorf("Expected 0 stored instances, got %d", len(instances))
+		}
+	})
+
+	t.Run("merges project config into result", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		configDir := filepath.Join(tmpDir, "config")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("Failed to create config dir: %v", err)
+		}
+
+		projectsJSON := `{
+  "my-project": {
+    "environment": [
+      {"name": "PROJECT_VAR", "value": "from-project"}
+    ]
+  }
+}`
+		if err := os.WriteFile(filepath.Join(configDir, "projects.json"), []byte(projectsJSON), 0644); err != nil {
+			t.Fatalf("Failed to write projects.json: %v", err)
+		}
+
+		detector := &fakeProjectDetector{result: "my-project"}
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), detector, time.Now)
+
+		instanceTmpDir := t.TempDir()
+		inst, _ := NewInstance(NewInstanceParams{
+			SourceDir: instanceTmpDir,
+			ConfigDir: filepath.Join(instanceTmpDir, ".kaiden"),
+		})
+
+		workspaceValue := "from-workspace"
+		cfg := &workspace.WorkspaceConfiguration{
+			Environment: &[]workspace.EnvironmentVariable{
+				{Name: "WORKSPACE_VAR", Value: &workspaceValue},
+			},
+		}
+
+		added, err := manager.Add(context.Background(), AddOptions{
+			Instance:        inst,
+			RuntimeType:     "fake",
+			WorkspaceConfig: cfg,
+			DumpConfig:      true,
+		})
+		if err != nil {
+			t.Fatalf("Add() unexpected error = %v", err)
+		}
+
+		mergedConfig := added.GetMergedConfig()
+		if mergedConfig == nil {
+			t.Fatal("GetMergedConfig() returned nil")
+		}
+		if mergedConfig.Environment == nil || len(*mergedConfig.Environment) != 2 {
+			t.Fatalf("Expected 2 environment variables, got %v", mergedConfig.Environment)
+		}
+
+		envMap := make(map[string]string)
+		for _, e := range *mergedConfig.Environment {
+			if e.Value != nil {
+				envMap[e.Name] = *e.Value
+			}
+		}
+		if envMap["WORKSPACE_VAR"] != "from-workspace" {
+			t.Errorf("Expected WORKSPACE_VAR=from-workspace, got %q", envMap["WORKSPACE_VAR"])
+		}
+		if envMap["PROJECT_VAR"] != "from-project" {
+			t.Errorf("Expected PROJECT_VAR=from-project, got %q", envMap["PROJECT_VAR"])
+		}
+	})
+
+	t.Run("returns empty merged config when no config provided at any level", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		instanceTmpDir := t.TempDir()
+		inst, _ := NewInstance(NewInstanceParams{
+			SourceDir: instanceTmpDir,
+			ConfigDir: filepath.Join(instanceTmpDir, ".kaiden"),
+		})
+
+		added, err := manager.Add(context.Background(), AddOptions{
+			Instance:    inst,
+			RuntimeType: "fake",
+			DumpConfig:  true,
+		})
+		if err != nil {
+			t.Fatalf("Add() unexpected error = %v", err)
+		}
+
+		// With no config at any level, mergedConfig is a non-nil empty struct
+		mergedConfig := added.GetMergedConfig()
+		if mergedConfig == nil {
+			t.Fatal("GetMergedConfig() returned nil; expected non-nil empty config")
+		}
+		if mergedConfig.Environment != nil && len(*mergedConfig.Environment) != 0 {
+			t.Errorf("Expected no environment variables, got %v", mergedConfig.Environment)
+		}
+	})
+
+	t.Run("normal mode also exposes merged config via GetMergedConfig", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		manager, _ := newManagerWithFactory(tmpDir, fakeInstanceFactory, newFakeGenerator(), newTestRegistry(tmpDir), agent.NewRegistry(), secretservice.NewRegistry(), credential.NewRegistry(), secret.NewStore(tmpDir), newFakeProjectDetector(), time.Now)
+
+		instanceTmpDir := t.TempDir()
+		inst, _ := NewInstance(NewInstanceParams{
+			SourceDir: instanceTmpDir,
+			ConfigDir: filepath.Join(instanceTmpDir, ".kaiden"),
+		})
+
+		envValue := "hello"
+		cfg := &workspace.WorkspaceConfiguration{
+			Environment: &[]workspace.EnvironmentVariable{
+				{Name: "MY_VAR", Value: &envValue},
+			},
+		}
+
+		added, err := manager.Add(context.Background(), AddOptions{
+			Instance:        inst,
+			RuntimeType:     "fake",
+			WorkspaceConfig: cfg,
+		})
+		if err != nil {
+			t.Fatalf("Add() unexpected error = %v", err)
+		}
+
+		mergedConfig := added.GetMergedConfig()
+		if mergedConfig == nil {
+			t.Fatal("GetMergedConfig() returned nil in normal mode")
+		}
+		if mergedConfig.Environment == nil || len(*mergedConfig.Environment) != 1 {
+			t.Fatalf("Expected 1 environment variable in normal mode, got %v", mergedConfig.Environment)
+		}
+
+		// Instance must be stored in normal mode
+		instances, _ := manager.List()
+		if len(instances) != 1 {
+			t.Errorf("Expected 1 stored instance in normal mode, got %d", len(instances))
 		}
 	})
 }


### PR DESCRIPTION
Adds a --dump-config flag to kdn init that prints the workspace configuration merged from all levels (workspace, project, global, agent) as JSON and exits without creating the workspace. This is a dry-run mode useful for verifying what configuration would be applied before committing to workspace creation.

The flag can be combined freely with any other init flags; only --agent, --project, and --workspace-configuration affect the output. Instance.GetMergedConfig() is also available on normally created instances (not persisted to storage).

Closes #397