### PR TITLE
feat(workspace): add --url flag to open and dashboard commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,6 +1249,12 @@ Exit code: `1` (error)
    - Success responses have specific fields (e.g., `id`, `items`, `name`, `paths`)
    - Error responses always have an `error` field
 
+5. **Use `--url`** with `open` and `dashboard` to get the URL without launching a browser — useful for scripts that need to capture or transform the URL:
+   ```bash
+   url=$(kdn open my-project --url)
+   curl "$url/api/health"
+   ```
+
 **Example script pattern:**
 
 ```bash
@@ -3799,6 +3805,7 @@ kdn dashboard NAME|ID [flags]
 
 #### Flags
 
+- `--url` - Print the URL without opening the browser
 - `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
 
 #### Examples
@@ -3813,6 +3820,12 @@ Output: `http://localhost:8888` (URL printed; browser opened automatically)
 ```bash
 kdn workspace dashboard my-project
 ```
+
+**Print the URL without opening the browser:**
+```bash
+kdn workspace dashboard my-project --url
+```
+Output: `http://localhost:8888` (URL printed; browser **not** opened)
 
 **Use the short alias:**
 ```bash
@@ -3868,6 +3881,7 @@ kdn open NAME|ID [PORT] [flags]
 
 #### Flags
 
+- `--url` - Print the URL without opening the browser
 - `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
 
 #### Examples
@@ -3883,6 +3897,12 @@ Output: `http://127.0.0.1:54321` (URL printed; browser opened automatically)
 kdn workspace open my-project 8080
 kdn open my-project 8080
 ```
+
+**Print the URL without opening the browser:**
+```bash
+kdn workspace open my-project --url
+```
+Output: `http://127.0.0.1:54321` (URL printed; browser **not** opened)
 
 #### Error Handling
 

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -36,5 +36,7 @@ func NewOpenCmd() *cobra.Command {
 		RunE:              workspaceOpenCmd.RunE,
 	}
 
+	cmd.Flags().AddFlagSet(workspaceOpenCmd.Flags())
+
 	return cmd
 }

--- a/pkg/cmd/workspace_dashboard.go
+++ b/pkg/cmd/workspace_dashboard.go
@@ -35,6 +35,7 @@ import (
 type workspaceDashboardCmd struct {
 	manager     instances.Manager
 	nameOrID    string
+	urlOnly     bool
 	openBrowser func(ctx context.Context, url string) error
 }
 
@@ -79,7 +80,7 @@ func (w *workspaceDashboardCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), url)
-	if w.openBrowser != nil {
+	if w.openBrowser != nil && !w.urlOnly {
 		_ = w.openBrowser(cmd.Context(), url)
 	}
 	return nil
@@ -113,12 +114,17 @@ func NewWorkspaceDashboardCmd() *cobra.Command {
 kdn workspace dashboard abc123
 
 # Open dashboard by workspace name
-kdn workspace dashboard my-project`,
+kdn workspace dashboard my-project
+
+# Print the URL without opening the browser
+kdn workspace dashboard my-project --url`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeDashboardWorkspaceID,
 		PreRunE:           c.preRun,
 		RunE:              c.run,
 	}
+
+	cmd.Flags().BoolVar(&c.urlOnly, "url", false, "Print the URL without opening the browser")
 
 	return cmd
 }

--- a/pkg/cmd/workspace_dashboard_test.go
+++ b/pkg/cmd/workspace_dashboard_test.go
@@ -216,6 +216,65 @@ func TestWorkspaceDashboardCmd_E2E(t *testing.T) {
 		}
 	})
 
+	t.Run("prints URL without opening browser when urlOnly is set", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		sourceDir := t.TempDir()
+
+		const dashboardURL = "http://localhost:8888"
+
+		manager, err := instances.NewManager(storageDir)
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		if err := manager.RegisterRuntime(fake.NewWithDashboard(dashboardURL)); err != nil {
+			t.Fatalf("Failed to register fake runtime with dashboard: %v", err)
+		}
+
+		inst, err := instances.NewInstance(instances.NewInstanceParams{
+			SourceDir: sourceDir,
+			ConfigDir: filepath.Join(sourceDir, ".kaiden"),
+		})
+		if err != nil {
+			t.Fatalf("Failed to create instance: %v", err)
+		}
+		added, err := manager.Add(context.Background(), instances.AddOptions{Instance: inst, RuntimeType: "fake"})
+		if err != nil {
+			t.Fatalf("Failed to add instance: %v", err)
+		}
+		if err := manager.Start(context.Background(), added.GetID()); err != nil {
+			t.Fatalf("Failed to start instance: %v", err)
+		}
+
+		browserCalled := false
+		c := &workspaceDashboardCmd{
+			manager:  manager,
+			nameOrID: added.GetID(),
+			urlOnly:  true,
+			openBrowser: func(_ context.Context, _ string) error {
+				browserCalled = true
+				return nil
+			},
+		}
+
+		var outBuf bytes.Buffer
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&outBuf)
+
+		if err := c.run(cobraCmd, nil); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		output := strings.TrimSpace(outBuf.String())
+		if output != dashboardURL {
+			t.Errorf("Expected output %q, got %q", dashboardURL, output)
+		}
+		if browserCalled {
+			t.Error("Expected openBrowser to NOT be called when urlOnly is true")
+		}
+	})
+
 	t.Run("requires exactly one argument", func(t *testing.T) {
 		t.Parallel()
 
@@ -245,7 +304,7 @@ func TestWorkspaceDashboardCmd_Examples(t *testing.T) {
 		t.Fatalf("Failed to parse examples: %v", err)
 	}
 
-	expectedCount := 2
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}

--- a/pkg/cmd/workspace_open.go
+++ b/pkg/cmd/workspace_open.go
@@ -37,6 +37,7 @@ type workspaceOpenCmd struct {
 	manager     instances.Manager
 	nameOrID    string
 	port        int // target port, 0 means not specified
+	urlOnly     bool
 	openBrowser func(ctx context.Context, url string) error
 }
 
@@ -110,7 +111,7 @@ func (w *workspaceOpenCmd) run(cmd *cobra.Command, args []string) error {
 
 	url := fmt.Sprintf("http://%s:%d", forward.Bind, forward.Port)
 	fmt.Fprintln(cmd.OutOrStdout(), url)
-	if w.openBrowser != nil {
+	if w.openBrowser != nil && !w.urlOnly {
 		_ = w.openBrowser(cmd.Context(), url)
 	}
 	return nil
@@ -143,12 +144,17 @@ func NewWorkspaceOpenCmd() *cobra.Command {
 kdn workspace open my-project
 
 # Open a specific forwarded port of a workspace
-kdn workspace open my-project 8080`,
+kdn workspace open my-project 8080
+
+# Print the URL without opening the browser
+kdn workspace open my-project --url`,
 		Args:              cobra.RangeArgs(1, 2),
 		ValidArgsFunction: completeOpenArgs,
 		PreRunE:           c.preRun,
 		RunE:              c.run,
 	}
+
+	cmd.Flags().BoolVar(&c.urlOnly, "url", false, "Print the URL without opening the browser")
 
 	return cmd
 }

--- a/pkg/cmd/workspace_open_test.go
+++ b/pkg/cmd/workspace_open_test.go
@@ -342,6 +342,46 @@ func TestWorkspaceOpenCmd_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("prints URL without opening browser when urlOnly is set", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		forwards := []map[string]any{
+			{"bind": "127.0.0.1", "port": 45678, "target": 8080},
+		}
+		id := setupWorkspaceWithForwards(t, storageDir, forwards)
+
+		manager, _ := instances.NewManager(storageDir)
+		_ = manager.RegisterRuntime(fake.New())
+
+		browserCalled := false
+		c := &workspaceOpenCmd{
+			manager:  manager,
+			nameOrID: id,
+			urlOnly:  true,
+			openBrowser: func(_ context.Context, _ string) error {
+				browserCalled = true
+				return nil
+			},
+		}
+
+		var outBuf bytes.Buffer
+		cobraCmd := &cobra.Command{}
+		cobraCmd.SetOut(&outBuf)
+
+		if err := c.run(cobraCmd, nil); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		expected := "http://127.0.0.1:45678"
+		if output := strings.TrimSpace(outBuf.String()); output != expected {
+			t.Errorf("stdout = %q, want %q", output, expected)
+		}
+		if browserCalled {
+			t.Error("Expected openBrowser to NOT be called when urlOnly is true")
+		}
+	})
+
 	t.Run("fails when specified port not found", func(t *testing.T) {
 		t.Parallel()
 
@@ -419,7 +459,7 @@ func TestWorkspaceOpenCmd_Examples(t *testing.T) {
 		t.Fatalf("Failed to parse examples: %v", err)
 	}
 
-	expectedCount := 2
+	expectedCount := 3
 	if len(commands) != expectedCount {
 		t.Errorf("Expected %d example commands, got %d", expectedCount, len(commands))
 	}


### PR DESCRIPTION
## Summary
- Adds a `--url` flag to `workspace open`, `workspace dashboard`, and the `open` alias
- When set, the URL is printed to stdout without launching the browser
- Useful for scripting, piping, and headless/remote environments

Fixes: https://github.com/openkaiden/kdn/issues/536

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/cmd/ -run TestWorkspaceOpen` — all pass, including new `urlOnly` test
- [x] `go test ./pkg/cmd/ -run TestWorkspaceDashboard` — all pass, including new `urlOnly` test
- [ ] Manual: `kdn workspace open <name> --url` prints URL only
- [ ] Manual: `kdn workspace dashboard <name> --url` prints URL only
- [ ] Manual: `kdn open <name> --url` works via alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)