### PR TITLE
feat(OpenShell): intercept gcloud ADC credential mounts and source ennv

### DIFF
--- a/pkg/runtime/openshell/create.go
+++ b/pkg/runtime/openshell/create.go
@@ -68,6 +68,16 @@ func (r *openshellRuntime) Create(ctx context.Context, params runtime.CreatePara
 	// Collect ports from workspace config and agent defaults
 	ports := collectPorts(params)
 
+	// Intercept file-based credentials (e.g. gcloud ADC) before sandbox
+	// creation. Detected credential mounts are removed from the config and
+	// the real file is uploaded into the sandbox after it is created.
+	step.Start("Detecting credentials", "Credential detection complete")
+	uploadCredentialsFn, err := r.interceptCredentials(ctx, params)
+	if err != nil {
+		step.Fail(err)
+		return runtime.RuntimeInfo{}, fmt.Errorf("failed to intercept credentials: %w", err)
+	}
+
 	// Provision OpenShell providers for workspace secrets before sandbox creation,
 	// because providers must be attached via --provider flags at create time.
 	step.Start("Provisioning secret providers", "Secret providers provisioned")
@@ -91,6 +101,15 @@ func (r *openshellRuntime) Create(ctx context.Context, params runtime.CreatePara
 	); err != nil {
 		step.Fail(err)
 		return runtime.RuntimeInfo{}, fmt.Errorf("failed to upload sources: %w", err)
+	}
+
+	// Upload credential files into the sandbox (after creation)
+	if uploadCredentialsFn != nil {
+		step.Start("Uploading credential files", "Credential files uploaded")
+		if err := uploadCredentialsFn(ctx, name); err != nil {
+			step.Fail(err)
+			return runtime.RuntimeInfo{}, fmt.Errorf("failed to upload credential files: %w", err)
+		}
 	}
 
 	// Upload agent settings
@@ -297,8 +316,17 @@ func (r *openshellRuntime) writeEnvFile(ctx context.Context, name string, params
 
 	destPath := path.Join(containerHome, ".kdn-env")
 	l := logger.FromContext(ctx)
-	return r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+	if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(),
 		"sandbox", "upload", name, tmpPath, destPath,
+	); err != nil {
+		return err
+	}
+
+	// Append source line to .bashrc so env vars are available in any shell
+	// session (e.g. openshell connect), not only kdn terminal.
+	return r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+		"sandbox", "exec", "--name", name, "--no-tty", "--",
+		"sh", "-c", fmt.Sprintf(`grep -q '.kdn-env' %s/.bashrc 2>/dev/null || echo '. %s/.kdn-env' >> %s/.bashrc`, containerHome, containerHome, containerHome),
 	)
 }
 

--- a/pkg/runtime/openshell/create_test.go
+++ b/pkg/runtime/openshell/create_test.go
@@ -328,8 +328,8 @@ func TestWriteEnvFile_UsesSandboxUpload(t *testing.T) {
 		t.Fatalf("writeEnvFile() failed: %v", err)
 	}
 
-	if len(fakeExec.RunCalls) != 1 {
-		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	if len(fakeExec.RunCalls) != 2 {
+		t.Fatalf("Expected 2 Run calls (upload + bashrc), got %d", len(fakeExec.RunCalls))
 	}
 
 	call := fakeExec.RunCalls[0]
@@ -340,6 +340,11 @@ func TestWriteEnvFile_UsesSandboxUpload(t *testing.T) {
 	expectedEnvDest := "/sandbox/.kdn-env"
 	if call[4] != expectedEnvDest {
 		t.Errorf("Expected destination %q, got %q", expectedEnvDest, call[4])
+	}
+
+	bashrcCall := fakeExec.RunCalls[1]
+	if bashrcCall[0] != "sandbox" || bashrcCall[1] != "exec" {
+		t.Errorf("Expected sandbox exec for bashrc, got %v", bashrcCall[:2])
 	}
 }
 
@@ -368,8 +373,8 @@ func TestWriteEnvFile_WorkspaceConfigEnvVars(t *testing.T) {
 		t.Fatalf("writeEnvFile() failed: %v", err)
 	}
 
-	if len(fakeExec.RunCalls) != 1 {
-		t.Fatalf("Expected 1 Run call, got %d", len(fakeExec.RunCalls))
+	if len(fakeExec.RunCalls) != 2 {
+		t.Fatalf("Expected 2 Run calls (upload + bashrc), got %d", len(fakeExec.RunCalls))
 	}
 }
 

--- a/pkg/runtime/openshell/credentials.go
+++ b/pkg/runtime/openshell/credentials.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/logger"
+	"github.com/openkaiden/kdn/pkg/runtime"
+)
+
+// containerADCPath is the ADC file path inside the OpenShell sandbox.
+var containerADCPath = path.Join(containerHome, ".config/gcloud/application_default_credentials.json")
+
+// interceptCredentials detects file-based credential mounts (e.g. gcloud ADC)
+// in the workspace config and returns a function that uploads the real
+// credential file into the sandbox after it is created. OpenShell sandboxes
+// are isolated so the real file can be uploaded directly.
+//
+// The intercepted mount is removed from the workspace config and the
+// credential's host patterns are added to the network allow list.
+func (r *openshellRuntime) interceptCredentials(ctx context.Context, params runtime.CreateParams) (func(context.Context, string) error, error) {
+	wsCfg := params.WorkspaceConfig
+	if r.credentialRegistry == nil || wsCfg == nil || wsCfg.Mounts == nil || len(*wsCfg.Mounts) == 0 {
+		return nil, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determining home directory: %w", err)
+	}
+
+	l := logger.FromContext(ctx)
+
+	var uploadFn func(context.Context, string) error
+
+	for _, cred := range r.credentialRegistry.List() {
+		hostPath, intercepted := cred.Detect(*wsCfg.Mounts, homeDir)
+		if intercepted == nil {
+			continue
+		}
+
+		if cred.Name() != "gcloud" {
+			continue
+		}
+
+		if _, err := os.Stat(hostPath); os.IsNotExist(err) {
+			fmt.Fprintf(l.Stderr(), "Gcloud ADC file not found at %s, skipping credential interception\n", hostPath)
+			continue
+		}
+
+		removeMountFromConfig(wsCfg, intercepted)
+		addHostsToNetworkConfig(wsCfg, expandWildcardHosts(cred.HostPatterns(hostPath)))
+
+		realPath := hostPath
+		uploadFn = func(ctx context.Context, sandboxName string) error {
+			l := logger.FromContext(ctx)
+			return r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+				"sandbox", "upload", sandboxName, realPath, containerADCPath,
+			)
+		}
+	}
+
+	return uploadFn, nil
+}
+
+// removeMountFromConfig removes the intercepted mount from the workspace config.
+func removeMountFromConfig(wsCfg *workspace.WorkspaceConfiguration, intercepted *workspace.Mount) {
+	if wsCfg.Mounts == nil {
+		return
+	}
+	filtered := make([]workspace.Mount, 0, len(*wsCfg.Mounts))
+	for i := range *wsCfg.Mounts {
+		if &(*wsCfg.Mounts)[i] != intercepted {
+			filtered = append(filtered, (*wsCfg.Mounts)[i])
+		}
+	}
+	*wsCfg.Mounts = filtered
+}
+
+// vertexAIRegions lists the Vertex AI regional endpoint prefixes.
+// OpenShell policy does not support "*-" wildcards (only "*." or "**."),
+// so we enumerate them explicitly.
+var vertexAIRegions = []string{
+	"us-central1",
+	"us-east4",
+	"us-east5",
+	"us-west1",
+	"us-west4",
+	"europe-west1",
+	"europe-west2",
+	"europe-west4",
+	"europe-west9",
+	"asia-southeast1",
+	"asia-northeast1",
+	"asia-northeast3",
+	"me-west1",
+	"northamerica-northeast1",
+}
+
+// extraVertexAIHosts lists additional Google Cloud hosts required by the
+// Vertex AI authentication and model serving flow beyond the regional
+// aiplatform endpoints.
+var extraVertexAIHosts = []string{
+	"storage.googleapis.com",
+}
+
+// expandWildcardHosts replaces unsupported wildcard patterns like
+// "*-aiplatform.googleapis.com" with explicit regional endpoints and
+// appends additional hosts required by the Vertex AI flow.
+func expandWildcardHosts(hosts []string) []string {
+	var result []string
+	expanded := false
+	for _, h := range hosts {
+		if h == "*-aiplatform.googleapis.com" {
+			for _, region := range vertexAIRegions {
+				result = append(result, region+"-aiplatform.googleapis.com")
+			}
+			expanded = true
+			continue
+		}
+		result = append(result, h)
+	}
+	if expanded {
+		result = append(result, extraVertexAIHosts...)
+	}
+	return result
+}
+
+// addHostsToNetworkConfig appends hosts to the workspace network allow list.
+func addHostsToNetworkConfig(wsCfg *workspace.WorkspaceConfiguration, hosts []string) {
+	if len(hosts) == 0 {
+		return
+	}
+	if wsCfg.Network == nil {
+		wsCfg.Network = &workspace.NetworkConfiguration{}
+	}
+	if wsCfg.Network.Hosts == nil {
+		hostsList := make([]string, 0, len(hosts))
+		wsCfg.Network.Hosts = &hostsList
+	}
+
+	seen := make(map[string]bool, len(*wsCfg.Network.Hosts))
+	for _, h := range *wsCfg.Network.Hosts {
+		seen[strings.ToLower(h)] = true
+	}
+	for _, h := range hosts {
+		if !seen[strings.ToLower(h)] {
+			*wsCfg.Network.Hosts = append(*wsCfg.Network.Hosts, h)
+		}
+	}
+}

--- a/pkg/runtime/openshell/credentials.go
+++ b/pkg/runtime/openshell/credentials.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
@@ -26,15 +25,40 @@ import (
 	"github.com/openkaiden/kdn/pkg/runtime"
 )
 
-// containerADCPath is the ADC file path inside the OpenShell sandbox.
-var containerADCPath = path.Join(containerHome, ".config/gcloud/application_default_credentials.json")
+// podmanContainerHome is the home directory used by credential implementations.
+const podmanContainerHome = "/home/agent"
 
-// interceptCredentials detects file-based credential mounts (e.g. gcloud ADC)
-// in the workspace config and returns a function that uploads the real
-// credential file into the sandbox after it is created. OpenShell sandboxes
-// are isolated so the real file can be uploaded directly.
+// hostExpanders holds functions that transform host patterns before they are
+// added to the network allow list. Credential-specific files (e.g.
+// credentials_gcloud.go) register their expanders via init().
+var hostExpanders []func([]string) []string
+
+// registerHostExpander adds a host-pattern expander. Called from init() in
+// credential-specific files.
+func registerHostExpander(fn func([]string) []string) {
+	hostExpanders = append(hostExpanders, fn)
+}
+
+// expandHostPatterns runs all registered host expanders on the given patterns.
+func expandHostPatterns(hosts []string) []string {
+	for _, fn := range hostExpanders {
+		hosts = fn(hosts)
+	}
+	return hosts
+}
+
+// credentialUpload captures a detected credential's upload parameters.
+type credentialUpload struct {
+	hostPath      string
+	containerPath string
+}
+
+// interceptCredentials detects file-based credential mounts in the workspace
+// config and returns a function that uploads the real credential files into the
+// sandbox after it is created. OpenShell sandboxes are isolated so real files
+// can be uploaded directly.
 //
-// The intercepted mount is removed from the workspace config and the
+// Intercepted mounts are removed from the workspace config and each
 // credential's host patterns are added to the network allow list.
 func (r *openshellRuntime) interceptCredentials(ctx context.Context, params runtime.CreateParams) (func(context.Context, string) error, error) {
 	wsCfg := params.WorkspaceConfig
@@ -49,7 +73,7 @@ func (r *openshellRuntime) interceptCredentials(ctx context.Context, params runt
 
 	l := logger.FromContext(ctx)
 
-	var uploadFn func(context.Context, string) error
+	var uploads []credentialUpload
 
 	for _, cred := range r.credentialRegistry.List() {
 		hostPath, intercepted := cred.Detect(*wsCfg.Mounts, homeDir)
@@ -57,28 +81,46 @@ func (r *openshellRuntime) interceptCredentials(ctx context.Context, params runt
 			continue
 		}
 
-		if cred.Name() != "gcloud" {
-			continue
-		}
-
 		if _, err := os.Stat(hostPath); os.IsNotExist(err) {
-			fmt.Fprintf(l.Stderr(), "Gcloud ADC file not found at %s, skipping credential interception\n", hostPath)
+			fmt.Fprintf(l.Stderr(), "%s credential file not found at %s, skipping\n", cred.Name(), hostPath)
 			continue
 		}
 
 		removeMountFromConfig(wsCfg, intercepted)
-		addHostsToNetworkConfig(wsCfg, expandWildcardHosts(cred.HostPatterns(hostPath)))
+		addHostsToNetworkConfig(wsCfg, expandHostPatterns(cred.HostPatterns(hostPath)))
 
-		realPath := hostPath
-		uploadFn = func(ctx context.Context, sandboxName string) error {
-			l := logger.FromContext(ctx)
-			return r.executor.Run(ctx, l.Stdout(), l.Stderr(),
-				"sandbox", "upload", sandboxName, realPath, containerADCPath,
-			)
+		uploads = append(uploads, credentialUpload{
+			hostPath:      hostPath,
+			containerPath: remapContainerPath(cred.ContainerFilePath()),
+		})
+	}
+
+	if len(uploads) == 0 {
+		return nil, nil
+	}
+
+	uploadFn := func(ctx context.Context, sandboxName string) error {
+		l := logger.FromContext(ctx)
+		for _, u := range uploads {
+			if err := r.executor.Run(ctx, l.Stdout(), l.Stderr(),
+				"sandbox", "upload", sandboxName, u.hostPath, u.containerPath,
+			); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
 
 	return uploadFn, nil
+}
+
+// remapContainerPath translates a container file path from the Podman home
+// directory (/home/agent) to the OpenShell sandbox home (/sandbox).
+func remapContainerPath(containerFilePath string) string {
+	if strings.HasPrefix(containerFilePath, podmanContainerHome) {
+		return containerHome + containerFilePath[len(podmanContainerHome):]
+	}
+	return containerFilePath
 }
 
 // removeMountFromConfig removes the intercepted mount from the workspace config.
@@ -93,55 +135,6 @@ func removeMountFromConfig(wsCfg *workspace.WorkspaceConfiguration, intercepted 
 		}
 	}
 	*wsCfg.Mounts = filtered
-}
-
-// vertexAIRegions lists the Vertex AI regional endpoint prefixes.
-// OpenShell policy does not support "*-" wildcards (only "*." or "**."),
-// so we enumerate them explicitly.
-var vertexAIRegions = []string{
-	"us-central1",
-	"us-east4",
-	"us-east5",
-	"us-west1",
-	"us-west4",
-	"europe-west1",
-	"europe-west2",
-	"europe-west4",
-	"europe-west9",
-	"asia-southeast1",
-	"asia-northeast1",
-	"asia-northeast3",
-	"me-west1",
-	"northamerica-northeast1",
-}
-
-// extraVertexAIHosts lists additional Google Cloud hosts required by the
-// Vertex AI authentication and model serving flow beyond the regional
-// aiplatform endpoints.
-var extraVertexAIHosts = []string{
-	"storage.googleapis.com",
-}
-
-// expandWildcardHosts replaces unsupported wildcard patterns like
-// "*-aiplatform.googleapis.com" with explicit regional endpoints and
-// appends additional hosts required by the Vertex AI flow.
-func expandWildcardHosts(hosts []string) []string {
-	var result []string
-	expanded := false
-	for _, h := range hosts {
-		if h == "*-aiplatform.googleapis.com" {
-			for _, region := range vertexAIRegions {
-				result = append(result, region+"-aiplatform.googleapis.com")
-			}
-			expanded = true
-			continue
-		}
-		result = append(result, h)
-	}
-	if expanded {
-		result = append(result, extraVertexAIHosts...)
-	}
-	return result
 }
 
 // addHostsToNetworkConfig appends hosts to the workspace network allow list.

--- a/pkg/runtime/openshell/credentials_gcloud.go
+++ b/pkg/runtime/openshell/credentials_gcloud.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+// vertexAIRegions lists the Vertex AI regional endpoint prefixes.
+// OpenShell policy does not support "*-" wildcards (only "*." or "**."),
+// so we enumerate them explicitly.
+var vertexAIRegions = []string{
+	"us-central1",
+	"us-east4",
+	"us-east5",
+	"us-west1",
+	"us-west4",
+	"europe-west1",
+	"europe-west2",
+	"europe-west4",
+	"europe-west9",
+	"asia-southeast1",
+	"asia-northeast1",
+	"asia-northeast3",
+	"me-west1",
+	"northamerica-northeast1",
+}
+
+// extraVertexAIHosts lists additional Google Cloud hosts required by the
+// Vertex AI authentication and model serving flow beyond the regional
+// aiplatform endpoints.
+var extraVertexAIHosts = []string{
+	"storage.googleapis.com",
+}
+
+func init() {
+	registerHostExpander(expandVertexAIWildcards)
+}
+
+// expandVertexAIWildcards replaces the unsupported wildcard pattern
+// "*-aiplatform.googleapis.com" with explicit regional endpoints and
+// appends additional hosts required by the Vertex AI flow.
+func expandVertexAIWildcards(hosts []string) []string {
+	var result []string
+	expanded := false
+	for _, h := range hosts {
+		if h == "*-aiplatform.googleapis.com" {
+			for _, region := range vertexAIRegions {
+				result = append(result, region+"-aiplatform.googleapis.com")
+			}
+			expanded = true
+			continue
+		}
+		result = append(result, h)
+	}
+	if expanded {
+		result = append(result, extraVertexAIHosts...)
+	}
+	return result
+}

--- a/pkg/runtime/openshell/credentials_gcloud_test.go
+++ b/pkg/runtime/openshell/credentials_gcloud_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestExpandVertexAIWildcards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("expands wildcard pattern", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{"oauth2.googleapis.com", "*-aiplatform.googleapis.com", "aiplatform.googleapis.com"}
+		result := expandVertexAIWildcards(input)
+
+		if slices.Contains(result, "*-aiplatform.googleapis.com") {
+			t.Error("wildcard should have been expanded")
+		}
+		if !slices.Contains(result, "oauth2.googleapis.com") {
+			t.Error("non-wildcard host should be preserved")
+		}
+		if !slices.Contains(result, "aiplatform.googleapis.com") {
+			t.Error("non-wildcard host should be preserved")
+		}
+		if !slices.Contains(result, "us-central1-aiplatform.googleapis.com") {
+			t.Error("expected us-central1 regional endpoint")
+		}
+		if !slices.Contains(result, "europe-west4-aiplatform.googleapis.com") {
+			t.Error("expected europe-west4 regional endpoint")
+		}
+		if !slices.Contains(result, "storage.googleapis.com") {
+			t.Error("expected storage.googleapis.com")
+		}
+
+		expectedLen := 2 + len(vertexAIRegions) + len(extraVertexAIHosts)
+		if len(result) != expectedLen {
+			t.Errorf("expected %d hosts, got %d", expectedLen, len(result))
+		}
+	})
+
+	t.Run("passes through non-wildcard hosts", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{"example.com", "api.github.com"}
+		result := expandVertexAIWildcards(input)
+
+		if len(result) != 2 {
+			t.Errorf("expected 2 hosts, got %d", len(result))
+		}
+	})
+
+	t.Run("handles nil input", func(t *testing.T) {
+		t.Parallel()
+
+		result := expandVertexAIWildcards(nil)
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %v", result)
+		}
+	})
+}

--- a/pkg/runtime/openshell/credentials_test.go
+++ b/pkg/runtime/openshell/credentials_test.go
@@ -1,0 +1,505 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openshell
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
+	"github.com/openkaiden/kdn/pkg/credential"
+	"github.com/openkaiden/kdn/pkg/credential/gcloud"
+	"github.com/openkaiden/kdn/pkg/onecli"
+	"github.com/openkaiden/kdn/pkg/runtime"
+	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
+)
+
+func TestInterceptCredentials_NilRegistry(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+
+	mounts := []workspace.Mount{{Host: "$HOME/.config/gcloud", Target: "$HOME/.config/gcloud"}}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn != nil {
+		t.Error("expected nil uploadFn")
+	}
+}
+
+func TestInterceptCredentials_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.credentialRegistry = credential.NewRegistry()
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn != nil {
+		t.Error("expected nil uploadFn")
+	}
+}
+
+func TestInterceptCredentials_NoMounts(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	rt.credentialRegistry = credential.NewRegistry()
+
+	cfg := &workspace.WorkspaceConfiguration{}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn != nil {
+		t.Error("expected nil uploadFn")
+	}
+}
+
+func TestInterceptCredentials_NoGcloudMount(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{{Host: "$HOME/projects", Target: "$HOME/projects"}}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn != nil {
+		t.Error("expected nil uploadFn")
+	}
+}
+
+func TestInterceptCredentials_DetectsGcloudMount(t *testing.T) {
+	t.Parallel()
+
+	adcDir := filepath.Join(t.TempDir(), ".config", "gcloud")
+	if err := os.MkdirAll(adcDir, 0755); err != nil {
+		t.Fatalf("failed to create ADC dir: %v", err)
+	}
+	adcPath := filepath.Join(adcDir, "application_default_credentials.json")
+	adcContent := `{
+		"client_id": "test-client-id",
+		"client_secret": "test-client-secret",
+		"refresh_token": "test-refresh-token",
+		"type": "authorized_user"
+	}`
+	if err := os.WriteFile(adcPath, []byte(adcContent), 0644); err != nil {
+		t.Fatalf("failed to write ADC file: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{
+		{Host: adcPath, Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn == nil {
+		t.Fatal("expected non-nil uploadFn")
+	}
+}
+
+func TestInterceptCredentials_RemovesInterceptedMount(t *testing.T) {
+	t.Parallel()
+
+	adcDir := filepath.Join(t.TempDir(), ".config", "gcloud")
+	if err := os.MkdirAll(adcDir, 0755); err != nil {
+		t.Fatalf("failed to create ADC dir: %v", err)
+	}
+	adcPath := filepath.Join(adcDir, "application_default_credentials.json")
+	if err := os.WriteFile(adcPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to write ADC file: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{
+		{Host: "$HOME/projects", Target: "$HOME/projects"},
+		{Host: adcPath, Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+		{Host: "$HOME/other", Target: "$HOME/other"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	_, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(*cfg.Mounts) != 2 {
+		t.Fatalf("expected 2 mounts after interception, got %d", len(*cfg.Mounts))
+	}
+	for _, m := range *cfg.Mounts {
+		if strings.Contains(m.Target, "gcloud") {
+			t.Errorf("gcloud mount should have been removed, found: %+v", m)
+		}
+	}
+}
+
+func TestInterceptCredentials_AddsVertexHosts(t *testing.T) {
+	t.Parallel()
+
+	adcDir := filepath.Join(t.TempDir(), ".config", "gcloud")
+	if err := os.MkdirAll(adcDir, 0755); err != nil {
+		t.Fatalf("failed to create ADC dir: %v", err)
+	}
+	adcPath := filepath.Join(adcDir, "application_default_credentials.json")
+	if err := os.WriteFile(adcPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to write ADC file: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	existingHosts := []string{"registry.npmjs.org"}
+	deny := workspace.Deny
+	mounts := []workspace.Mount{
+		{Host: adcPath, Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{
+		Mounts:  &mounts,
+		Network: &workspace.NetworkConfiguration{Mode: &deny, Hosts: &existingHosts},
+	}
+
+	_, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Network == nil || cfg.Network.Hosts == nil {
+		t.Fatal("expected network hosts to be set")
+	}
+
+	hosts := *cfg.Network.Hosts
+	for _, want := range []string{"oauth2.googleapis.com", "aiplatform.googleapis.com", "us-central1-aiplatform.googleapis.com", "europe-west4-aiplatform.googleapis.com", "storage.googleapis.com"} {
+		if !slices.Contains(hosts, want) {
+			t.Errorf("missing host %q in %v", want, hosts)
+		}
+	}
+
+	for _, h := range hosts {
+		if h == "*-aiplatform.googleapis.com" {
+			t.Error("wildcard *-aiplatform.googleapis.com should have been expanded")
+		}
+	}
+
+	if !slices.Contains(hosts, "registry.npmjs.org") {
+		t.Error("original host should still be present")
+	}
+}
+
+func TestInterceptCredentials_HostFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{
+		{Host: "/nonexistent/path/application_default_credentials.json", Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn != nil {
+		t.Error("expected nil uploadFn for missing file")
+	}
+}
+
+func TestInterceptCredentials_UploadFnCallsSandboxUpload(t *testing.T) {
+	t.Parallel()
+
+	adcDir := filepath.Join(t.TempDir(), ".config", "gcloud")
+	if err := os.MkdirAll(adcDir, 0755); err != nil {
+		t.Fatalf("failed to create ADC dir: %v", err)
+	}
+	adcPath := filepath.Join(adcDir, "application_default_credentials.json")
+	if err := os.WriteFile(adcPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to write ADC file: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{
+		{Host: adcPath, Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn == nil {
+		t.Fatal("expected non-nil uploadFn")
+	}
+
+	if err := uploadFn(context.Background(), "kdn-test-sandbox"); err != nil {
+		t.Fatalf("uploadFn failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("expected 1 Run call for upload, got %d", len(fakeExec.RunCalls))
+	}
+
+	uploadCall := fakeExec.RunCalls[0]
+	assertContainsAll(t, uploadCall, "sandbox", "upload", "kdn-test-sandbox", adcPath)
+
+	lastArg := uploadCall[len(uploadCall)-1]
+	if lastArg != "/sandbox/.config/gcloud/application_default_credentials.json" {
+		t.Errorf("upload destination = %q, want %q", lastArg, "/sandbox/.config/gcloud/application_default_credentials.json")
+	}
+}
+
+func TestInterceptCredentials_AddsHostsToNilNetwork(t *testing.T) {
+	t.Parallel()
+
+	adcDir := filepath.Join(t.TempDir(), ".config", "gcloud")
+	if err := os.MkdirAll(adcDir, 0755); err != nil {
+		t.Fatalf("failed to create ADC dir: %v", err)
+	}
+	adcPath := filepath.Join(adcDir, "application_default_credentials.json")
+	if err := os.WriteFile(adcPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to write ADC file: %v", err)
+	}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(gcloud.New())
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{
+		{Host: adcPath, Target: "$HOME/.config/gcloud/application_default_credentials.json"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	_, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Network == nil || cfg.Network.Hosts == nil {
+		t.Fatal("expected network hosts to be initialized")
+	}
+
+	hosts := *cfg.Network.Hosts
+	if len(hosts) == 0 {
+		t.Error("expected Vertex AI hosts to be added")
+	}
+}
+
+func TestExpandWildcardHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("expands wildcard pattern", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{"oauth2.googleapis.com", "*-aiplatform.googleapis.com", "aiplatform.googleapis.com"}
+		result := expandWildcardHosts(input)
+
+		if slices.Contains(result, "*-aiplatform.googleapis.com") {
+			t.Error("wildcard should have been expanded")
+		}
+		if !slices.Contains(result, "oauth2.googleapis.com") {
+			t.Error("non-wildcard host should be preserved")
+		}
+		if !slices.Contains(result, "aiplatform.googleapis.com") {
+			t.Error("non-wildcard host should be preserved")
+		}
+		if !slices.Contains(result, "us-central1-aiplatform.googleapis.com") {
+			t.Error("expected us-central1 regional endpoint")
+		}
+		if !slices.Contains(result, "europe-west4-aiplatform.googleapis.com") {
+			t.Error("expected europe-west4 regional endpoint")
+		}
+		if !slices.Contains(result, "storage.googleapis.com") {
+			t.Error("expected storage.googleapis.com")
+		}
+
+		expectedLen := 2 + len(vertexAIRegions) + len(extraVertexAIHosts)
+		if len(result) != expectedLen {
+			t.Errorf("expected %d hosts, got %d", expectedLen, len(result))
+		}
+	})
+
+	t.Run("passes through non-wildcard hosts", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{"example.com", "api.github.com"}
+		result := expandWildcardHosts(input)
+
+		if len(result) != 2 {
+			t.Errorf("expected 2 hosts, got %d", len(result))
+		}
+	})
+
+	t.Run("handles nil input", func(t *testing.T) {
+		t.Parallel()
+
+		result := expandWildcardHosts(nil)
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %v", result)
+		}
+	})
+}
+
+func TestRemoveMountFromConfig(t *testing.T) {
+	t.Parallel()
+
+	mounts := []workspace.Mount{
+		{Host: "/a", Target: "/a"},
+		{Host: "/b", Target: "/b"},
+		{Host: "/c", Target: "/c"},
+	}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	removeMountFromConfig(cfg, &(*cfg.Mounts)[1])
+
+	if len(*cfg.Mounts) != 2 {
+		t.Fatalf("expected 2 mounts, got %d", len(*cfg.Mounts))
+	}
+	for _, m := range *cfg.Mounts {
+		if m.Host == "/b" {
+			t.Error("mount /b should have been removed")
+		}
+	}
+}
+
+func TestAddHostsToNetworkConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates network config if nil", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &workspace.WorkspaceConfiguration{}
+		addHostsToNetworkConfig(cfg, []string{"example.com"})
+
+		if cfg.Network == nil || cfg.Network.Hosts == nil {
+			t.Fatal("expected network hosts to be created")
+		}
+		if len(*cfg.Network.Hosts) != 1 || (*cfg.Network.Hosts)[0] != "example.com" {
+			t.Errorf("hosts = %v, want [example.com]", *cfg.Network.Hosts)
+		}
+	})
+
+	t.Run("deduplicates hosts", func(t *testing.T) {
+		t.Parallel()
+
+		hosts := []string{"existing.com"}
+		cfg := &workspace.WorkspaceConfiguration{
+			Network: &workspace.NetworkConfiguration{Hosts: &hosts},
+		}
+
+		addHostsToNetworkConfig(cfg, []string{"existing.com", "new.com"})
+
+		if len(*cfg.Network.Hosts) != 2 {
+			t.Errorf("expected 2 hosts, got %d: %v", len(*cfg.Network.Hosts), *cfg.Network.Hosts)
+		}
+	})
+
+	t.Run("no-op for empty hosts", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &workspace.WorkspaceConfiguration{}
+		addHostsToNetworkConfig(cfg, nil)
+
+		if cfg.Network != nil {
+			t.Error("expected network to remain nil")
+		}
+	})
+}
+
+// fakeCredential implements credential.Credential for testing non-gcloud credentials.
+type fakeCredential struct {
+	name         string
+	hostPatterns []string
+}
+
+var _ credential.Credential = (*fakeCredential)(nil)
+
+func (f *fakeCredential) Name() string                      { return f.name }
+func (f *fakeCredential) ContainerFilePath() string         { return "/fake/path" }
+func (f *fakeCredential) HostPatterns(_ string) []string    { return f.hostPatterns }
+func (f *fakeCredential) FakeFile(_ string) ([]byte, error) { return nil, nil }
+func (f *fakeCredential) Detect(_ []workspace.Mount, _ string) (string, *workspace.Mount) {
+	return "", nil
+}
+func (f *fakeCredential) Configure(_ context.Context, _ onecli.Client, _ string) error { return nil }
+
+func TestInterceptCredentials_SkipsNonGcloudCredentials(t *testing.T) {
+	t.Parallel()
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(&fakeCredential{name: "custom"})
+	rt.credentialRegistry = reg
+
+	mounts := []workspace.Mount{{Host: "/some/path", Target: "/some/target"}}
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn != nil {
+		t.Error("expected nil uploadFn")
+	}
+}

--- a/pkg/runtime/openshell/credentials_test.go
+++ b/pkg/runtime/openshell/credentials_test.go
@@ -345,61 +345,6 @@ func TestInterceptCredentials_AddsHostsToNilNetwork(t *testing.T) {
 	}
 }
 
-func TestExpandWildcardHosts(t *testing.T) {
-	t.Parallel()
-
-	t.Run("expands wildcard pattern", func(t *testing.T) {
-		t.Parallel()
-
-		input := []string{"oauth2.googleapis.com", "*-aiplatform.googleapis.com", "aiplatform.googleapis.com"}
-		result := expandWildcardHosts(input)
-
-		if slices.Contains(result, "*-aiplatform.googleapis.com") {
-			t.Error("wildcard should have been expanded")
-		}
-		if !slices.Contains(result, "oauth2.googleapis.com") {
-			t.Error("non-wildcard host should be preserved")
-		}
-		if !slices.Contains(result, "aiplatform.googleapis.com") {
-			t.Error("non-wildcard host should be preserved")
-		}
-		if !slices.Contains(result, "us-central1-aiplatform.googleapis.com") {
-			t.Error("expected us-central1 regional endpoint")
-		}
-		if !slices.Contains(result, "europe-west4-aiplatform.googleapis.com") {
-			t.Error("expected europe-west4 regional endpoint")
-		}
-		if !slices.Contains(result, "storage.googleapis.com") {
-			t.Error("expected storage.googleapis.com")
-		}
-
-		expectedLen := 2 + len(vertexAIRegions) + len(extraVertexAIHosts)
-		if len(result) != expectedLen {
-			t.Errorf("expected %d hosts, got %d", expectedLen, len(result))
-		}
-	})
-
-	t.Run("passes through non-wildcard hosts", func(t *testing.T) {
-		t.Parallel()
-
-		input := []string{"example.com", "api.github.com"}
-		result := expandWildcardHosts(input)
-
-		if len(result) != 2 {
-			t.Errorf("expected 2 hosts, got %d", len(result))
-		}
-	})
-
-	t.Run("handles nil input", func(t *testing.T) {
-		t.Parallel()
-
-		result := expandWildcardHosts(nil)
-		if len(result) != 0 {
-			t.Errorf("expected empty result, got %v", result)
-		}
-	})
-}
-
 func TestRemoveMountFromConfig(t *testing.T) {
 	t.Parallel()
 
@@ -466,30 +411,80 @@ func TestAddHostsToNetworkConfig(t *testing.T) {
 	})
 }
 
-// fakeCredential implements credential.Credential for testing non-gcloud credentials.
+func TestRemapContainerPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("remaps /home/agent prefix", func(t *testing.T) {
+		t.Parallel()
+
+		got := remapContainerPath("/home/agent/.config/gcloud/application_default_credentials.json")
+		want := "/sandbox/.config/gcloud/application_default_credentials.json"
+		if got != want {
+			t.Errorf("remapContainerPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("remaps /home/agent/.kube/config", func(t *testing.T) {
+		t.Parallel()
+
+		got := remapContainerPath("/home/agent/.kube/config")
+		want := "/sandbox/.kube/config"
+		if got != want {
+			t.Errorf("remapContainerPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("preserves paths without /home/agent prefix", func(t *testing.T) {
+		t.Parallel()
+
+		got := remapContainerPath("/etc/ssl/certs/ca-certificates.crt")
+		want := "/etc/ssl/certs/ca-certificates.crt"
+		if got != want {
+			t.Errorf("remapContainerPath() = %q, want %q", got, want)
+		}
+	})
+}
+
+// fakeCredential implements credential.Credential for testing.
 type fakeCredential struct {
-	name         string
-	hostPatterns []string
+	name              string
+	containerFilePath string
+	hostPatterns      []string
+	detectHostPath    string
+	detectTarget      string
 }
 
 var _ credential.Credential = (*fakeCredential)(nil)
 
-func (f *fakeCredential) Name() string                      { return f.name }
-func (f *fakeCredential) ContainerFilePath() string         { return "/fake/path" }
-func (f *fakeCredential) HostPatterns(_ string) []string    { return f.hostPatterns }
-func (f *fakeCredential) FakeFile(_ string) ([]byte, error) { return nil, nil }
-func (f *fakeCredential) Detect(_ []workspace.Mount, _ string) (string, *workspace.Mount) {
+func (f *fakeCredential) Name() string                   { return f.name }
+func (f *fakeCredential) ContainerFilePath() string      { return f.containerFilePath }
+func (f *fakeCredential) HostPatterns(_ string) []string { return f.hostPatterns }
+func (f *fakeCredential) FakeFile(_ string) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeCredential) Detect(mounts []workspace.Mount, _ string) (string, *workspace.Mount) {
+	if f.detectTarget == "" {
+		return "", nil
+	}
+	for i := range mounts {
+		if mounts[i].Target == f.detectTarget {
+			return f.detectHostPath, &mounts[i]
+		}
+	}
 	return "", nil
 }
 func (f *fakeCredential) Configure(_ context.Context, _ onecli.Client, _ string) error { return nil }
 
-func TestInterceptCredentials_SkipsNonGcloudCredentials(t *testing.T) {
+func TestInterceptCredentials_UndetectedCredentialSkipped(t *testing.T) {
 	t.Parallel()
 
 	fakeExec := exec.NewFake()
 	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
 	reg := credential.NewRegistry()
-	_ = reg.Register(&fakeCredential{name: "custom"})
+	_ = reg.Register(&fakeCredential{
+		name:              "custom",
+		containerFilePath: "/home/agent/.custom/creds",
+	})
 	rt.credentialRegistry = reg
 
 	mounts := []workspace.Mount{{Host: "/some/path", Target: "/some/target"}}
@@ -500,6 +495,137 @@ func TestInterceptCredentials_SkipsNonGcloudCredentials(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if uploadFn != nil {
-		t.Error("expected nil uploadFn")
+		t.Error("expected nil uploadFn when credential is not detected")
+	}
+}
+
+func TestInterceptCredentials_DetectedCredentialUploaded(t *testing.T) {
+	t.Parallel()
+
+	credFile := filepath.Join(t.TempDir(), "my-creds.json")
+	if err := os.WriteFile(credFile, []byte(`{"token":"test"}`), 0644); err != nil {
+		t.Fatalf("failed to write credential file: %v", err)
+	}
+
+	mounts := []workspace.Mount{{Host: credFile, Target: "$HOME/.custom/creds"}}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(&fakeCredential{
+		name:              "custom",
+		containerFilePath: "/home/agent/.custom/creds",
+		hostPatterns:      []string{"api.custom.com"},
+		detectHostPath:    credFile,
+		detectTarget:      "$HOME/.custom/creds",
+	})
+	rt.credentialRegistry = reg
+
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn == nil {
+		t.Fatal("expected non-nil uploadFn for detected credential")
+	}
+
+	if err := uploadFn(context.Background(), "kdn-test"); err != nil {
+		t.Fatalf("uploadFn failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 1 {
+		t.Fatalf("expected 1 upload call, got %d", len(fakeExec.RunCalls))
+	}
+
+	call := fakeExec.RunCalls[0]
+	lastArg := call[len(call)-1]
+	if lastArg != "/sandbox/.custom/creds" {
+		t.Errorf("upload destination = %q, want %q", lastArg, "/sandbox/.custom/creds")
+	}
+}
+
+func TestInterceptCredentials_MultipleCredentials(t *testing.T) {
+	t.Parallel()
+
+	credFile1 := filepath.Join(t.TempDir(), "cred1.json")
+	credFile2 := filepath.Join(t.TempDir(), "cred2.json")
+	if err := os.WriteFile(credFile1, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to write cred1: %v", err)
+	}
+	if err := os.WriteFile(credFile2, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to write cred2: %v", err)
+	}
+
+	mounts := []workspace.Mount{
+		{Host: credFile1, Target: "$HOME/.cred1"},
+		{Host: credFile2, Target: "$HOME/.cred2"},
+	}
+
+	fakeExec := exec.NewFake()
+	rt := newWithDeps(fakeExec, "/fake/gw", t.TempDir())
+	reg := credential.NewRegistry()
+	_ = reg.Register(&fakeCredential{
+		name:              "cred-a",
+		containerFilePath: "/home/agent/.cred1",
+		hostPatterns:      []string{"api.a.com"},
+		detectHostPath:    credFile1,
+		detectTarget:      "$HOME/.cred1",
+	})
+	_ = reg.Register(&fakeCredential{
+		name:              "cred-b",
+		containerFilePath: "/home/agent/.cred2",
+		hostPatterns:      []string{"api.b.com"},
+		detectHostPath:    credFile2,
+		detectTarget:      "$HOME/.cred2",
+	})
+	rt.credentialRegistry = reg
+
+	cfg := &workspace.WorkspaceConfiguration{Mounts: &mounts}
+
+	uploadFn, err := rt.interceptCredentials(context.Background(), runtime.CreateParams{WorkspaceConfig: cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uploadFn == nil {
+		t.Fatal("expected non-nil uploadFn")
+	}
+
+	if err := uploadFn(context.Background(), "kdn-test"); err != nil {
+		t.Fatalf("uploadFn failed: %v", err)
+	}
+
+	if len(fakeExec.RunCalls) != 2 {
+		t.Fatalf("expected 2 upload calls, got %d", len(fakeExec.RunCalls))
+	}
+
+	if len(*cfg.Mounts) != 0 {
+		t.Errorf("expected all mounts removed, got %d", len(*cfg.Mounts))
+	}
+
+	if cfg.Network == nil || cfg.Network.Hosts == nil {
+		t.Fatal("expected network hosts to be set")
+	}
+	hosts := *cfg.Network.Hosts
+	if !slices.Contains(hosts, "api.a.com") {
+		t.Error("missing host api.a.com")
+	}
+	if !slices.Contains(hosts, "api.b.com") {
+		t.Error("missing host api.b.com")
+	}
+}
+
+func TestExpandHostPatterns(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"oauth2.googleapis.com", "*-aiplatform.googleapis.com"}
+	result := expandHostPatterns(input)
+
+	if slices.Contains(result, "*-aiplatform.googleapis.com") {
+		t.Error("registered expander should have expanded the wildcard")
+	}
+	if !slices.Contains(result, "us-central1-aiplatform.googleapis.com") {
+		t.Error("expected expanded regional endpoint")
 	}
 }

--- a/pkg/runtime/openshell/openshell.go
+++ b/pkg/runtime/openshell/openshell.go
@@ -23,6 +23,7 @@ import (
 
 	workspace "github.com/openkaiden/kdn-api/workspace-configuration/go"
 	"github.com/openkaiden/kdn/pkg/containerurl"
+	"github.com/openkaiden/kdn/pkg/credential"
 	"github.com/openkaiden/kdn/pkg/runtime"
 	"github.com/openkaiden/kdn/pkg/runtime/openshell/exec"
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -49,6 +50,7 @@ type openshellRuntime struct {
 	binariesErr           error
 	secretStore           secret.Store
 	secretServiceRegistry secretservice.Registry
+	credentialRegistry    credential.Registry
 	version               string
 }
 
@@ -75,6 +77,9 @@ var _ runtime.HostResolver = (*openshellRuntime)(nil)
 
 // Ensure openshellRuntime implements runtime.ConfigTransformer at compile time.
 var _ runtime.ConfigTransformer = (*openshellRuntime)(nil)
+
+// Ensure openshellRuntime implements runtime.CredentialRegistryAware at compile time.
+var _ runtime.CredentialRegistryAware = (*openshellRuntime)(nil)
 
 // New creates a new OpenShell Gateway runtime instance.
 func New() runtime.Runtime {
@@ -137,6 +142,11 @@ func (r *openshellRuntime) Flags() []runtime.FlagDef {
 // SetSecretServiceRegistry implements runtime.SecretServiceRegistryAware.
 func (r *openshellRuntime) SetSecretServiceRegistry(reg secretservice.Registry) {
 	r.secretServiceRegistry = reg
+}
+
+// SetCredentialRegistry implements runtime.CredentialRegistryAware.
+func (r *openshellRuntime) SetCredentialRegistry(reg credential.Registry) {
+	r.credentialRegistry = reg
 }
 
 // Initialize implements runtime.StorageAware.

--- a/pkg/runtime/openshell/terminal.go
+++ b/pkg/runtime/openshell/terminal.go
@@ -32,12 +32,10 @@ func (r *openshellRuntime) Terminal(ctx context.Context, instanceID string, _ st
 		return err
 	}
 
-	if len(command) == 0 {
-		args := []string{"sandbox", "connect", instanceID}
-		return r.executor.RunInteractive(ctx, args...)
+	shellCmd := "bash"
+	if len(command) > 0 {
+		shellCmd = strings.Join(command, " ")
 	}
-
-	shellCmd := strings.Join(command, " ")
 	wrappedCmd := fmt.Sprintf("source %s/.kdn-env 2>/dev/null; cd %s 2>/dev/null; exec %s", containerHome, containerWorkspaceSources, shellCmd)
 
 	args := []string{

--- a/pkg/runtime/openshell/terminal_test.go
+++ b/pkg/runtime/openshell/terminal_test.go
@@ -49,18 +49,20 @@ func TestTerminal_DefaultCommand(t *testing.T) {
 
 	args := fakeExec.RunInteractiveCalls[0]
 
-	// Should use sandbox connect for interactive terminal
-	if args[0] != "sandbox" || args[1] != "connect" {
-		t.Errorf("Expected 'sandbox connect', got %v", args[:2])
+	// Should use sandbox exec (not connect) so .kdn-env is sourced
+	if args[0] != "sandbox" || args[1] != "exec" {
+		t.Errorf("Expected 'sandbox exec', got %v", args[:2])
+	}
+	if args[2] != "--name" || args[3] != "kdn-test" {
+		t.Errorf("Expected '--name kdn-test', got %v", args[2:4])
 	}
 
-	// Instance ID should be a positional argument
-	if args[2] != "kdn-test" {
-		t.Errorf("Expected instance ID 'kdn-test', got %s", args[2])
+	lastArg := args[len(args)-1]
+	if !strings.Contains(lastArg, "source /sandbox/.kdn-env") {
+		t.Errorf("Expected env sourcing, got %q", lastArg)
 	}
-
-	if len(args) != 3 {
-		t.Errorf("Expected 3 args, got %d: %v", len(args), args)
+	if !strings.Contains(lastArg, "exec bash") {
+		t.Errorf("Expected default 'exec bash' command, got %q", lastArg)
 	}
 }
 


### PR DESCRIPTION
Detect gcloud ADC file mounts in workspace config and upload the real credential file directly into the sandbox via `sandbox upload`. The intercepted mount is removed from config and Vertex AI regional hosts (expanded from unsupported *- wildcards) plus storage.googleapis.com are added to the network allow list.

Source .kdn-env from .bashrc so environment variables are available in any shell session (openshell connect, kdn terminal, sandbox exec), not only through kdn terminal's wrapper.

fixes #525