### PR TITLE
feat(workspace): display list in two-line format per workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3260,14 +3260,16 @@ kdn workspace list
 ```
 Output:
 ```text
-NAME             SHORT ID      PROJECT                              SOURCES                              AGENT    MODEL                          STATE
-myproject        a1b2c3d4e5f6  /absolute/path/to/myproject          /absolute/path/to/myproject          claude   claude-sonnet-4-20250514       running for 5min
-another-project  f6e5d4c3b2a1  /absolute/path/to/another-project    /absolute/path/to/another-project    goose                                   stopped
+NAME/SHORT ID    PROJECT/SOURCES                       AGENT/MODEL                    RUNTIME  STATE
+myproject        /absolute/path/to/myproject           claude                         podman   running
+a1b2c3d4e5f6     /absolute/path/to/myproject           claude-sonnet-4-20250514                for 5min
+another-project  /absolute/path/to/another-project     goose                          podman   stopped
+f6e5d4c3b2a1     /absolute/path/to/another-project
 ```
 
-The `AGENT` and `MODEL` columns are displayed separately. When no model is set, the `MODEL` column is empty.
+Each workspace is shown on two lines: the first line shows the name, project, agent, runtime, and state; the second line shows the short ID, sources path, model, and running duration (if applicable). When no model is set, the model field on the second line is empty.
 
-The `STATE` column shows a human-readable duration for running workspaces: `running for Xs` (under 1 minute), `running for Xmin` (under 1 hour), or `running for H:MMh` (1 hour or more). Stopped, errored, or unknown workspaces show their state name directly.
+The `STATE` column shows `running` or `stopped` on the first line. For running workspaces, the duration appears on the second line: `for Xs` (under 1 minute), `for Xmin` (under 1 hour), or `for H:MMh` (1 hour or more).
 
 **Use the short aliases:**
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/charmbracelet/huh v1.0.0
+	github.com/charmbracelet/x/ansi v0.9.3
 	github.com/devfile/alizer v1.9.6
 	github.com/fatih/color v1.19.0
 	github.com/goccy/go-yaml v1.19.2
@@ -14,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/yarlson/pin v0.9.1
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/sys v0.42.0
 )
 
 require (
@@ -24,7 +26,6 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
-	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
@@ -58,7 +59,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/cmd/workspace_list.go
+++ b/pkg/cmd/workspace_list.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/fatih/color"
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/instances"
@@ -48,27 +49,31 @@ func truncateID(id string, n int) string {
 	return id[:n]
 }
 
-// formatState returns a human-readable state string.
-// For running instances with a known start time it shows "running for X".
-func formatState(instance instances.Instance) string {
-	state := instance.GetRuntimeData().State
-	if state != api.WorkspaceStateRunning {
-		return string(state)
+// formatStateWord returns the state string for the first display line (e.g. "running", "stopped").
+func formatStateWord(instance instances.Instance) string {
+	return string(instance.GetRuntimeData().State)
+}
+
+// formatStateDuration returns the running duration for the second display line (e.g. "for 3:25h"),
+// or an empty string when the instance is not running or has no recorded start time.
+func formatStateDuration(instance instances.Instance) string {
+	if instance.GetRuntimeData().State != api.WorkspaceStateRunning {
+		return ""
 	}
 	startedAt := instance.GetStartedAt()
 	if startedAt.IsZero() {
-		return string(state)
+		return ""
 	}
 	d := time.Since(startedAt)
 	switch {
 	case d < time.Minute:
-		return fmt.Sprintf("running for %ds", int(d.Seconds()))
+		return fmt.Sprintf("for %ds", int(d.Seconds()))
 	case d < time.Hour:
-		return fmt.Sprintf("running for %dmin", int(d.Minutes()))
+		return fmt.Sprintf("for %dmin", int(d.Minutes()))
 	default:
 		h := int(d.Hours())
 		m := int(d.Minutes()) % 60
-		return fmt.Sprintf("running for %d:%02dh", h, m)
+		return fmt.Sprintf("for %d:%02dh", h, m)
 	}
 }
 
@@ -167,24 +172,25 @@ func (w *workspaceListCmd) displayTable(cmd *cobra.Command, instancesList []inst
 
 	// Create table with headers and formatters
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
-	columnFmt := color.New(color.FgYellow).SprintfFunc()
+	nameFmt := color.New(color.FgYellow).SprintfFunc()
 
-	tbl := table.New("NAME", "SHORT ID", "PROJECT", "SOURCES", "AGENT", "MODEL", "RUNTIME", "STATE")
+	tbl := table.New("NAME/SHORT ID", "PROJECT/SOURCES", "AGENT/MODEL", "RUNTIME", "STATE")
 	tbl.WithWriter(out)
-	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+	tbl.WithHeaderFormatter(headerFmt)
+	tbl.WithWidthFunc(ansi.StringWidth)
 
-	// Add each instance as a row
+	// Add each instance as two rows: name/project/agent/runtime/state then shortID/sources/model//duration
 	for _, instance := range instancesList {
 		shortID := truncateID(instance.GetID(), 12)
-		name := instance.GetName()
+		name := nameFmt("%s", instance.GetName())
 		project := instance.GetProject()
 		sources := compactPath(instance.GetSourceDir())
 		agent := instance.GetAgent()
 		model := displayModelID(instance.GetModel())
 		runtime := instance.GetRuntimeData().Type
-		state := formatState(instance)
 
-		tbl.AddRow(name, shortID, project, sources, agent, model, runtime, state)
+		tbl.AddRow(name, project, agent, runtime, formatStateWord(instance))
+		tbl.AddRow(shortID, sources, model, "", formatStateDuration(instance))
 	}
 
 	// Print the table

--- a/pkg/cmd/workspace_list_test.go
+++ b/pkg/cmd/workspace_list_test.go
@@ -380,6 +380,80 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 		}
 	})
 
+	t.Run("name and short ID appear on separate lines", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourcesDir := t.TempDir()
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+
+		instance, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourcesDir,
+			ConfigDir: filepath.Join(sourcesDir, ".kaiden"),
+			Name:      "my-workspace",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+
+		if err := manager.RegisterRuntime(fake.New()); err != nil {
+			t.Fatalf("Failed to register fake runtime: %v", err)
+		}
+
+		addedInstance, err := manager.Add(context.Background(), instances.AddOptions{Instance: instance, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"workspace", "list", "--storage", storageDir})
+
+		var output bytes.Buffer
+		rootCmd.SetOut(&output)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		shortID := addedInstance.GetID()[:12]
+		lines := strings.Split(output.String(), "\n")
+
+		var nameLine, idLine int = -1, -1
+		for i, line := range lines {
+			// Strip ANSI escape sequences for comparison
+			stripped := strings.Map(func(r rune) rune {
+				if r < 32 && r != '\t' {
+					return -1
+				}
+				return r
+			}, line)
+			if strings.Contains(stripped, addedInstance.GetName()) {
+				nameLine = i
+			}
+			if strings.Contains(stripped, shortID) {
+				idLine = i
+			}
+		}
+
+		if nameLine == -1 {
+			t.Errorf("Name %q not found in output:\n%s", addedInstance.GetName(), output.String())
+		}
+		if idLine == -1 {
+			t.Errorf("Short ID %q not found in output:\n%s", shortID, output.String())
+		}
+		if nameLine != -1 && idLine != -1 && nameLine == idLine {
+			t.Errorf("Expected name and short ID on different lines, both on line %d:\n%s", nameLine, output.String())
+		}
+		if nameLine != -1 && idLine != -1 && idLine != nameLine+1 {
+			t.Errorf("Expected short ID on the line immediately after name (lines %d and %d), got lines %d and %d:\n%s",
+				nameLine, nameLine+1, nameLine, idLine, output.String())
+		}
+	})
+
 	t.Run("list command alias works", func(t *testing.T) {
 		t.Parallel()
 
@@ -551,7 +625,7 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 func TestWorkspaceListCmd_Model(t *testing.T) {
 	t.Parallel()
 
-	t.Run("table header shows AGENT and MODEL columns", func(t *testing.T) {
+	t.Run("table header shows combined AGENT/MODEL column", func(t *testing.T) {
 		t.Parallel()
 
 		storageDir := t.TempDir()
@@ -590,14 +664,8 @@ func TestWorkspaceListCmd_Model(t *testing.T) {
 		}
 
 		result := output.String()
-		if !strings.Contains(result, "AGENT") {
-			t.Errorf("Expected table header 'AGENT', got: %s", result)
-		}
-		if !strings.Contains(result, "MODEL") {
-			t.Errorf("Expected table header 'MODEL', got: %s", result)
-		}
-		if strings.Contains(result, "AGENT/MODEL") {
-			t.Errorf("Expected separate AGENT and MODEL headers, got combined header: %s", result)
+		if !strings.Contains(result, "AGENT/MODEL") {
+			t.Errorf("Expected combined table header 'AGENT/MODEL', got: %s", result)
 		}
 	})
 
@@ -952,7 +1020,7 @@ func TestWorkspaceListCmd_Timestamps(t *testing.T) {
 	})
 }
 
-func TestFormatState(t *testing.T) {
+func TestFormatStateWord(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns stopped for stopped instance", func(t *testing.T) {
@@ -969,12 +1037,12 @@ func TestFormatState(t *testing.T) {
 			},
 		}
 		inst, _ := instances.NewInstanceFromData(data)
-		if got := formatState(inst); got != "stopped" {
+		if got := formatStateWord(inst); got != "stopped" {
 			t.Errorf("Expected 'stopped', got %q", got)
 		}
 	})
 
-	t.Run("returns running for running instance with no start time", func(t *testing.T) {
+	t.Run("returns running for running instance", func(t *testing.T) {
 		t.Parallel()
 
 		sourceDir := t.TempDir()
@@ -988,12 +1056,54 @@ func TestFormatState(t *testing.T) {
 			},
 		}
 		inst, _ := instances.NewInstanceFromData(data)
-		if got := formatState(inst); got != "running" {
+		if got := formatStateWord(inst); got != "running" {
 			t.Errorf("Expected 'running', got %q", got)
 		}
 	})
+}
 
-	t.Run("returns running for Xs when started less than a minute ago", func(t *testing.T) {
+func TestFormatStateDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty for stopped instance", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:    "id1",
+			Name:  "ws",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateStopped,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		if got := formatStateDuration(inst); got != "" {
+			t.Errorf("Expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns empty for running instance with no start time", func(t *testing.T) {
+		t.Parallel()
+
+		sourceDir := t.TempDir()
+		configDir := t.TempDir()
+		data := instances.InstanceData{
+			ID:    "id2",
+			Name:  "ws",
+			Paths: instances.InstancePaths{Source: sourceDir, Configuration: configDir},
+			Runtime: instances.RuntimeData{
+				State: api.WorkspaceStateRunning,
+			},
+		}
+		inst, _ := instances.NewInstanceFromData(data)
+		if got := formatStateDuration(inst); got != "" {
+			t.Errorf("Expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns for Xs when started less than a minute ago", func(t *testing.T) {
 		t.Parallel()
 
 		sourceDir := t.TempDir()
@@ -1008,13 +1118,13 @@ func TestFormatState(t *testing.T) {
 			},
 		}
 		inst, _ := instances.NewInstanceFromData(data)
-		got := formatState(inst)
-		if !strings.HasPrefix(got, "running for ") || !strings.HasSuffix(got, "s") {
-			t.Errorf("Expected 'running for Xs', got %q", got)
+		got := formatStateDuration(inst)
+		if !strings.HasPrefix(got, "for ") || !strings.HasSuffix(got, "s") {
+			t.Errorf("Expected 'for Xs', got %q", got)
 		}
 	})
 
-	t.Run("returns running for Xmin when started between 1 and 60 minutes ago", func(t *testing.T) {
+	t.Run("returns for Xmin when started between 1 and 60 minutes ago", func(t *testing.T) {
 		t.Parallel()
 
 		sourceDir := t.TempDir()
@@ -1029,13 +1139,13 @@ func TestFormatState(t *testing.T) {
 			},
 		}
 		inst, _ := instances.NewInstanceFromData(data)
-		got := formatState(inst)
-		if got != "running for 5min" {
-			t.Errorf("Expected 'running for 5min', got %q", got)
+		got := formatStateDuration(inst)
+		if got != "for 5min" {
+			t.Errorf("Expected 'for 5min', got %q", got)
 		}
 	})
 
-	t.Run("returns running for h:mmh when started over 1 hour ago", func(t *testing.T) {
+	t.Run("returns for h:mmh when started over 1 hour ago", func(t *testing.T) {
 		t.Parallel()
 
 		sourceDir := t.TempDir()
@@ -1050,9 +1160,9 @@ func TestFormatState(t *testing.T) {
 			},
 		}
 		inst, _ := instances.NewInstanceFromData(data)
-		got := formatState(inst)
-		if got != "running for 2:15h" {
-			t.Errorf("Expected 'running for 2:15h', got %q", got)
+		got := formatStateDuration(inst)
+		if got != "for 2:15h" {
+			t.Errorf("Expected 'for 2:15h', got %q", got)
 		}
 	})
 }

--- a/pkg/cmd/workspace_list_test.go
+++ b/pkg/cmd/workspace_list_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/cmd/testutil"
 	"github.com/openkaiden/kdn/pkg/instances"
@@ -422,15 +423,9 @@ func TestWorkspaceListCmd_E2E(t *testing.T) {
 		shortID := addedInstance.GetID()[:12]
 		lines := strings.Split(output.String(), "\n")
 
-		var nameLine, idLine int = -1, -1
+		nameLine, idLine := -1, -1
 		for i, line := range lines {
-			// Strip ANSI escape sequences for comparison
-			stripped := strings.Map(func(r rune) rune {
-				if r < 32 && r != '\t' {
-					return -1
-				}
-				return r
-			}, line)
+			stripped := ansi.Strip(line)
 			if strings.Contains(stripped, addedInstance.GetName()) {
 				nameLine = i
 			}


### PR DESCRIPTION
Each workspace now spans two rows in kdn list: the first line shows name, project, agent, runtime, and state word; the second shows short ID, sources, model, and running duration. This keeps the table compact while surfacing all relevant fields.

ANSI colour is applied directly to the name string and ansi.StringWidth is registered as the table WidthFunc so escape codes no longer skew column alignment.

Closes #522

Before / After in wide terminal

<img width="988" height="221" alt="kdn-list-large" src="https://github.com/user-attachments/assets/2f4b7692-9640-4df9-a300-f451488de0ff" />

Before / After in narrow terminal

<img width="646" height="263" alt="kdn-list-no-large" src="https://github.com/user-attachments/assets/24b940a7-eb46-4f9e-862c-99af131606f7" />
