### PR TITLE
feat(provider): add provider connection management commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,21 @@ When a workspace has `network.mode = deny`, the Podman runtime enforces outbound
 
 **For the full design, use:** `/working-with-onecli`
 
+### Provider Connection System
+
+The provider connection system stores named, typed LLM connections (e.g. `anthropic`, `vertexai`) persistently. Secret-kind parameters are stored in the shared secret store under a namespaced key (`<providerName>/<paramName>`) so they appear in `kdn secret list` with the correct type and description.
+
+**Key Components:**
+- **`ProviderService` interface** (`pkg/providerservice/providerservice.go`): Describes a provider type — `Name()`, `Params()`. Each `ProviderParam` carries `Name`, `Kind` (`plain`, `secret`, `credential`), `Required`, `Description`, and `SecretType` (the secret service type used when storing the param; only meaningful for `Kind=secret`; valid values are registered secret service names such as `"anthropic"`)
+- **Registry** (`pkg/providerservice/registry.go`): Thread-safe ordered list of `ProviderService` instances
+- **JSON-driven registration** (`pkg/providerservicesetup/register.go` + `providerservices.json`): All provider types and their params are declared in `providerservices.json`; `register.go` parses the file and registers each service. Adding a new provider type only requires a new JSON entry — no Go code change
+- **`provider.Store` interface** (`pkg/provider/store.go`): `Create`, `List`, `Get`, `Remove`. The store writes provider records to `<storageDir>/providers/providers.json` and delegates secret-kind params to the shared `secret.Store` (`<storageDir>/secrets.json`)
+- **CLI commands** (`pkg/cmd/provider_*.go`): `provider create`, `provider list`, `provider remove` — follow the standard `preRun`/`run` split pattern with JSON output support
+
+**Secret storage:** When a provider is created, each `secret`-kind param is stored in the shared secret store as `<providerName>/<paramName>` with type `p.SecretType` and description `"<paramName> for <providerName> provider"`. This makes provider secrets visible alongside user secrets in `kdn secret list`.
+
+**Dynamic `Long` description:** `buildProviderCreateUsage()` generates the usage synopsis for `provider create` from `ListServices()` at startup — types in alphabetical order, required params first (alphabetical), then optional params (alphabetical). Adding a new provider type to `providerservices.json` automatically updates the help text.
+
 ### Secret Service System
 
 The secret service system provides a pluggable architecture for managing secret service definitions that describe how secrets are applied to workspace requests.

--- a/README.md
+++ b/README.md
@@ -2887,6 +2887,170 @@ kdn secret rm my-github-token
 - Workspaces that reference the removed secret by name will fail to start until a new secret with the same name is created
 - **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1. Always check the exit code to determine success/failure
 
+## Provider Commands
+
+Provider connections are named, typed LLM connections (e.g. `anthropic`, `vertexai`) that kdn stores persistently. Secret-kind parameters (such as API tokens) are kept in the shared secret store under a namespaced key (`<provider>/<param>`) and appear in `kdn secret list`.
+
+**Workflow:**
+1. Create a connection: `kdn provider create my-anthropic --type anthropic --token sk-ant-xxx`
+2. List connections: `kdn provider list`
+3. Remove a connection: `kdn provider remove my-anthropic`
+
+### `provider create` - Create a New Provider Connection
+
+Creates a named LLM provider connection and stores its parameters. Secret-kind parameters are stored in the shared secret store.
+
+#### Usage
+
+```bash
+kdn provider create <name> --type <type> [flags]
+```
+
+#### Arguments
+
+- `name` - Name for the provider connection (must be unique)
+
+#### Flags
+
+- `--type <type>` - Provider type (`anthropic`, `vertexai`)
+- `--token <secret>` - API token (anthropic)
+- `--url <url>` - API base URL override (anthropic, optional)
+- `--project <project>` - GCP project ID (vertexai)
+- `--region <region>` - GCP region (vertexai)
+- `--credentials <path>` - Path to GCP credentials file (vertexai, optional)
+- `--output, -o <format>` - Output format (supported: `json`)
+- `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
+
+#### Examples
+
+**Create an Anthropic provider connection:**
+```bash
+kdn provider create my-anthropic --type anthropic --token sk-ant-mytoken
+```
+Output:
+```text
+Provider "my-anthropic" created successfully
+```
+
+**Create a Vertex AI provider connection:**
+```bash
+kdn provider create my-vertexai --type vertexai --project my-project --region us-central1
+```
+
+**Create with JSON output:**
+```bash
+kdn provider create my-anthropic --type anthropic --token sk-ant-mytoken --output json
+```
+Output:
+```json
+{
+  "name": "my-anthropic"
+}
+```
+
+#### Notes
+
+- Secret-kind parameters (e.g. `--token`) are stored in the shared secret store under `<name>/<param>` and appear in `kdn secret list`
+- **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1
+
+### `provider list` - List Provider Connections
+
+Lists all configured LLM provider connections. Secret-kind parameter values are masked as `<secret>` in table output; the reference name is shown in JSON output.
+
+#### Usage
+
+```bash
+kdn provider list [flags]
+```
+
+#### Flags
+
+- `--output, -o <format>` - Output format (supported: `json`)
+- `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
+
+#### Examples
+
+**List all provider connections:**
+```bash
+kdn provider list
+```
+Output:
+```text
+NAME           TYPE       PARAMS
+my-anthropic   anthropic  token=<secret>
+my-vertexai    vertexai   project=my-project, region=us-central1
+```
+
+**List with JSON output:**
+```bash
+kdn provider list --output json
+```
+Output:
+```json
+{
+  "items": [
+    {
+      "name": "my-anthropic",
+      "type": "anthropic",
+      "params": [
+        {"name": "token", "value": "my-anthropic/token"}
+      ]
+    }
+  ]
+}
+```
+
+#### Notes
+
+- Secret param `value` in JSON output is the secret reference name (e.g. `my-anthropic/token`), not the actual secret value
+- **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1
+
+### `provider remove` - Remove a Provider Connection
+
+Removes a provider connection and its associated secrets from the store.
+
+#### Usage
+
+```bash
+kdn provider remove <name> [flags]
+kdn provider rm <name> [flags]
+```
+
+#### Arguments
+
+- `name` - Name of the provider connection to remove
+
+#### Flags
+
+- `--output, -o <format>` - Output format (supported: `json`)
+- `--storage <path>` - Storage directory for kdn data (default: `$HOME/.kdn`)
+
+#### Examples
+
+**Remove a provider connection:**
+```bash
+kdn provider remove my-anthropic
+```
+Output:
+```text
+Provider "my-anthropic" removed successfully
+```
+
+**Remove with JSON output:**
+```bash
+kdn provider remove my-anthropic --output json
+```
+Output:
+```json
+{
+  "name": "my-anthropic"
+}
+```
+
+#### Notes
+
+- **JSON error handling**: When `--output json` is used, errors are written to stdout (not stderr) in JSON format, and the CLI exits with code 1
+
 ## Commands
 
 ### `info` - Display Information About kdn

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -26,6 +26,7 @@ import (
 	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/envvars"
 	"github.com/openkaiden/kdn/pkg/instances"
+	"github.com/openkaiden/kdn/pkg/provider"
 	"github.com/openkaiden/kdn/pkg/runtimesetup"
 	"github.com/openkaiden/kdn/pkg/secret"
 	"github.com/spf13/cobra"
@@ -205,6 +206,37 @@ func completeSecretName(cmd *cobra.Command, args []string, toComplete string) ([
 	}
 
 	items, err := secret.NewStore(absStorageDir).List()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeProviderName provides completion for provider names by reading the provider store.
+// The args and toComplete parameters are part of Cobra's ValidArgsFunction signature but are unused
+// because Cobra's shell completion framework automatically filters results based on user input.
+func completeProviderName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	if _, err := os.Stat(absStorageDir); os.IsNotExist(err) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	items, err := provider.NewStore(absStorageDir).List()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/pkg/cmd/autocomplete_test.go
+++ b/pkg/cmd/autocomplete_test.go
@@ -742,6 +742,129 @@ func TestCompleteSecretName(t *testing.T) {
 	})
 }
 
+func TestCompleteProviderName(t *testing.T) {
+	t.Parallel()
+
+	// writeProvidersJSON writes a minimal providers.json so List() returns known names.
+	writeProvidersJSON := func(t *testing.T, dir string, names []string) {
+		t.Helper()
+		type paramRecord struct {
+			Name  string `json:"name"`
+			Kind  string `json:"kind"`
+			Value string `json:"value"`
+		}
+		type record struct {
+			Name   string        `json:"name"`
+			Type   string        `json:"type"`
+			Params []paramRecord `json:"params"`
+		}
+		type file struct {
+			Providers []record `json:"providers"`
+		}
+		records := make([]record, 0, len(names))
+		for _, n := range names {
+			records = append(records, record{Name: n, Type: "anthropic", Params: []paramRecord{}})
+		}
+		data, err := json.Marshal(file{Providers: records})
+		if err != nil {
+			t.Fatalf("failed to marshal providers: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "providers.json"), data, 0600); err != nil {
+			t.Fatalf("failed to write providers.json: %v", err)
+		}
+	}
+
+	t.Run("returns names of stored providers", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		writeProvidersJSON(t, storageDir, []string{"my-anthropic", "my-vertexai"})
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		completions, directive := completeProviderName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 2 {
+			t.Fatalf("expected 2 completions, got %d: %v", len(completions), completions)
+		}
+		found := map[string]bool{}
+		for _, c := range completions {
+			found[c] = true
+		}
+		for _, name := range []string{"my-anthropic", "my-vertexai"} {
+			if !found[name] {
+				t.Errorf("expected %q in completions, got %v", name, completions)
+			}
+		}
+	})
+
+	t.Run("returns no completions when storage directory does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", filepath.Join(t.TempDir(), "nonexistent"), "")
+
+		completions, directive := completeProviderName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns empty list when no providers exist", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", t.TempDir(), "")
+
+		completions, directive := completeProviderName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+		}
+		if len(completions) != 0 {
+			t.Errorf("expected 0 completions, got %d: %v", len(completions), completions)
+		}
+	})
+
+	t.Run("returns error directive when storage flag is not registered", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{}
+
+		_, directive := completeProviderName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("expected ShellCompDirectiveError, got %v", directive)
+		}
+	})
+
+	t.Run("returns error directive when providers.json is corrupt", func(t *testing.T) {
+		t.Parallel()
+
+		storageDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(storageDir, "providers.json"), []byte("not-json"), 0600); err != nil {
+			t.Fatalf("failed to write corrupt providers.json: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", storageDir, "")
+
+		_, directive := completeProviderName(cmd, []string{}, "")
+
+		if directive != cobra.ShellCompDirectiveError {
+			t.Errorf("expected ShellCompDirectiveError, got %v", directive)
+		}
+	})
+}
+
 func TestCompleteDashboardWorkspaceID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/provider.go
+++ b/pkg/cmd/provider.go
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// providerNameOutput is the JSON output for provider create and remove commands.
+type providerNameOutput struct {
+	Name string `json:"name"`
+}
+
+// providerParamOutput is the JSON output for a single provider parameter.
+type providerParamOutput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// providerInfoOutput is the JSON output for a single provider entry.
+type providerInfoOutput struct {
+	Name   string                `json:"name"`
+	Type   string                `json:"type"`
+	Params []providerParamOutput `json:"params,omitempty"`
+}
+
+// providersListOutput is the JSON output for the provider list command.
+type providersListOutput struct {
+	Items []providerInfoOutput `json:"items"`
+}
+
+func NewProviderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "provider",
+		Short: "Manage LLM provider connections",
+		Long:  "Manage LLM provider connections",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewProviderCreateCmd())
+	cmd.AddCommand(NewProviderListCmd())
+	cmd.AddCommand(NewProviderRemoveCmd())
+
+	return cmd
+}

--- a/pkg/cmd/provider.go
+++ b/pkg/cmd/provider.go
@@ -24,29 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// providerNameOutput is the JSON output for provider create and remove commands.
-type providerNameOutput struct {
-	Name string `json:"name"`
-}
-
-// providerParamOutput is the JSON output for a single provider parameter.
-type providerParamOutput struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-}
-
-// providerInfoOutput is the JSON output for a single provider entry.
-type providerInfoOutput struct {
-	Name   string                `json:"name"`
-	Type   string                `json:"type"`
-	Params []providerParamOutput `json:"params,omitempty"`
-}
-
-// providersListOutput is the JSON output for the provider list command.
-type providersListOutput struct {
-	Items []providerInfoOutput `json:"items"`
-}
-
 func NewProviderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider",

--- a/pkg/cmd/provider_create.go
+++ b/pkg/cmd/provider_create.go
@@ -1,0 +1,233 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/openkaiden/kdn/pkg/provider"
+	"github.com/openkaiden/kdn/pkg/providerservice"
+	"github.com/openkaiden/kdn/pkg/providerservicesetup"
+	"github.com/spf13/cobra"
+)
+
+type providerCreateCmd struct {
+	providerType string
+	output       string
+	store        provider.Store
+	validTypes   []string
+	// params is populated in preRun from the flags explicitly set by the user.
+	params []provider.ProviderParamEntry
+}
+
+func (c *providerCreateCmd) isValidType(t string) bool {
+	for _, v := range c.validTypes {
+		if t == v {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *providerCreateCmd) preRun(cmd *cobra.Command, args []string) error {
+	if c.output != "" && c.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", c.output)
+	}
+	if c.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
+	if c.providerType == "" {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("--type is required"))
+	}
+	if !c.isValidType(c.providerType) {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("invalid --type %q: must be one of %s", c.providerType, strings.Join(c.validTypes, ", ")))
+	}
+
+	services := providerservicesetup.ListServices()
+
+	// Build the set of valid params for the selected type.
+	validParams := make(map[string]providerservice.ProviderParam)
+	var selectedSvc providerservice.ProviderService
+	for _, s := range services {
+		if s.Name() == c.providerType {
+			selectedSvc = s
+			for _, p := range s.Params() {
+				validParams[p.Name] = p
+			}
+			break
+		}
+	}
+
+	// Reject flags that don't belong to the selected type.
+	for paramName := range allProviderParamNames(services) {
+		if cmd.Flags().Changed(paramName) {
+			if _, ok := validParams[paramName]; !ok {
+				return outputErrorIfJSON(cmd, c.output, fmt.Errorf("--%s is not valid for --type=%s", paramName, c.providerType))
+			}
+		}
+	}
+
+	// Verify all required params were explicitly provided.
+	for _, p := range selectedSvc.Params() {
+		if p.Required && !cmd.Flags().Changed(p.Name) {
+			return outputErrorIfJSON(cmd, c.output, fmt.Errorf("--%s is required for --type=%s", p.Name, c.providerType))
+		}
+	}
+
+	// Collect param entries from the flags that were explicitly set.
+	params, err := collectProviderParams(cmd, selectedSvc)
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, err)
+	}
+	c.params = params
+
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to read --storage flag: %w", err))
+	}
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to resolve storage directory path: %w", err))
+	}
+	c.store = provider.NewStore(absStorageDir)
+	return nil
+}
+
+func (c *providerCreateCmd) run(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := c.store.Create(provider.CreateParams{
+		Name:   name,
+		Type:   c.providerType,
+		Params: c.params,
+	}); err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to create provider: %w", err))
+	}
+
+	if c.output == "json" {
+		return c.outputJSON(cmd, name)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Provider %q created successfully\n", name)
+	return nil
+}
+
+func (c *providerCreateCmd) outputJSON(cmd *cobra.Command, name string) error {
+	response := providerNameOutput{Name: name}
+
+	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to marshal to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
+// paramPlaceholder returns the usage placeholder string for a provider param.
+// Secrets show <value> to avoid hinting at the param name; credential params
+// append -path to signal that a file path is expected; all others use <paramname>.
+func paramPlaceholder(p providerservice.ProviderParam) string {
+	switch p.Kind {
+	case providerservice.ProviderParamKindSecret:
+		return "<secret>"
+	case providerservice.ProviderParamKindCredential:
+		return "<" + p.Name + "-path>"
+	default:
+		return "<" + p.Name + ">"
+	}
+}
+
+// buildProviderCreateUsage builds the synopsis section of the Long description dynamically
+// from the registered provider services. Types are listed alphabetically; within each type,
+// required params come first (alphabetical), followed by optional params (alphabetical).
+func buildProviderCreateUsage(services []providerservice.ProviderService) string {
+	sorted := make([]providerservice.ProviderService, len(services))
+	copy(sorted, services)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name() < sorted[j].Name() })
+
+	lines := make([]string, 0, len(sorted))
+	for _, svc := range sorted {
+		var required, optional []providerservice.ProviderParam
+		for _, p := range svc.Params() {
+			if p.Required {
+				required = append(required, p)
+			} else {
+				optional = append(optional, p)
+			}
+		}
+		sort.Slice(required, func(i, j int) bool { return required[i].Name < required[j].Name })
+		sort.Slice(optional, func(i, j int) bool { return optional[i].Name < optional[j].Name })
+
+		parts := []string{"--type " + svc.Name()}
+		for _, p := range required {
+			parts = append(parts, "--"+p.Name+" "+paramPlaceholder(p))
+		}
+		for _, p := range optional {
+			parts = append(parts, "[--"+p.Name+" "+paramPlaceholder(p)+"]")
+		}
+		lines = append(lines, strings.Join(parts, " "))
+	}
+
+	return "create <name>\n  " + strings.Join(lines, " |\n  ")
+}
+
+func NewProviderCreateCmd() *cobra.Command {
+	availableTypes := providerservicesetup.ListAvailable()
+	sort.Strings(availableTypes)
+	typesStr := strings.Join(availableTypes, ", ")
+
+	c := &providerCreateCmd{validTypes: availableTypes}
+
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new provider connection",
+		Long: "Create a new LLM provider connection.\n\nUsage:\n  " +
+			buildProviderCreateUsage(providerservicesetup.ListServices()),
+		Example: `# Create an Anthropic provider connection
+kdn provider create my-anthropic --type anthropic --token my-secret-token
+
+# Create a Vertex AI provider connection
+kdn provider create my-vertexai --type vertexai --project my-project --region us-central1 --credentials ~/.config/gcloud/application_default_credentials.json
+
+# Create an Anthropic provider connection with JSON output
+kdn provider create my-anthropic --type anthropic --token my-secret-token --output json`,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	cmd.Flags().StringVar(&c.providerType, "type", "", fmt.Sprintf("Type of provider (%s)", typesStr))
+	cmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return availableTypes, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	registerProviderParamFlags(cmd, providerservicesetup.ListServices())
+	registerProviderParamFlagCompletions(cmd, providerservicesetup.ListServices())
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
+
+	return cmd
+}

--- a/pkg/cmd/provider_create.go
+++ b/pkg/cmd/provider_create.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/provider"
 	"github.com/openkaiden/kdn/pkg/providerservice"
 	"github.com/openkaiden/kdn/pkg/providerservicesetup"
@@ -134,7 +135,7 @@ func (c *providerCreateCmd) run(cmd *cobra.Command, args []string) error {
 }
 
 func (c *providerCreateCmd) outputJSON(cmd *cobra.Command, name string) error {
-	response := providerNameOutput{Name: name}
+	response := api.ProviderName{Name: name}
 
 	jsonData, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {

--- a/pkg/cmd/provider_create_test.go
+++ b/pkg/cmd/provider_create_test.go
@@ -1,0 +1,391 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/openkaiden/kdn/pkg/provider"
+	"github.com/openkaiden/kdn/pkg/providerservicesetup"
+	"github.com/spf13/cobra"
+)
+
+// fakeProviderStore records calls for assertion in tests.
+type fakeProviderStore struct {
+	createParams provider.CreateParams
+	createErr    error
+	listItems    []provider.ListItem
+	listErr      error
+	removeName   string
+	removeErr    error
+}
+
+func (f *fakeProviderStore) Create(params provider.CreateParams) error {
+	f.createParams = params
+	return f.createErr
+}
+
+func (f *fakeProviderStore) List() ([]provider.ListItem, error) {
+	return f.listItems, f.listErr
+}
+
+func (f *fakeProviderStore) Get(name string) (provider.ListItem, map[string]string, error) {
+	return provider.ListItem{}, nil, errors.New("not found")
+}
+
+func (f *fakeProviderStore) Remove(name string) error {
+	f.removeName = name
+	return f.removeErr
+}
+
+// buildProviderPreRunCmd creates a cobra.Command that mirrors the flag set seen by
+// preRun when called through the real command tree.
+func buildProviderPreRunCmd(storageDir string) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("storage", storageDir, "")
+	// Register all provider param flags so Changed() / GetString() work in tests
+	registerProviderParamFlags(cmd, providerservicesetup.ListServices())
+	return cmd
+}
+
+func TestBuildProviderCreateUsage(t *testing.T) {
+	t.Parallel()
+
+	usage := buildProviderCreateUsage(providerservicesetup.ListServices())
+
+	// Must start with the command synopsis.
+	if !strings.HasPrefix(usage, "create <name>") {
+		t.Errorf("expected usage to start with 'create <name>', got: %s", usage)
+	}
+	// Types must appear in alphabetical order (anthropic before vertexai).
+	anthropicIdx := strings.Index(usage, "--type anthropic")
+	vertexaiIdx := strings.Index(usage, "--type vertexai")
+	if anthropicIdx == -1 || vertexaiIdx == -1 {
+		t.Fatalf("expected both --type anthropic and --type vertexai in usage, got: %s", usage)
+	}
+	if anthropicIdx > vertexaiIdx {
+		t.Errorf("expected anthropic before vertexai in usage, got: %s", usage)
+	}
+	// Required anthropic param must appear without brackets.
+	if !strings.Contains(usage, "--token <secret>") {
+		t.Errorf("expected '--token <secret>' (required, no brackets) in usage, got: %s", usage)
+	}
+	// Optional anthropic param must appear with brackets.
+	if !strings.Contains(usage, "[--url <url>]") {
+		t.Errorf("expected '[--url <url>]' (optional, bracketed) in usage, got: %s", usage)
+	}
+	// Credential param must use <name-path> placeholder.
+	if !strings.Contains(usage, "[--credentials <credentials-path>]") {
+		t.Errorf("expected '[--credentials <credentials-path>]' in usage, got: %s", usage)
+	}
+	// Alternatives must be separated by |.
+	if !strings.Contains(usage, "|") {
+		t.Errorf("expected '|' separator between type alternatives, got: %s", usage)
+	}
+}
+
+func TestProviderCreateCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderCreateCmd()
+	if cmd == nil {
+		t.Fatal("NewProviderCreateCmd() returned nil")
+	}
+	if cmd.Use != "create <name>" {
+		t.Errorf("expected Use %q, got %q", "create <name>", cmd.Use)
+	}
+}
+
+func TestProviderCreateCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderCreateCmd()
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("failed to parse examples: %v", err)
+	}
+
+	expectedCount := 3
+	if len(commands) != expectedCount {
+		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	if err := testutil.ValidateCommandExamples(rootCmd, cmd.Example); err != nil {
+		t.Errorf("example validation failed: %v", err)
+	}
+}
+
+func TestProviderCreateCmd_PreRun_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &providerCreateCmd{output: "xml", validTypes: []string{"anthropic", "vertexai"}}
+	cmd := buildProviderPreRunCmd(t.TempDir())
+	if err := c.preRun(cmd, []string{"name"}); err == nil {
+		t.Fatal("expected error for unsupported output format")
+	}
+}
+
+func TestProviderCreateCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing --type", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--type is required") {
+			t.Errorf("expected '--type is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid --type", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "openai", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "invalid --type") {
+			t.Errorf("expected 'invalid --type' error, got: %v", err)
+		}
+	})
+
+	t.Run("anthropic missing --token", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "anthropic", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--token is required") {
+			t.Errorf("expected '--token is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("vertexai missing --project", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "vertexai", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("region", "us-central1"); err != nil {
+			t.Fatal(err)
+		}
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--project is required") {
+			t.Errorf("expected '--project is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("vertexai missing --region", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "vertexai", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("project", "my-project"); err != nil {
+			t.Fatal(err)
+		}
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--region is required") {
+			t.Errorf("expected '--region is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("anthropic with vertexai-only flag rejected", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "anthropic", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("token", "my-token"); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Flags().Set("project", "my-project"); err != nil {
+			t.Fatal(err)
+		}
+		err := c.preRun(cmd, []string{"name"})
+		if err == nil || !strings.Contains(err.Error(), "--project is not valid for --type=anthropic") {
+			t.Errorf("expected '--project is not valid' error, got: %v", err)
+		}
+	})
+
+	t.Run("valid anthropic params", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "anthropic", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("token", "sk-ant-token"); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.preRun(cmd, []string{"my-provider"}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if c.store == nil {
+			t.Error("expected store to be initialised")
+		}
+		if len(c.params) != 1 || c.params[0].Name != "token" {
+			t.Errorf("expected params to contain token, got: %v", c.params)
+		}
+	})
+
+	t.Run("json output silences errors", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerCreateCmd{providerType: "anthropic", output: "json", validTypes: []string{"anthropic", "vertexai"}}
+		cmd := buildProviderPreRunCmd(t.TempDir())
+		if err := cmd.Flags().Set("token", "sk-ant-token"); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.preRun(cmd, []string{"my-provider"}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !cmd.SilenceErrors {
+			t.Error("expected cmd.SilenceErrors to be true when output is json")
+		}
+	})
+}
+
+func TestProviderCreateCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("calls store with correct params", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{}
+		c := &providerCreateCmd{
+			providerType: "anthropic",
+			store:        fs,
+			params: []provider.ProviderParamEntry{
+				{Name: "token", Value: "sk-ant-token"},
+			},
+			validTypes: []string{"anthropic", "vertexai"},
+		}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-anthropic"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		if fs.createParams.Name != "my-anthropic" {
+			t.Errorf("Name: want %q, got %q", "my-anthropic", fs.createParams.Name)
+		}
+		if fs.createParams.Type != "anthropic" {
+			t.Errorf("Type: want %q, got %q", "anthropic", fs.createParams.Type)
+		}
+		if len(fs.createParams.Params) != 1 || fs.createParams.Params[0].Name != "token" {
+			t.Errorf("Params: want [{token}], got %v", fs.createParams.Params)
+		}
+		if !strings.Contains(out.String(), "my-anthropic") {
+			t.Errorf("expected success message to contain provider name, got: %q", out.String())
+		}
+	})
+
+	t.Run("store error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{createErr: errors.New("disk full")}
+		c := &providerCreateCmd{store: fs, validTypes: []string{"anthropic", "vertexai"}}
+
+		cmd := &cobra.Command{}
+		err := c.run(cmd, []string{"x"})
+		if err == nil {
+			t.Fatal("expected error when store fails")
+		}
+	})
+
+	t.Run("json output contains provider name", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{}
+		c := &providerCreateCmd{
+			providerType: "anthropic",
+			output:       "json",
+			store:        fs,
+			validTypes:   []string{"anthropic", "vertexai"},
+		}
+
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-anthropic"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		if !strings.Contains(output, `"name"`) {
+			t.Errorf("expected 'name' key in JSON output, got: %s", output)
+		}
+		if !strings.Contains(output, `"my-anthropic"`) {
+			t.Errorf("expected provider name in JSON output, got: %s", output)
+		}
+	})
+}
+
+func TestProviderCreateCmd_CredentialsFlagCompletion(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderCreateCmd()
+	completionFunc, ok := cmd.GetFlagCompletionFunc("credentials")
+	if !ok {
+		t.Fatal("expected completion function registered for --credentials flag")
+	}
+
+	_, directive := completionFunc(cmd, []string{}, "")
+	if directive != cobra.ShellCompDirectiveDefault {
+		t.Errorf("expected ShellCompDirectiveDefault for credential flag, got %v", directive)
+	}
+}
+
+func TestProviderCreateCmd_TypeFlagCompletion(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderCreateCmd()
+	completionFunc, ok := cmd.GetFlagCompletionFunc("type")
+	if !ok {
+		t.Fatal("expected completion function registered for --type flag")
+	}
+
+	completions, directive := completionFunc(cmd, []string{}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	found := false
+	for _, c := range completions {
+		if c == "anthropic" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'anthropic' in completions, got %v", completions)
+	}
+}

--- a/pkg/cmd/provider_flags.go
+++ b/pkg/cmd/provider_flags.go
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openkaiden/kdn/pkg/provider"
+	"github.com/openkaiden/kdn/pkg/providerservice"
+	"github.com/spf13/cobra"
+)
+
+// registerProviderParamFlagCompletions registers shell completion for provider param flags.
+// Credential-kind params (e.g. --credentials for vertexai) get file completion so the shell
+// can suggest paths; all other param kinds get no completion.
+func registerProviderParamFlagCompletions(cmd *cobra.Command, services []providerservice.ProviderService) {
+	seen := make(map[string]bool)
+	for _, svc := range services {
+		for _, p := range svc.Params() {
+			if seen[p.Name] {
+				continue
+			}
+			seen[p.Name] = true
+			if p.Kind == providerservice.ProviderParamKindCredential {
+				cmd.RegisterFlagCompletionFunc(p.Name, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+					return nil, cobra.ShellCompDirectiveDefault
+				})
+			}
+		}
+	}
+}
+
+// providerParamFlagInfo tracks a param definition together with all provider type names that use it.
+type providerParamFlagInfo struct {
+	param     providerservice.ProviderParam
+	typeNames []string
+}
+
+// buildProviderParamFlagInfos returns an ordered list of unique param names and a map from
+// param name to its flag info (definition + all type names that use it).
+// The order follows the first appearance of each param across the services slice.
+func buildProviderParamFlagInfos(services []providerservice.ProviderService) ([]string, map[string]*providerParamFlagInfo) {
+	order := make([]string, 0)
+	infos := make(map[string]*providerParamFlagInfo)
+	for _, svc := range services {
+		for _, p := range svc.Params() {
+			if _, seen := infos[p.Name]; !seen {
+				order = append(order, p.Name)
+				infos[p.Name] = &providerParamFlagInfo{param: p}
+			}
+			infos[p.Name].typeNames = append(infos[p.Name].typeNames, svc.Name())
+		}
+	}
+	return order, infos
+}
+
+// registerProviderParamFlags registers a string flag on cmd for each unique param across
+// the given services. The flag description lists every provider type that uses the param.
+func registerProviderParamFlags(cmd *cobra.Command, services []providerservice.ProviderService) {
+	order, infos := buildProviderParamFlagInfos(services)
+	for _, name := range order {
+		info := infos[name]
+		typeList := strings.Join(info.typeNames, ", ")
+		cmd.Flags().String(info.param.Name, "", fmt.Sprintf("%s (for --type=%s)", info.param.Description, typeList))
+	}
+}
+
+// allProviderParamNames returns the set of all unique param names across the given services.
+func allProviderParamNames(services []providerservice.ProviderService) map[string]bool {
+	names := make(map[string]bool)
+	for _, svc := range services {
+		for _, p := range svc.Params() {
+			names[p.Name] = true
+		}
+	}
+	return names
+}
+
+// collectProviderParams reads the provider params for the given service from the cobra command's
+// flags, returning only those flags that were explicitly set by the user.
+func collectProviderParams(cmd *cobra.Command, svc providerservice.ProviderService) ([]provider.ProviderParamEntry, error) {
+	params := make([]provider.ProviderParamEntry, 0, len(svc.Params()))
+	for _, p := range svc.Params() {
+		if !cmd.Flags().Changed(p.Name) {
+			continue
+		}
+		val, err := cmd.Flags().GetString(p.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read --%s flag: %w", p.Name, err)
+		}
+		params = append(params, provider.ProviderParamEntry{
+			Name:       p.Name,
+			Kind:       p.Kind,
+			Value:      val,
+			SecretType: p.SecretType,
+		})
+	}
+	return params, nil
+}

--- a/pkg/cmd/provider_list.go
+++ b/pkg/cmd/provider_list.go
@@ -1,0 +1,160 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/openkaiden/kdn/pkg/provider"
+	"github.com/openkaiden/kdn/pkg/providerservice"
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+)
+
+type providerListCmd struct {
+	store  provider.Store
+	output string
+}
+
+func (c *providerListCmd) preRun(cmd *cobra.Command, args []string) error {
+	if c.output != "" && c.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", c.output)
+	}
+	if c.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to read --storage flag: %w", err))
+	}
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to resolve storage directory path: %w", err))
+	}
+	c.store = provider.NewStore(absStorageDir)
+	return nil
+}
+
+func (c *providerListCmd) run(cmd *cobra.Command, args []string) error {
+	items, err := c.store.List()
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to list providers: %w", err))
+	}
+
+	if c.output == "json" {
+		return c.outputJSON(cmd, items)
+	}
+
+	return c.displayTable(cmd, items)
+}
+
+func (c *providerListCmd) displayTable(cmd *cobra.Command, items []provider.ListItem) error {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No providers found")
+		return nil
+	}
+
+	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+	columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+	tbl := table.New("NAME", "TYPE", "PARAMS")
+	tbl.WithWriter(out)
+	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+	for _, item := range items {
+		tbl.AddRow(item.Name, item.Type, formatProviderParams(item))
+	}
+
+	tbl.Print()
+	return nil
+}
+
+// formatProviderParams formats params as "key=value, key=value".
+// Secret-kind params are shown as "key=<secret>" to avoid displaying the reference name.
+func formatProviderParams(item provider.ListItem) string {
+	parts := make([]string, 0, len(item.Params))
+	for _, p := range item.Params {
+		if p.Kind == providerservice.ProviderParamKindSecret {
+			parts = append(parts, fmt.Sprintf("%s=<secret>", p.Name))
+		} else if p.Value != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", p.Name, p.Value))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (c *providerListCmd) outputJSON(cmd *cobra.Command, items []provider.ListItem) error {
+	output := providersListOutput{
+		Items: make([]providerInfoOutput, 0, len(items)),
+	}
+	for _, item := range items {
+		info := providerInfoOutput{
+			Name:   item.Name,
+			Type:   item.Type,
+			Params: make([]providerParamOutput, 0, len(item.Params)),
+		}
+		for _, p := range item.Params {
+			info.Params = append(info.Params, providerParamOutput{
+				Name:  p.Name,
+				Value: p.Value,
+			})
+		}
+		output.Items = append(output.Items, info)
+	}
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to marshal providers to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
+func NewProviderListCmd() *cobra.Command {
+	c := &providerListCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all provider connections",
+		Long:  "List all configured LLM provider connections",
+		Example: `# List all provider connections
+kdn provider list
+
+# List provider connections in JSON format
+kdn provider list --output json
+
+# List provider connections using short flag
+kdn provider list -o json`,
+		Args:    cobra.NoArgs,
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
+
+	return cmd
+}

--- a/pkg/cmd/provider_list.go
+++ b/pkg/cmd/provider_list.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/provider"
 	"github.com/openkaiden/kdn/pkg/providerservice"
 	"github.com/rodaine/table"
@@ -106,17 +107,17 @@ func formatProviderParams(item provider.ListItem) string {
 }
 
 func (c *providerListCmd) outputJSON(cmd *cobra.Command, items []provider.ListItem) error {
-	output := providersListOutput{
-		Items: make([]providerInfoOutput, 0, len(items)),
+	output := api.ProvidersList{
+		Items: make([]api.ProviderInfo, 0, len(items)),
 	}
 	for _, item := range items {
-		info := providerInfoOutput{
+		info := api.ProviderInfo{
 			Name:   item.Name,
 			Type:   item.Type,
-			Params: make([]providerParamOutput, 0, len(item.Params)),
+			Params: make([]api.ProviderParam, 0, len(item.Params)),
 		}
 		for _, p := range item.Params {
-			info.Params = append(info.Params, providerParamOutput{
+			info.Params = append(info.Params, api.ProviderParam{
 				Name:  p.Name,
 				Value: p.Value,
 			})

--- a/pkg/cmd/provider_list_test.go
+++ b/pkg/cmd/provider_list_test.go
@@ -1,0 +1,256 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/openkaiden/kdn/pkg/provider"
+	"github.com/openkaiden/kdn/pkg/providerservice"
+	"github.com/spf13/cobra"
+)
+
+func TestProviderListCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderListCmd()
+	if cmd == nil {
+		t.Fatal("NewProviderListCmd() returned nil")
+	}
+	if cmd.Use != "list" {
+		t.Errorf("expected Use %q, got %q", "list", cmd.Use)
+	}
+}
+
+func TestProviderListCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderListCmd()
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("failed to parse examples: %v", err)
+	}
+
+	expectedCount := 3
+	if len(commands) != expectedCount {
+		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	if err := testutil.ValidateCommandExamples(rootCmd, cmd.Example); err != nil {
+		t.Errorf("example validation failed: %v", err)
+	}
+}
+
+func TestProviderListCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	c := &providerListCmd{}
+	cmd := &cobra.Command{}
+	cmd.Flags().String("storage", t.TempDir(), "")
+
+	if err := c.preRun(cmd, []string{}); err != nil {
+		t.Fatalf("preRun() failed: %v", err)
+	}
+	if c.store == nil {
+		t.Error("expected store to be initialised")
+	}
+}
+
+func TestProviderListCmd_PreRun_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &providerListCmd{output: "xml"}
+	cmd := &cobra.Command{}
+	cmd.Flags().String("storage", t.TempDir(), "")
+
+	if err := c.preRun(cmd, []string{}); err == nil {
+		t.Fatal("expected error for unsupported output format")
+	}
+}
+
+func TestProviderListCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("displays empty message when no providers", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerListCmd{store: &fakeProviderStore{}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		if !strings.Contains(out.String(), "No providers found") {
+			t.Errorf("expected 'No providers found' in output, got: %s", out.String())
+		}
+	})
+
+	t.Run("table output contains provider fields", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerListCmd{store: &fakeProviderStore{
+			listItems: []provider.ListItem{
+				{
+					Name: "my-anthropic",
+					Type: "anthropic",
+					Params: []provider.ProviderParamEntry{
+						{Name: "url", Kind: providerservice.ProviderParamKindURL, Value: "https://api.anthropic.com"},
+					},
+				},
+			},
+		}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		if !strings.Contains(output, "my-anthropic") {
+			t.Errorf("expected 'my-anthropic' in output, got: %s", output)
+		}
+		if !strings.Contains(output, "anthropic") {
+			t.Errorf("expected 'anthropic' in output, got: %s", output)
+		}
+		if !strings.Contains(output, "url=https://api.anthropic.com") {
+			t.Errorf("expected param in output, got: %s", output)
+		}
+	})
+
+	t.Run("table output shows secret params as <secret>", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerListCmd{store: &fakeProviderStore{
+			listItems: []provider.ListItem{
+				{
+					Name: "my-anthropic",
+					Type: "anthropic",
+					Params: []provider.ProviderParamEntry{
+						// Value is the reference name returned by the real store.
+						{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "my-anthropic/token"},
+					},
+				},
+			},
+		}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		if !strings.Contains(output, "token=<secret>") {
+			t.Errorf("expected 'token=<secret>' in table output, got: %s", output)
+		}
+		// The actual reference name must not be shown in the table.
+		if strings.Contains(output, "my-anthropic/token") {
+			t.Errorf("expected reference name to be hidden in table, got: %s", output)
+		}
+	})
+
+	t.Run("json output contains all fields including secret reference name", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerListCmd{
+			output: "json",
+			store: &fakeProviderStore{
+				listItems: []provider.ListItem{
+					{
+						Name: "my-anthropic",
+						Type: "anthropic",
+						Params: []provider.ProviderParamEntry{
+							// Value is the reference name returned by the real store.
+							{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "my-anthropic/token"},
+							{Name: "url", Kind: providerservice.ProviderParamKindURL, Value: "https://api.anthropic.com"},
+						},
+					},
+				},
+			},
+		}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		output := out.String()
+		for _, want := range []string{`"items"`, `"my-anthropic"`, `"anthropic"`, `"token"`, `"my-anthropic/token"`, `"url"`} {
+			if !strings.Contains(output, want) {
+				t.Errorf("expected %q in JSON output, got: %s", want, output)
+			}
+		}
+	})
+
+	t.Run("json output empty list returns items array", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerListCmd{output: "json", store: &fakeProviderStore{}}
+		root := &cobra.Command{}
+		var out bytes.Buffer
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+		if !strings.Contains(out.String(), `"items"`) {
+			t.Errorf("expected JSON with items key, got: %s", out.String())
+		}
+	})
+
+	t.Run("store error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		sentinel := errors.New("store error")
+		c := &providerListCmd{store: &fakeProviderStore{listErr: sentinel}}
+		cmd := &cobra.Command{}
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		err := c.run(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error when store fails")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected error to wrap sentinel, got: %v", err)
+		}
+	})
+}

--- a/pkg/cmd/provider_remove.go
+++ b/pkg/cmd/provider_remove.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	api "github.com/openkaiden/kdn-api/cli/go"
 	"github.com/openkaiden/kdn/pkg/provider"
 	"github.com/spf13/cobra"
 )
@@ -68,7 +69,7 @@ func (c *providerRemoveCmd) run(cmd *cobra.Command, args []string) error {
 }
 
 func (c *providerRemoveCmd) outputJSON(cmd *cobra.Command, name string) error {
-	response := providerNameOutput{Name: name}
+	response := api.ProviderName{Name: name}
 
 	jsonData, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {

--- a/pkg/cmd/provider_remove.go
+++ b/pkg/cmd/provider_remove.go
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/openkaiden/kdn/pkg/provider"
+	"github.com/spf13/cobra"
+)
+
+type providerRemoveCmd struct {
+	store  provider.Store
+	output string
+}
+
+func (c *providerRemoveCmd) preRun(cmd *cobra.Command, args []string) error {
+	if c.output != "" && c.output != "json" {
+		return fmt.Errorf("unsupported output format: %s (supported: json)", c.output)
+	}
+	if c.output == "json" {
+		cmd.SilenceErrors = true
+	}
+
+	storageDir, err := cmd.Flags().GetString("storage")
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to read --storage flag: %w", err))
+	}
+	absStorageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to resolve storage directory path: %w", err))
+	}
+	c.store = provider.NewStore(absStorageDir)
+	return nil
+}
+
+func (c *providerRemoveCmd) run(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := c.store.Remove(name); err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to remove provider: %w", err))
+	}
+
+	if c.output == "json" {
+		return c.outputJSON(cmd, name)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Provider %q removed successfully\n", name)
+	return nil
+}
+
+func (c *providerRemoveCmd) outputJSON(cmd *cobra.Command, name string) error {
+	response := providerNameOutput{Name: name}
+
+	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return outputErrorIfJSON(cmd, c.output, fmt.Errorf("failed to marshal to JSON: %w", err))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
+func NewProviderRemoveCmd() *cobra.Command {
+	c := &providerRemoveCmd{}
+
+	cmd := &cobra.Command{
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a provider connection",
+		Long:    "Remove a configured LLM provider connection.",
+		Example: `# Remove a provider connection by name
+kdn provider remove my-anthropic
+
+# Remove a provider connection with JSON output
+kdn provider remove my-anthropic --output json
+
+# Remove a provider connection with short flag
+kdn provider remove my-anthropic -o json`,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Output format (supported: json)")
+	cmd.RegisterFlagCompletionFunc("output", newOutputFlagCompletion([]string{"json"}))
+	cmd.ValidArgsFunction = completeProviderName
+
+	return cmd
+}

--- a/pkg/cmd/provider_remove_test.go
+++ b/pkg/cmd/provider_remove_test.go
@@ -1,0 +1,193 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/cmd/testutil"
+	"github.com/spf13/cobra"
+)
+
+func TestProviderRemoveCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderRemoveCmd()
+	if cmd == nil {
+		t.Fatal("NewProviderRemoveCmd() returned nil")
+	}
+	if cmd.Use != "remove <name>" {
+		t.Errorf("expected Use %q, got %q", "remove <name>", cmd.Use)
+	}
+}
+
+func TestProviderRemoveCmd_Examples(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderRemoveCmd()
+	if cmd.Example == "" {
+		t.Fatal("Example field should not be empty")
+	}
+
+	commands, err := testutil.ParseExampleCommands(cmd.Example)
+	if err != nil {
+		t.Fatalf("failed to parse examples: %v", err)
+	}
+
+	expectedCount := 3
+	if len(commands) != expectedCount {
+		t.Errorf("expected %d example commands, got %d", expectedCount, len(commands))
+	}
+
+	rootCmd := NewRootCmd()
+	if err := testutil.ValidateCommandExamples(rootCmd, cmd.Example); err != nil {
+		t.Errorf("example validation failed: %v", err)
+	}
+}
+
+func TestProviderRemoveCmd_PreRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects invalid output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerRemoveCmd{output: "xml"}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", t.TempDir(), "")
+
+		err := c.preRun(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error for invalid output format")
+		}
+		if !strings.Contains(err.Error(), "unsupported output format") {
+			t.Errorf("expected 'unsupported output format' error, got: %v", err)
+		}
+	})
+
+	t.Run("accepts json output format", func(t *testing.T) {
+		t.Parallel()
+
+		c := &providerRemoveCmd{output: "json"}
+		cmd := &cobra.Command{}
+		cmd.Flags().String("storage", t.TempDir(), "")
+
+		err := c.preRun(cmd, []string{})
+		if err != nil {
+			t.Fatalf("preRun() failed: %v", err)
+		}
+		if c.store == nil {
+			t.Error("expected store to be set")
+		}
+	})
+}
+
+func TestProviderRemoveCmd_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("calls store with correct name", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{}
+		c := &providerRemoveCmd{store: fs}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-anthropic"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		if fs.removeName != "my-anthropic" {
+			t.Errorf("Name: want %q, got %q", "my-anthropic", fs.removeName)
+		}
+		if !strings.Contains(out.String(), "my-anthropic") {
+			t.Errorf("expected success message to contain provider name, got: %q", out.String())
+		}
+	})
+
+	t.Run("store error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{removeErr: errors.New("not found")}
+		c := &providerRemoveCmd{store: fs}
+
+		cmd := &cobra.Command{}
+		err := c.run(cmd, []string{"x"})
+		if err == nil {
+			t.Fatal("expected error when store fails")
+		}
+	})
+
+	t.Run("outputs JSON on success", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{}
+		c := &providerRemoveCmd{store: fs, output: "json"}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		if err := child.RunE(child, []string{"my-anthropic"}); err != nil {
+			t.Fatalf("run() failed: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(out.String()), &result); err != nil {
+			t.Fatalf("failed to parse JSON output: %v", err)
+		}
+		if result["name"] != "my-anthropic" {
+			t.Errorf("expected name %q in JSON, got: %v", "my-anthropic", result["name"])
+		}
+	})
+
+	t.Run("outputs JSON error on store failure", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &fakeProviderStore{removeErr: errors.New("store failed")}
+		c := &providerRemoveCmd{store: fs, output: "json"}
+
+		root := &cobra.Command{}
+		var out strings.Builder
+		root.SetOut(&out)
+		child := &cobra.Command{RunE: c.run}
+		root.AddCommand(child)
+
+		err := child.RunE(child, []string{"x"})
+		if err == nil {
+			t.Fatal("expected error when store fails")
+		}
+
+		var result map[string]interface{}
+		if jsonErr := json.Unmarshal([]byte(out.String()), &result); jsonErr != nil {
+			t.Fatalf("failed to parse JSON error output: %v", jsonErr)
+		}
+		if _, ok := result["error"]; !ok {
+			t.Errorf("expected 'error' key in JSON output, got: %v", result)
+		}
+	})
+}

--- a/pkg/cmd/provider_test.go
+++ b/pkg/cmd/provider_test.go
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestProviderCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProviderCmd()
+	if cmd == nil {
+		t.Fatal("NewProviderCmd() returned nil")
+	}
+	if cmd.Use != "provider" {
+		t.Errorf("expected Use %q, got %q", "provider", cmd.Use)
+	}
+
+	subCmds := cmd.Commands()
+	if len(subCmds) == 0 {
+		t.Fatal("expected provider command to have subcommands")
+	}
+
+	foundCreate := false
+	foundList := false
+	foundRemove := false
+	for _, sub := range subCmds {
+		switch sub.Use {
+		case "create <name>":
+			foundCreate = true
+		case "list":
+			foundList = true
+		case "remove <name>":
+			foundRemove = true
+		}
+	}
+	if !foundCreate {
+		t.Error("expected provider command to have 'create' subcommand")
+	}
+	if !foundList {
+		t.Error("expected provider command to have 'list' subcommand")
+	}
+	if !foundRemove {
+		t.Error("expected provider command to have 'remove' subcommand")
+	}
+}
+
+func TestProviderCmd_UnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"provider", "foobar"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected Execute() to return an error for unknown command")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("expected 'unknown command' in error, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "foobar") {
+		t.Errorf("expected 'foobar' in error, got: %s", err.Error())
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -68,6 +68,10 @@ func NewRootCmd() *cobra.Command {
 		Title: "Secret Commands:",
 	})
 	rootCmd.AddGroup(&cobra.Group{
+		ID:    "provider",
+		Title: "Provider Commands:",
+	})
+	rootCmd.AddGroup(&cobra.Group{
 		ID:    "config",
 		Title: "Configuration Commands:",
 	})
@@ -116,6 +120,10 @@ func NewRootCmd() *cobra.Command {
 	secretCmd := NewSecretCmd()
 	secretCmd.GroupID = "secret"
 	rootCmd.AddCommand(secretCmd)
+
+	providerCmd := NewProviderCmd()
+	providerCmd.GroupID = "provider"
+	rootCmd.AddCommand(providerCmd)
 
 	autoconfCmd := NewAutoconfCmd()
 	autoconfCmd.GroupID = "config"

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package provider provides interfaces and implementations for managing user provider instances.
+// Provider metadata (name, type, non-sensitive param values, and keychain reference names for
+// sensitive params) is persisted in a JSON file under the kdn storage directory.
+// Sensitive param values are stored in the system keychain.
+package provider
+
+import (
+	"errors"
+
+	"github.com/openkaiden/kdn/pkg/providerservice"
+)
+
+var (
+	// ErrProviderAlreadyExists is returned when a provider with the same name already exists.
+	ErrProviderAlreadyExists = errors.New("provider already exists")
+	// ErrProviderNotFound is returned when no provider with the given name exists.
+	ErrProviderNotFound = errors.New("provider not found")
+)
+
+// ProviderParamEntry holds a single parameter with its kind and value.
+// For Kind=secret: Value is the keychain reference name (e.g. "my-anthropic/token");
+// the actual secret is stored in the system keychain under that reference.
+// For all other kinds: Value is the literal parameter value.
+type ProviderParamEntry struct {
+	Name       string
+	Kind       providerservice.ProviderParamKind
+	Value      string
+	SecretType string // secret service type used when storing this param; only set for Kind=secret
+}
+
+// CreateParams holds all parameters needed to create a provider.
+// For secret-kind entries, Value is the actual secret value (e.g. the API token);
+// the store generates the keychain reference name, stores the secret in the keychain,
+// and writes the reference name to the JSON file.
+type CreateParams struct {
+	Name   string
+	Type   string
+	Params []ProviderParamEntry
+}
+
+// ListItem holds the metadata fields returned by List.
+// Secret-kind entries have an empty Value (the actual value is in the keychain).
+type ListItem struct {
+	Name   string
+	Type   string
+	Params []ProviderParamEntry
+}
+
+// Store manages persistent storage of provider instances.
+type Store interface {
+	// Create stores secret param values in the system keychain and persists
+	// all metadata to the storage directory.
+	Create(params CreateParams) error
+	// List returns the metadata for all stored providers.
+	List() ([]ListItem, error)
+	// Get returns the metadata and secret values for the named provider.
+	// The returned map contains secret param values keyed by param name.
+	// Returns ErrProviderNotFound if no provider with the given name exists.
+	Get(name string) (ListItem, map[string]string, error)
+	// Remove deletes all secret param values from the system keychain and removes
+	// the provider metadata from the storage directory.
+	Remove(name string) error
+}

--- a/pkg/provider/store.go
+++ b/pkg/provider/store.go
@@ -1,0 +1,235 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package provider
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/openkaiden/kdn/pkg/providerservice"
+	"github.com/openkaiden/kdn/pkg/secret"
+)
+
+const providersFileName = "providers.json"
+
+// store is the unexported implementation of Store.
+type store struct {
+	storageDir  string
+	secretStore secret.Store
+}
+
+var _ Store = (*store)(nil)
+
+// NewStore creates a Store backed by the given storage directory.
+// Secret-kind provider params are stored via the shared secret.Store so they appear in `kdn secret list`.
+func NewStore(storageDir string) Store {
+	return newStoreWithSecretStore(storageDir, secret.NewStore(storageDir))
+}
+
+// newStoreWithSecretStore creates a Store with an injectable secret.Store, used in tests.
+func newStoreWithSecretStore(storageDir string, ss secret.Store) Store {
+	return &store{storageDir: storageDir, secretStore: ss}
+}
+
+// paramRecord is the JSON-serialisable representation of a single provider parameter.
+type paramRecord struct {
+	Name  string                            `json:"name"`
+	Kind  providerservice.ProviderParamKind `json:"kind"`
+	Value string                            `json:"value"`
+}
+
+// providerRecord is the JSON-serialisable metadata for a single provider.
+type providerRecord struct {
+	Name   string        `json:"name"`
+	Type   string        `json:"type"`
+	Params []paramRecord `json:"params"`
+}
+
+type providersFile struct {
+	Providers []providerRecord `json:"providers"`
+}
+
+// Create stores secret param values via the secret store and persists metadata.
+// The duplicate check is performed before writing to the secret store so that an
+// existing entry is never overwritten when the name is already taken.
+func (s *store) Create(params CreateParams) error {
+	pf, err := s.loadProvidersFile()
+	if err != nil {
+		return err
+	}
+
+	for _, existing := range pf.Providers {
+		if existing.Name == params.Name {
+			return fmt.Errorf("provider %q: %w", params.Name, ErrProviderAlreadyExists)
+		}
+	}
+
+	rec := providerRecord{
+		Name:   params.Name,
+		Type:   params.Type,
+		Params: make([]paramRecord, 0, len(params.Params)),
+	}
+
+	for _, p := range params.Params {
+		pr := paramRecord{Name: p.Name, Kind: p.Kind}
+		if p.Kind == providerservice.ProviderParamKindSecret {
+			// Use "{providerName}/{paramName}" as the secret name for namespacing.
+			secretName := fmt.Sprintf("%s/%s", params.Name, p.Name)
+			if err := s.secretStore.Create(secret.CreateParams{
+				Name:        secretName,
+				Type:        p.SecretType,
+				Description: fmt.Sprintf("%s for %s provider", p.Name, params.Name),
+				Value:       p.Value,
+			}); err != nil {
+				return fmt.Errorf("failed to store secret param %q: %w", p.Name, err)
+			}
+			pr.Value = secretName
+		} else {
+			pr.Value = p.Value
+		}
+		rec.Params = append(rec.Params, pr)
+	}
+
+	pf.Providers = append(pf.Providers, rec)
+	return s.saveProvidersFile(pf)
+}
+
+// List reads providers.json and returns metadata for all stored providers.
+func (s *store) List() ([]ListItem, error) {
+	pf, err := s.loadProvidersFile()
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]ListItem, 0, len(pf.Providers))
+	for _, rec := range pf.Providers {
+		items = append(items, s.recordToListItem(rec))
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return items, nil
+}
+
+// Get returns the metadata and secret values for the named provider.
+func (s *store) Get(name string) (ListItem, map[string]string, error) {
+	pf, err := s.loadProvidersFile()
+	if err != nil {
+		return ListItem{}, nil, err
+	}
+
+	for _, rec := range pf.Providers {
+		if rec.Name != name {
+			continue
+		}
+
+		item := s.recordToListItem(rec)
+		secrets := make(map[string]string)
+		for _, p := range rec.Params {
+			if p.Kind == providerservice.ProviderParamKindSecret {
+				_, val, err := s.secretStore.Get(p.Value)
+				if err != nil {
+					return ListItem{}, nil, fmt.Errorf("failed to get secret param %q: %w", p.Name, err)
+				}
+				secrets[p.Name] = val
+			}
+		}
+		return item, secrets, nil
+	}
+
+	return ListItem{}, nil, fmt.Errorf("provider %q: %w", name, ErrProviderNotFound)
+}
+
+// Remove deletes all secret param values and removes the provider metadata.
+// Secret params that are already missing from the secret store are skipped.
+func (s *store) Remove(name string) error {
+	pf, err := s.loadProvidersFile()
+	if err != nil {
+		return err
+	}
+
+	idx := -1
+	for i, rec := range pf.Providers {
+		if rec.Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("provider %q: %w", name, ErrProviderNotFound)
+	}
+
+	for _, p := range pf.Providers[idx].Params {
+		if p.Kind == providerservice.ProviderParamKindSecret {
+			if err := s.secretStore.Remove(p.Value); err != nil && !errors.Is(err, secret.ErrSecretNotFound) {
+				return fmt.Errorf("failed to remove secret param %q: %w", p.Name, err)
+			}
+		}
+	}
+
+	pf.Providers = append(pf.Providers[:idx], pf.Providers[idx+1:]...)
+	return s.saveProvidersFile(pf)
+}
+
+// recordToListItem converts a providerRecord to a ListItem.
+// For secret-kind params, Value holds the secret reference name (not the actual secret value).
+func (s *store) recordToListItem(rec providerRecord) ListItem {
+	params := make([]ProviderParamEntry, 0, len(rec.Params))
+	for _, p := range rec.Params {
+		params = append(params, ProviderParamEntry{Name: p.Name, Kind: p.Kind, Value: p.Value})
+	}
+	return ListItem{Name: rec.Name, Type: rec.Type, Params: params}
+}
+
+// loadProvidersFile reads and parses providers.json, returning an empty struct when
+// the file does not yet exist.
+func (s *store) loadProvidersFile() (providersFile, error) {
+	var pf providersFile
+	data, err := os.ReadFile(filepath.Join(s.storageDir, providersFileName))
+	if os.IsNotExist(err) {
+		return pf, nil
+	}
+	if err != nil {
+		return pf, fmt.Errorf("failed to read providers file: %w", err)
+	}
+	if err := json.Unmarshal(data, &pf); err != nil {
+		return pf, fmt.Errorf("failed to parse providers file: %w", err)
+	}
+	return pf, nil
+}
+
+// saveProvidersFile marshals pf and writes it to disk.
+func (s *store) saveProvidersFile(pf providersFile) error {
+	jsonData, err := json.MarshalIndent(pf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal providers: %w", err)
+	}
+
+	if err := os.MkdirAll(s.storageDir, 0700); err != nil {
+		return fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(s.storageDir, providersFileName), jsonData, 0600); err != nil {
+		return fmt.Errorf("failed to write providers file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/provider/store.go
+++ b/pkg/provider/store.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 
 	"github.com/openkaiden/kdn/pkg/providerservice"
 	"github.com/openkaiden/kdn/pkg/secret"
@@ -34,6 +35,7 @@ const providersFileName = "providers.json"
 
 // store is the unexported implementation of Store.
 type store struct {
+	mu          sync.Mutex
 	storageDir  string
 	secretStore secret.Store
 }
@@ -73,6 +75,9 @@ type providersFile struct {
 // The duplicate check is performed before writing to the secret store so that an
 // existing entry is never overwritten when the name is already taken.
 func (s *store) Create(params CreateParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	pf, err := s.loadProvidersFile()
 	if err != nil {
 		return err
@@ -161,6 +166,9 @@ func (s *store) Get(name string) (ListItem, map[string]string, error) {
 // Remove deletes all secret param values and removes the provider metadata.
 // Secret params that are already missing from the secret store are skipped.
 func (s *store) Remove(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	pf, err := s.loadProvidersFile()
 	if err != nil {
 		return err

--- a/pkg/provider/store_test.go
+++ b/pkg/provider/store_test.go
@@ -1,0 +1,487 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package provider
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/providerservice"
+	"github.com/openkaiden/kdn/pkg/secret"
+)
+
+// fakeSecretStore is a fake implementation of secret.Store for use in tests.
+type fakeSecretStore struct {
+	secrets      map[string]string
+	descriptions map[string]string
+	types        map[string]string
+	createErr    error
+	removeErr    error
+	getErr       error
+}
+
+func newFakeSecretStore() *fakeSecretStore {
+	return &fakeSecretStore{
+		secrets:      make(map[string]string),
+		descriptions: make(map[string]string),
+		types:        make(map[string]string),
+	}
+}
+
+func (f *fakeSecretStore) Create(params secret.CreateParams) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	if _, exists := f.secrets[params.Name]; exists {
+		return fmt.Errorf("secret %q: %w", params.Name, secret.ErrSecretAlreadyExists)
+	}
+	f.secrets[params.Name] = params.Value
+	f.descriptions[params.Name] = params.Description
+	f.types[params.Name] = params.Type
+	return nil
+}
+
+func (f *fakeSecretStore) List() ([]secret.ListItem, error) {
+	return nil, nil
+}
+
+func (f *fakeSecretStore) Get(name string) (secret.ListItem, string, error) {
+	if f.getErr != nil {
+		return secret.ListItem{}, "", f.getErr
+	}
+	val, ok := f.secrets[name]
+	if !ok {
+		return secret.ListItem{}, "", fmt.Errorf("secret %q: %w", name, secret.ErrSecretNotFound)
+	}
+	return secret.ListItem{Name: name}, val, nil
+}
+
+func (f *fakeSecretStore) Remove(name string) error {
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	if _, ok := f.secrets[name]; !ok {
+		return fmt.Errorf("secret %q: %w", name, secret.ErrSecretNotFound)
+	}
+	delete(f.secrets, name)
+	return nil
+}
+
+var _ secret.Store = (*fakeSecretStore)(nil)
+
+func TestStore_Create_StoresSecretParamViaSecretStore(t *testing.T) {
+	t.Parallel()
+
+	ss := newFakeSecretStore()
+	st := newStoreWithSecretStore(t.TempDir(), ss)
+
+	err := st.Create(CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-ant-secret", SecretType: "anthropic"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Secret should be stored under "{providerName}/{paramName}"
+	val, ok := ss.secrets["my-anthropic/token"]
+	if !ok {
+		t.Fatal("expected secret to be stored in secret store as 'my-anthropic/token'")
+	}
+	if val != "sk-ant-secret" {
+		t.Errorf("secret value = %q, want %q", val, "sk-ant-secret")
+	}
+	// Type must match the param's SecretType, not a hardcoded value.
+	if ss.types["my-anthropic/token"] != "anthropic" {
+		t.Errorf("type = %q, want %q", ss.types["my-anthropic/token"], "anthropic")
+	}
+	// Description should identify the param and provider.
+	if ss.descriptions["my-anthropic/token"] != "token for my-anthropic provider" {
+		t.Errorf("description = %q, want %q", ss.descriptions["my-anthropic/token"], "token for my-anthropic provider")
+	}
+}
+
+func TestStore_Create_SavesMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st := newStoreWithSecretStore(dir, newFakeSecretStore())
+
+	err := st.Create(CreateParams{
+		Name: "my-vertexai",
+		Type: "vertexai",
+		Params: []ProviderParamEntry{
+			{Name: "project", Kind: providerservice.ProviderParamKindText, Value: "my-project"},
+			{Name: "region", Kind: providerservice.ProviderParamKindText, Value: "us-central1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, providersFileName))
+	if err != nil {
+		t.Fatalf("failed to read providers file: %v", err)
+	}
+
+	var pf providersFile
+	if err := json.Unmarshal(data, &pf); err != nil {
+		t.Fatalf("failed to parse providers file: %v", err)
+	}
+
+	if len(pf.Providers) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(pf.Providers))
+	}
+
+	rec := pf.Providers[0]
+	if rec.Name != "my-vertexai" {
+		t.Errorf("Name: want %q, got %q", "my-vertexai", rec.Name)
+	}
+	if rec.Type != "vertexai" {
+		t.Errorf("Type: want %q, got %q", "vertexai", rec.Type)
+	}
+	if len(rec.Params) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(rec.Params))
+	}
+	if rec.Params[0].Value != "my-project" {
+		t.Errorf("project value: want %q, got %q", "my-project", rec.Params[0].Value)
+	}
+	if rec.Params[1].Value != "us-central1" {
+		t.Errorf("region value: want %q, got %q", "us-central1", rec.Params[1].Value)
+	}
+}
+
+func TestStore_Create_StoresSecretRefInJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st := newStoreWithSecretStore(dir, newFakeSecretStore())
+
+	err := st.Create(CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-secret", SecretType: "anthropic"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, providersFileName))
+	var pf providersFile
+	_ = json.Unmarshal(data, &pf)
+
+	// The JSON should store the reference name, not the actual secret value.
+	if pf.Providers[0].Params[0].Value != "my-anthropic/token" {
+		t.Errorf("expected ref name %q in JSON, got %q", "my-anthropic/token", pf.Providers[0].Params[0].Value)
+	}
+}
+
+func TestStore_Create_ErrorsOnDuplicate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ss := newFakeSecretStore()
+	st := newStoreWithSecretStore(dir, ss)
+
+	params := CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "v1", SecretType: "anthropic"},
+		},
+	}
+	if err := st.Create(params); err != nil {
+		t.Fatalf("first Create() failed: %v", err)
+	}
+
+	secretsBefore := len(ss.secrets)
+	params.Params[0].Value = "v2"
+	err := st.Create(params)
+	if err == nil {
+		t.Fatal("expected error when creating duplicate provider")
+	}
+	if !errors.Is(err, ErrProviderAlreadyExists) {
+		t.Errorf("expected ErrProviderAlreadyExists, got: %v", err)
+	}
+	// Secret store must not be touched when the duplicate is detected.
+	if len(ss.secrets) != secretsBefore {
+		t.Errorf("secret store was modified despite duplicate: got %d entries, want %d", len(ss.secrets), secretsBefore)
+	}
+}
+
+func TestStore_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty when no providers exist", func(t *testing.T) {
+		t.Parallel()
+
+		st := newStoreWithSecretStore(t.TempDir(), newFakeSecretStore())
+		items, err := st.List()
+		if err != nil {
+			t.Fatalf("List() failed: %v", err)
+		}
+		if len(items) != 0 {
+			t.Errorf("expected 0 items, got %d", len(items))
+		}
+	})
+
+	t.Run("returns metadata sorted by name", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		st := newStoreWithSecretStore(dir, newFakeSecretStore())
+
+		if err := st.Create(CreateParams{
+			Name: "z-provider",
+			Type: "vertexai",
+			Params: []ProviderParamEntry{
+				{Name: "project", Kind: providerservice.ProviderParamKindText, Value: "proj-z"},
+			},
+		}); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		if err := st.Create(CreateParams{
+			Name: "a-provider",
+			Type: "anthropic",
+			Params: []ProviderParamEntry{
+				{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "tok", SecretType: "anthropic"},
+			},
+		}); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		items, err := st.List()
+		if err != nil {
+			t.Fatalf("List() failed: %v", err)
+		}
+		if len(items) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(items))
+		}
+		// Items must be sorted by name.
+		if items[0].Name != "a-provider" {
+			t.Errorf("items[0].Name = %q, want %q", items[0].Name, "a-provider")
+		}
+		if items[1].Name != "z-provider" {
+			t.Errorf("items[1].Name = %q, want %q", items[1].Name, "z-provider")
+		}
+	})
+
+	t.Run("secret param value is the reference name in list", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		st := newStoreWithSecretStore(dir, newFakeSecretStore())
+
+		if err := st.Create(CreateParams{
+			Name: "my-anthropic",
+			Type: "anthropic",
+			Params: []ProviderParamEntry{
+				{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-secret", SecretType: "anthropic"},
+			},
+		}); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+
+		items, _ := st.List()
+		if len(items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(items))
+		}
+		// Value for secret params is the secret reference name, not the actual secret value.
+		if items[0].Params[0].Value != "my-anthropic/token" {
+			t.Errorf("expected reference name %q for secret param in list, got %q", "my-anthropic/token", items[0].Params[0].Value)
+		}
+	})
+}
+
+func TestStore_Get_ReturnsMetadataAndSecrets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	st := newStoreWithSecretStore(dir, newFakeSecretStore())
+
+	if err := st.Create(CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-ant-secret", SecretType: "anthropic"},
+			{Name: "url", Kind: providerservice.ProviderParamKindURL, Value: "https://api.anthropic.com"},
+		},
+	}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	item, secrets, err := st.Get("my-anthropic")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if item.Name != "my-anthropic" {
+		t.Errorf("item.Name = %q, want %q", item.Name, "my-anthropic")
+	}
+	if item.Type != "anthropic" {
+		t.Errorf("item.Type = %q, want %q", item.Type, "anthropic")
+	}
+	if secrets["token"] != "sk-ant-secret" {
+		t.Errorf("secrets[token] = %q, want %q", secrets["token"], "sk-ant-secret")
+	}
+	// Non-secret param should not appear in secrets map.
+	if _, ok := secrets["url"]; ok {
+		t.Error("expected 'url' not to appear in secrets map")
+	}
+	// URL param value should be in item.Params.
+	var urlVal string
+	for _, p := range item.Params {
+		if p.Name == "url" {
+			urlVal = p.Value
+		}
+	}
+	if urlVal != "https://api.anthropic.com" {
+		t.Errorf("url param value = %q, want %q", urlVal, "https://api.anthropic.com")
+	}
+}
+
+func TestStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+
+	st := newStoreWithSecretStore(t.TempDir(), newFakeSecretStore())
+
+	_, _, err := st.Get("nonexistent")
+	if err == nil {
+		t.Fatal("expected error when provider does not exist")
+	}
+	if !errors.Is(err, ErrProviderNotFound) {
+		t.Errorf("expected ErrProviderNotFound, got: %v", err)
+	}
+}
+
+func TestStore_Remove_DeletesSecretsAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ss := newFakeSecretStore()
+	st := newStoreWithSecretStore(dir, ss)
+
+	if err := st.Create(CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-secret", SecretType: "anthropic"},
+		},
+	}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	if err := st.Remove("my-anthropic"); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	// Secret should be gone from secret store.
+	if _, ok := ss.secrets["my-anthropic/token"]; ok {
+		t.Error("expected secret to be removed from secret store")
+	}
+
+	// Provider should be gone from JSON.
+	data, err := os.ReadFile(filepath.Join(dir, providersFileName))
+	if err != nil {
+		t.Fatalf("failed to read providers file: %v", err)
+	}
+	var pf providersFile
+	_ = json.Unmarshal(data, &pf)
+	if len(pf.Providers) != 0 {
+		t.Errorf("expected 0 providers after Remove, got %d", len(pf.Providers))
+	}
+}
+
+func TestStore_Remove_NotFound(t *testing.T) {
+	t.Parallel()
+
+	st := newStoreWithSecretStore(t.TempDir(), newFakeSecretStore())
+
+	err := st.Remove("nonexistent")
+	if err == nil {
+		t.Fatal("expected error when provider does not exist")
+	}
+	if !errors.Is(err, ErrProviderNotFound) {
+		t.Errorf("expected ErrProviderNotFound, got: %v", err)
+	}
+}
+
+func TestStore_Remove_MissingSecretStillRemovesMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ss := newFakeSecretStore()
+	st := newStoreWithSecretStore(dir, ss)
+
+	if err := st.Create(CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-secret", SecretType: "anthropic"},
+		},
+	}); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Manually delete the secret from the secret store to simulate out-of-sync state.
+	delete(ss.secrets, "my-anthropic/token")
+
+	// Remove should succeed even when the secret is already gone.
+	if err := st.Remove("my-anthropic"); err != nil {
+		t.Fatalf("Remove() should succeed even when secret is missing: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, providersFileName))
+	if err != nil {
+		t.Fatalf("failed to read providers file: %v", err)
+	}
+	var pf providersFile
+	_ = json.Unmarshal(data, &pf)
+	if len(pf.Providers) != 0 {
+		t.Errorf("expected 0 providers after Remove, got %d", len(pf.Providers))
+	}
+}
+
+func TestStore_Create_SecretStoreError(t *testing.T) {
+	t.Parallel()
+
+	ss := newFakeSecretStore()
+	ss.createErr = os.ErrPermission
+	st := newStoreWithSecretStore(t.TempDir(), ss)
+
+	err := st.Create(CreateParams{
+		Name: "my-anthropic",
+		Type: "anthropic",
+		Params: []ProviderParamEntry{
+			{Name: "token", Kind: providerservice.ProviderParamKindSecret, Value: "sk-secret", SecretType: "anthropic"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when secret store fails")
+	}
+}

--- a/pkg/providerservice/providerservice.go
+++ b/pkg/providerservice/providerservice.go
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package providerservice provides interfaces and types for managing LLM provider service definitions.
+// A provider service describes the parameters required to configure an LLM provider connection.
+package providerservice
+
+// ProviderParamKind describes the nature of a provider parameter and how it is stored/used.
+type ProviderParamKind string
+
+const (
+	// ProviderParamKindSecret — sensitive value (API token); stored in system keychain.
+	ProviderParamKindSecret ProviderParamKind = "secret"
+	// ProviderParamKindCredential — path to a credential file (e.g. gcloud ADC JSON);
+	// only the path is stored (non-sensitive); the runtime intercepts and injects the file.
+	ProviderParamKindCredential ProviderParamKind = "credential"
+	// ProviderParamKindURL — a URL endpoint; stored as plain text but may be rewritten
+	// by runtimes (e.g. localhost → host.containers.internal inside a container).
+	ProviderParamKindURL ProviderParamKind = "url"
+	// ProviderParamKindText — free-form plain text (e.g. GCP project ID, region);
+	// stored as-is in providers.json.
+	ProviderParamKindText ProviderParamKind = "text"
+)
+
+// ProviderParam describes a single parameter accepted by a provider service.
+type ProviderParam struct {
+	Name        string
+	Description string
+	Required    bool
+	Kind        ProviderParamKind
+	// SecretType is the secret type used when storing this param in the secret store.
+	// Only meaningful when Kind == ProviderParamKindSecret.
+	// Valid values are the names of registered secret services (e.g. "anthropic", "github").
+	SecretType string
+}
+
+// ProviderService defines the contract for a provider service implementation.
+// Each provider service describes how a particular type of LLM provider is configured.
+type ProviderService interface {
+	// Name returns the identifier of the provider service.
+	Name() string
+
+	// Description returns a human-readable description of the provider service.
+	Description() string
+
+	// Params returns the list of parameters accepted by this provider service.
+	Params() []ProviderParam
+}
+
+// providerService is the concrete implementation of ProviderService.
+type providerService struct {
+	name        string
+	description string
+	params      []ProviderParam
+}
+
+// Compile-time check to ensure providerService implements ProviderService interface.
+var _ ProviderService = (*providerService)(nil)
+
+// NewProviderService creates a new ProviderService implementation with the given parameters.
+func NewProviderService(name, description string, params []ProviderParam) ProviderService {
+	return &providerService{
+		name:        name,
+		description: description,
+		params:      params,
+	}
+}
+
+func (p *providerService) Name() string            { return p.name }
+func (p *providerService) Description() string     { return p.description }
+func (p *providerService) Params() []ProviderParam { return p.params }

--- a/pkg/providerservice/providerservice.go
+++ b/pkg/providerservice/providerservice.go
@@ -77,10 +77,12 @@ func NewProviderService(name, description string, params []ProviderParam) Provid
 	return &providerService{
 		name:        name,
 		description: description,
-		params:      params,
+		params:      append([]ProviderParam(nil), params...),
 	}
 }
 
-func (p *providerService) Name() string            { return p.name }
-func (p *providerService) Description() string     { return p.description }
-func (p *providerService) Params() []ProviderParam { return p.params }
+func (p *providerService) Name() string        { return p.name }
+func (p *providerService) Description() string { return p.description }
+func (p *providerService) Params() []ProviderParam {
+	return append([]ProviderParam(nil), p.params...)
+}

--- a/pkg/providerservice/providerservice_test.go
+++ b/pkg/providerservice/providerservice_test.go
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package providerservice
+
+import (
+	"testing"
+)
+
+func TestProviderParamKind_Constants(t *testing.T) {
+	t.Parallel()
+
+	if ProviderParamKindSecret != "secret" {
+		t.Errorf("ProviderParamKindSecret = %q, want %q", ProviderParamKindSecret, "secret")
+	}
+	if ProviderParamKindCredential != "credential" {
+		t.Errorf("ProviderParamKindCredential = %q, want %q", ProviderParamKindCredential, "credential")
+	}
+	if ProviderParamKindURL != "url" {
+		t.Errorf("ProviderParamKindURL = %q, want %q", ProviderParamKindURL, "url")
+	}
+	if ProviderParamKindText != "text" {
+		t.Errorf("ProviderParamKindText = %q, want %q", ProviderParamKindText, "text")
+	}
+}
+
+func TestProviderParam_Fields(t *testing.T) {
+	t.Parallel()
+
+	p := ProviderParam{
+		Name:        "token",
+		Description: "API token",
+		Required:    true,
+		Kind:        ProviderParamKindSecret,
+	}
+
+	if p.Name != "token" {
+		t.Errorf("Name = %q, want %q", p.Name, "token")
+	}
+	if p.Description != "API token" {
+		t.Errorf("Description = %q, want %q", p.Description, "API token")
+	}
+	if !p.Required {
+		t.Error("Required = false, want true")
+	}
+	if p.Kind != ProviderParamKindSecret {
+		t.Errorf("Kind = %q, want %q", p.Kind, ProviderParamKindSecret)
+	}
+}
+
+func TestNewProviderService(t *testing.T) {
+	t.Parallel()
+
+	params := []ProviderParam{
+		{Name: "token", Description: "API token", Required: true, Kind: ProviderParamKindSecret},
+		{Name: "url", Description: "Custom base URL", Required: false, Kind: ProviderParamKindURL},
+	}
+	svc := NewProviderService("anthropic", "Anthropic Claude AI models", params)
+
+	if svc == nil {
+		t.Fatal("NewProviderService() returned nil")
+	}
+	if svc.Name() != "anthropic" {
+		t.Errorf("Name() = %q, want %q", svc.Name(), "anthropic")
+	}
+	if svc.Description() != "Anthropic Claude AI models" {
+		t.Errorf("Description() = %q, want %q", svc.Description(), "Anthropic Claude AI models")
+	}
+	if len(svc.Params()) != 2 {
+		t.Fatalf("Params() returned %d params, want 2", len(svc.Params()))
+	}
+	if svc.Params()[0].Name != "token" || svc.Params()[0].Kind != ProviderParamKindSecret || !svc.Params()[0].Required {
+		t.Errorf("Params()[0] = %+v, unexpected", svc.Params()[0])
+	}
+	if svc.Params()[1].Name != "url" || svc.Params()[1].Kind != ProviderParamKindURL || svc.Params()[1].Required {
+		t.Errorf("Params()[1] = %+v, unexpected", svc.Params()[1])
+	}
+}
+
+func TestNewProviderService_EmptyParams(t *testing.T) {
+	t.Parallel()
+
+	svc := NewProviderService("minimal", "", nil)
+	if svc.Name() != "minimal" {
+		t.Errorf("Name() = %q, want %q", svc.Name(), "minimal")
+	}
+	if svc.Description() != "" {
+		t.Errorf("Description() = %q, want empty", svc.Description())
+	}
+	if svc.Params() != nil {
+		t.Errorf("Params() = %v, want nil", svc.Params())
+	}
+}

--- a/pkg/providerservice/registry.go
+++ b/pkg/providerservice/registry.go
@@ -21,6 +21,7 @@ package providerservice
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -101,5 +102,6 @@ func (r *registry) List() []string {
 	for name := range r.services {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }

--- a/pkg/providerservice/registry.go
+++ b/pkg/providerservice/registry.go
@@ -1,0 +1,105 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package providerservice
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrProviderServiceNotFound is returned when a provider service is not found in the registry.
+	ErrProviderServiceNotFound = errors.New("provider service not found")
+)
+
+// Registry manages provider service implementations.
+type Registry interface {
+	// Register registers a provider service implementation.
+	// Returns an error if a provider service with the same name is already registered.
+	Register(service ProviderService) error
+	// Get retrieves a provider service implementation by name.
+	// Returns ErrProviderServiceNotFound if the provider service is not registered.
+	Get(name string) (ProviderService, error)
+	// List returns all registered provider service names.
+	List() []string
+}
+
+// registry is the internal implementation of Registry.
+type registry struct {
+	mu       sync.RWMutex
+	services map[string]ProviderService
+}
+
+// Compile-time check to ensure registry implements Registry interface.
+var _ Registry = (*registry)(nil)
+
+// NewRegistry creates a new provider service registry.
+func NewRegistry() Registry {
+	return &registry{
+		services: make(map[string]ProviderService),
+	}
+}
+
+// Register registers a provider service implementation.
+func (r *registry) Register(service ProviderService) error {
+	if service == nil {
+		return errors.New("provider service cannot be nil")
+	}
+
+	name := service.Name()
+	if name == "" {
+		return errors.New("provider service name cannot be empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.services[name]; exists {
+		return fmt.Errorf("provider service %q is already registered", name)
+	}
+
+	r.services[name] = service
+	return nil
+}
+
+// Get retrieves a provider service implementation by name.
+func (r *registry) Get(name string) (ProviderService, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	service, exists := r.services[name]
+	if !exists {
+		return nil, ErrProviderServiceNotFound
+	}
+
+	return service, nil
+}
+
+// List returns all registered provider service names.
+func (r *registry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.services))
+	for name := range r.services {
+		names = append(names, name)
+	}
+	return names
+}

--- a/pkg/providerservice/registry_test.go
+++ b/pkg/providerservice/registry_test.go
@@ -1,0 +1,210 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package providerservice
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeProviderService is a test implementation of the ProviderService interface.
+type fakeProviderService struct {
+	name        string
+	description string
+	params      []ProviderParam
+}
+
+func (f *fakeProviderService) Name() string            { return f.name }
+func (f *fakeProviderService) Description() string     { return f.description }
+func (f *fakeProviderService) Params() []ProviderParam { return f.params }
+
+func TestNewRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if reg == nil {
+		t.Fatal("NewRegistry() returned nil")
+	}
+}
+
+func TestRegistry_Register(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successfully registers provider service", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+		svc := &fakeProviderService{name: "anthropic"}
+
+		err := reg.Register(svc)
+		if err != nil {
+			t.Errorf("Register() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("returns error for nil service", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+
+		err := reg.Register(nil)
+		if err == nil {
+			t.Error("Register() with nil service should return error")
+		}
+	})
+
+	t.Run("returns error for empty name", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+		svc := &fakeProviderService{name: ""}
+
+		err := reg.Register(svc)
+		if err == nil {
+			t.Error("Register() with empty name should return error")
+		}
+	})
+
+	t.Run("returns error for duplicate registration", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+		svc1 := &fakeProviderService{name: "anthropic"}
+		svc2 := &fakeProviderService{name: "anthropic"}
+
+		if err := reg.Register(svc1); err != nil {
+			t.Fatalf("First Register() error = %v, want nil", err)
+		}
+
+		err := reg.Register(svc2)
+		if err == nil {
+			t.Error("Register() duplicate should return error")
+		}
+	})
+}
+
+func TestRegistry_Get(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retrieves registered provider service", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+		svc := &fakeProviderService{name: "anthropic"}
+
+		if err := reg.Register(svc); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+
+		retrieved, err := reg.Get("anthropic")
+		if err != nil {
+			t.Errorf("Get() error = %v, want nil", err)
+		}
+
+		if retrieved == nil {
+			t.Fatal("Get() returned nil provider service")
+		}
+
+		if retrieved.Name() != "anthropic" {
+			t.Errorf("Get() returned service with name %q, want %q", retrieved.Name(), "anthropic")
+		}
+	})
+
+	t.Run("returns ErrProviderServiceNotFound for unregistered service", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+
+		_, err := reg.Get("nonexistent")
+		if err == nil {
+			t.Error("Get() for nonexistent service should return error")
+		}
+
+		if !errors.Is(err, ErrProviderServiceNotFound) {
+			t.Errorf("Get() error = %v, want ErrProviderServiceNotFound", err)
+		}
+	})
+}
+
+func TestRegistry_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty list for new registry", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+		names := reg.List()
+
+		if len(names) != 0 {
+			t.Errorf("List() returned %d names, want 0", len(names))
+		}
+	})
+
+	t.Run("returns all registered provider service names", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+
+		services := []string{"anthropic", "vertexai"}
+		for _, name := range services {
+			if err := reg.Register(&fakeProviderService{name: name}); err != nil {
+				t.Fatalf("Register(%q) error = %v", name, err)
+			}
+		}
+
+		names := reg.List()
+		if len(names) != len(services) {
+			t.Errorf("List() returned %d names, want %d", len(names), len(services))
+		}
+
+		nameMap := make(map[string]bool)
+		for _, name := range names {
+			nameMap[name] = true
+		}
+
+		for _, expected := range services {
+			if !nameMap[expected] {
+				t.Errorf("List() missing expected service %q", expected)
+			}
+		}
+	})
+}
+
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	if err := reg.Register(&fakeProviderService{name: "anthropic"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, _ = reg.Get("anthropic")
+			_ = reg.List()
+			done <- true
+		}()
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}

--- a/pkg/providerservice/registry_test.go
+++ b/pkg/providerservice/registry_test.go
@@ -184,6 +184,26 @@ func TestRegistry_List(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("returns names in sorted order", func(t *testing.T) {
+		t.Parallel()
+
+		reg := NewRegistry()
+
+		for _, name := range []string{"zebra", "alpha", "mango"} {
+			if err := reg.Register(&fakeProviderService{name: name}); err != nil {
+				t.Fatalf("Register(%q) error = %v", name, err)
+			}
+		}
+
+		names := reg.List()
+		expected := []string{"alpha", "mango", "zebra"}
+		for i, want := range expected {
+			if names[i] != want {
+				t.Errorf("names[%d] = %q, want %q", i, names[i], want)
+			}
+		}
+	})
 }
 
 func TestRegistry_ConcurrentAccess(t *testing.T) {

--- a/pkg/providerservicesetup/providerservices.json
+++ b/pkg/providerservicesetup/providerservices.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "anthropic",
+    "description": "Anthropic Claude AI models",
+    "params": [
+      {"name": "token", "description": "API token", "required": true,  "kind": "secret", "secret_type": "anthropic"},
+      {"name": "url",   "description": "Custom base URL", "required": false, "kind": "url"}
+    ]
+  },
+  {
+    "name": "vertexai",
+    "description": "Google Cloud Vertex AI",
+    "params": [
+      {"name": "project",     "description": "GCP project ID",           "required": true,  "kind": "text"},
+      {"name": "region",      "description": "GCP region",               "required": true,  "kind": "text"},
+      {"name": "credentials", "description": "Path to credentials file", "required": false, "kind": "credential"}
+    ]
+  }
+]

--- a/pkg/providerservicesetup/register.go
+++ b/pkg/providerservicesetup/register.go
@@ -60,18 +60,46 @@ var availableProviderServices = mustLoadProviderServices()
 // mustLoadProviderServices loads provider service definitions from the embedded JSON and returns
 // factory functions for each. It panics on error since embedded data corruption is a build defect.
 func mustLoadProviderServices() []providerServiceFactory {
-	factories, err := loadProviderServices()
+	factories, err := loadProviderServices(providerServicesJSON)
 	if err != nil {
 		panic(fmt.Sprintf("failed to load embedded provider services: %v", err))
 	}
 	return factories
 }
 
-// loadProviderServices parses the embedded JSON and returns a factory function for each definition.
-func loadProviderServices() ([]providerServiceFactory, error) {
+// validProviderParamKinds is the set of accepted ProviderParamKind values.
+var validProviderParamKinds = map[providerservice.ProviderParamKind]bool{
+	providerservice.ProviderParamKindSecret:     true,
+	providerservice.ProviderParamKindCredential: true,
+	providerservice.ProviderParamKindURL:        true,
+	providerservice.ProviderParamKindText:       true,
+}
+
+// loadProviderServices parses the given JSON bytes and returns a factory function for each definition.
+func loadProviderServices(data []byte) ([]providerServiceFactory, error) {
 	var definitions []providerServiceDefinition
-	if err := json.Unmarshal(providerServicesJSON, &definitions); err != nil {
+	if err := json.Unmarshal(data, &definitions); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal provider services JSON: %w", err)
+	}
+
+	for _, def := range definitions {
+		if def.Name == "" {
+			return nil, fmt.Errorf("provider service definition has empty name")
+		}
+		for _, p := range def.Params {
+			if p.Name == "" {
+				return nil, fmt.Errorf("provider %q: param has empty name", def.Name)
+			}
+			if !validProviderParamKinds[p.Kind] {
+				return nil, fmt.Errorf("provider %q: param %q has invalid kind %q", def.Name, p.Name, p.Kind)
+			}
+			if p.Kind == providerservice.ProviderParamKindSecret && p.SecretType == "" {
+				return nil, fmt.Errorf("provider %q: secret param %q must have a non-empty secret_type", def.Name, p.Name)
+			}
+			if p.Kind != providerservice.ProviderParamKindSecret && p.SecretType != "" {
+				return nil, fmt.Errorf("provider %q: non-secret param %q must not have a secret_type", def.Name, p.Name)
+			}
+		}
 	}
 
 	factories := make([]providerServiceFactory, 0, len(definitions))
@@ -98,6 +126,9 @@ func loadProviderServices() ([]providerServiceFactory, error) {
 // RegisterAll registers all available provider service implementations to the given registrar.
 // Returns an error if any provider service fails to register.
 func RegisterAll(registrar ProviderServiceRegistrar) error {
+	if registrar == nil {
+		return fmt.Errorf("provider service registrar cannot be nil")
+	}
 	return registerAllWithFactories(registrar, availableProviderServices)
 }
 
@@ -132,6 +163,9 @@ func listAvailableWithFactories(factories []providerServiceFactory) []string {
 
 // registerAllWithFactories registers provider services from the given factories to the registrar.
 func registerAllWithFactories(registrar ProviderServiceRegistrar, factories []providerServiceFactory) error {
+	if registrar == nil {
+		return fmt.Errorf("provider service registrar cannot be nil")
+	}
 	for _, factory := range factories {
 		svc := factory()
 		if svc == nil {

--- a/pkg/providerservicesetup/register.go
+++ b/pkg/providerservicesetup/register.go
@@ -1,0 +1,145 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package providerservicesetup provides centralized registration of all available provider service implementations.
+package providerservicesetup
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openkaiden/kdn/pkg/providerservice"
+)
+
+// ProviderServiceRegistrar is an interface for types that can register provider services.
+type ProviderServiceRegistrar interface {
+	RegisterProviderService(service providerservice.ProviderService) error
+}
+
+// providerServiceFactory is a function that creates a new provider service instance.
+type providerServiceFactory func() providerservice.ProviderService
+
+//go:embed providerservices.json
+var providerServicesJSON []byte
+
+// providerParamDefinition represents a parameter entry in the embedded JSON file.
+type providerParamDefinition struct {
+	Name        string                            `json:"name"`
+	Description string                            `json:"description"`
+	Required    bool                              `json:"required"`
+	Kind        providerservice.ProviderParamKind `json:"kind"`
+	SecretType  string                            `json:"secret_type"`
+}
+
+// providerServiceDefinition represents a provider service entry in the embedded JSON file.
+type providerServiceDefinition struct {
+	Name        string                    `json:"name"`
+	Description string                    `json:"description"`
+	Params      []providerParamDefinition `json:"params"`
+}
+
+// availableProviderServices is the list of all provider services loaded from the embedded JSON file.
+var availableProviderServices = mustLoadProviderServices()
+
+// mustLoadProviderServices loads provider service definitions from the embedded JSON and returns
+// factory functions for each. It panics on error since embedded data corruption is a build defect.
+func mustLoadProviderServices() []providerServiceFactory {
+	factories, err := loadProviderServices()
+	if err != nil {
+		panic(fmt.Sprintf("failed to load embedded provider services: %v", err))
+	}
+	return factories
+}
+
+// loadProviderServices parses the embedded JSON and returns a factory function for each definition.
+func loadProviderServices() ([]providerServiceFactory, error) {
+	var definitions []providerServiceDefinition
+	if err := json.Unmarshal(providerServicesJSON, &definitions); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal provider services JSON: %w", err)
+	}
+
+	factories := make([]providerServiceFactory, 0, len(definitions))
+	for _, def := range definitions {
+		d := def // capture loop variable
+		factories = append(factories, func() providerservice.ProviderService {
+			params := make([]providerservice.ProviderParam, 0, len(d.Params))
+			for _, p := range d.Params {
+				params = append(params, providerservice.ProviderParam{
+					Name:        p.Name,
+					Description: p.Description,
+					Required:    p.Required,
+					Kind:        p.Kind,
+					SecretType:  p.SecretType,
+				})
+			}
+			return providerservice.NewProviderService(d.Name, d.Description, params)
+		})
+	}
+
+	return factories, nil
+}
+
+// RegisterAll registers all available provider service implementations to the given registrar.
+// Returns an error if any provider service fails to register.
+func RegisterAll(registrar ProviderServiceRegistrar) error {
+	return registerAllWithFactories(registrar, availableProviderServices)
+}
+
+// ListAvailable returns the names of all available provider services.
+func ListAvailable() []string {
+	return listAvailableWithFactories(availableProviderServices)
+}
+
+// ListServices returns fully-constructed instances of all available provider services.
+func ListServices() []providerservice.ProviderService {
+	return listServicesWithFactories(availableProviderServices)
+}
+
+// listServicesWithFactories returns fully-constructed provider services from the given factories.
+func listServicesWithFactories(factories []providerServiceFactory) []providerservice.ProviderService {
+	services := make([]providerservice.ProviderService, 0, len(factories))
+	for _, factory := range factories {
+		services = append(services, factory())
+	}
+	return services
+}
+
+// listAvailableWithFactories returns the names of provider services from the given factories.
+func listAvailableWithFactories(factories []providerServiceFactory) []string {
+	names := make([]string, 0, len(factories))
+	for _, factory := range factories {
+		svc := factory()
+		names = append(names, svc.Name())
+	}
+	return names
+}
+
+// registerAllWithFactories registers provider services from the given factories to the registrar.
+func registerAllWithFactories(registrar ProviderServiceRegistrar, factories []providerServiceFactory) error {
+	for _, factory := range factories {
+		svc := factory()
+		if svc == nil {
+			return fmt.Errorf("provider service factory returned nil")
+		}
+		if err := registrar.RegisterProviderService(svc); err != nil {
+			return fmt.Errorf("failed to register provider service %q: %w", svc.Name(), err)
+		}
+	}
+	return nil
+}

--- a/pkg/providerservicesetup/register_test.go
+++ b/pkg/providerservicesetup/register_test.go
@@ -1,0 +1,251 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package providerservicesetup
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openkaiden/kdn/pkg/providerservice"
+)
+
+// fakeRegistrar implements ProviderServiceRegistrar for testing.
+type fakeRegistrar struct {
+	registered map[string]providerservice.ProviderService
+	failOn     string
+}
+
+func newFakeRegistrar() *fakeRegistrar {
+	return &fakeRegistrar{
+		registered: make(map[string]providerservice.ProviderService),
+	}
+}
+
+func (f *fakeRegistrar) RegisterProviderService(service providerservice.ProviderService) error {
+	if service.Name() == f.failOn {
+		return errors.New("registration failed")
+	}
+	f.registered[service.Name()] = service
+	return nil
+}
+
+func TestRegisterAll(t *testing.T) {
+	t.Parallel()
+
+	registrar := newFakeRegistrar()
+
+	if err := RegisterAll(registrar); err != nil {
+		t.Fatalf("RegisterAll() error = %v, want nil", err)
+	}
+
+	if len(registrar.registered) != 2 {
+		t.Errorf("registered %d provider services, want 2", len(registrar.registered))
+	}
+	if _, exists := registrar.registered["anthropic"]; !exists {
+		t.Error("anthropic provider service was not registered")
+	}
+	if _, exists := registrar.registered["vertexai"]; !exists {
+		t.Error("vertexai provider service was not registered")
+	}
+}
+
+func TestListAvailable(t *testing.T) {
+	t.Parallel()
+
+	names := ListAvailable()
+
+	if len(names) != 2 {
+		t.Fatalf("ListAvailable() returned %d names, want 2", len(names))
+	}
+	// Order matches providerservices.json: anthropic, vertexai.
+	expected := []string{"anthropic", "vertexai"}
+	for i, want := range expected {
+		if names[i] != want {
+			t.Errorf("names[%d] = %q, want %q", i, names[i], want)
+		}
+	}
+}
+
+func TestListServices(t *testing.T) {
+	t.Parallel()
+
+	services := ListServices()
+
+	if len(services) != 2 {
+		t.Fatalf("ListServices() returned %d services, want 2", len(services))
+	}
+	for i, svc := range services {
+		if svc == nil {
+			t.Errorf("services[%d] is nil", i)
+			continue
+		}
+		if svc.Name() == "" {
+			t.Errorf("services[%d].Name() is empty", i)
+		}
+		if len(svc.Params()) == 0 {
+			t.Errorf("services[%d] (%s) has no params", i, svc.Name())
+		}
+	}
+	if services[0].Name() != "anthropic" {
+		t.Errorf("services[0].Name() = %q, want %q", services[0].Name(), "anthropic")
+	}
+}
+
+func TestLoadProviderServices(t *testing.T) {
+	t.Parallel()
+
+	factories, err := loadProviderServices()
+	if err != nil {
+		t.Fatalf("loadProviderServices() error = %v", err)
+	}
+	if len(factories) != 2 {
+		t.Fatalf("loadProviderServices() returned %d factories, want 2", len(factories))
+	}
+
+	svc := factories[0]()
+	if svc == nil {
+		t.Fatal("factory returned nil")
+	}
+	if svc.Name() != "anthropic" {
+		t.Errorf("Name() = %q, want %q", svc.Name(), "anthropic")
+	}
+}
+
+func TestAnthropicProviderService(t *testing.T) {
+	t.Parallel()
+
+	services := ListServices()
+	if len(services) == 0 {
+		t.Fatal("no services returned")
+	}
+
+	svc := services[0]
+	if svc.Name() != "anthropic" {
+		t.Fatalf("expected anthropic service first, got %q", svc.Name())
+	}
+	if svc.Description() == "" {
+		t.Error("Description() should not be empty")
+	}
+
+	params := svc.Params()
+	if len(params) != 2 {
+		t.Fatalf("Params() returned %d params, want 2", len(params))
+	}
+
+	token := params[0]
+	if token.Name != "token" {
+		t.Errorf("params[0].Name = %q, want %q", token.Name, "token")
+	}
+	if token.Kind != providerservice.ProviderParamKindSecret {
+		t.Errorf("params[0].Kind = %q, want %q", token.Kind, providerservice.ProviderParamKindSecret)
+	}
+	if !token.Required {
+		t.Error("params[0].Required = false, want true")
+	}
+	if token.SecretType != "anthropic" {
+		t.Errorf("params[0].SecretType = %q, want %q", token.SecretType, "anthropic")
+	}
+
+	url := params[1]
+	if url.Name != "url" {
+		t.Errorf("params[1].Name = %q, want %q", url.Name, "url")
+	}
+	if url.Kind != providerservice.ProviderParamKindURL {
+		t.Errorf("params[1].Kind = %q, want %q", url.Kind, providerservice.ProviderParamKindURL)
+	}
+	if url.Required {
+		t.Error("params[1].Required = true, want false")
+	}
+}
+
+func TestVertexAIProviderService(t *testing.T) {
+	t.Parallel()
+
+	services := ListServices()
+	if len(services) < 2 {
+		t.Fatal("expected at least 2 services")
+	}
+
+	svc := services[1]
+	if svc.Name() != "vertexai" {
+		t.Fatalf("expected vertexai service second, got %q", svc.Name())
+	}
+	if svc.Description() == "" {
+		t.Error("Description() should not be empty")
+	}
+
+	params := svc.Params()
+	if len(params) != 3 {
+		t.Fatalf("Params() returned %d params, want 3", len(params))
+	}
+
+	project := params[0]
+	if project.Name != "project" || project.Kind != providerservice.ProviderParamKindText || !project.Required {
+		t.Errorf("params[0] = %+v, unexpected", project)
+	}
+
+	region := params[1]
+	if region.Name != "region" || region.Kind != providerservice.ProviderParamKindText || !region.Required {
+		t.Errorf("params[1] = %+v, unexpected", region)
+	}
+
+	creds := params[2]
+	if creds.Name != "credentials" || creds.Kind != providerservice.ProviderParamKindCredential || creds.Required {
+		t.Errorf("params[2] = %+v, unexpected", creds)
+	}
+}
+
+func TestRegisterAllWithFactories_StopsOnError(t *testing.T) {
+	t.Parallel()
+
+	registrar := newFakeRegistrar()
+	registrar.failOn = "anthropic"
+
+	factories := []providerServiceFactory{
+		func() providerservice.ProviderService {
+			return providerservice.NewProviderService("anthropic", "test", nil)
+		},
+	}
+
+	err := registerAllWithFactories(registrar, factories)
+	if err == nil {
+		t.Error("registerAllWithFactories() should return error when registration fails")
+	}
+}
+
+func TestListAvailableWithFactories(t *testing.T) {
+	t.Parallel()
+
+	factories := []providerServiceFactory{
+		func() providerservice.ProviderService { return providerservice.NewProviderService("alpha", "", nil) },
+		func() providerservice.ProviderService { return providerservice.NewProviderService("beta", "", nil) },
+	}
+
+	names := listAvailableWithFactories(factories)
+
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d", len(names))
+	}
+	if names[0] != "alpha" {
+		t.Errorf("names[0] = %q, want %q", names[0], "alpha")
+	}
+	if names[1] != "beta" {
+		t.Errorf("names[1] = %q, want %q", names[1], "beta")
+	}
+}

--- a/pkg/providerservicesetup/register_test.go
+++ b/pkg/providerservicesetup/register_test.go
@@ -110,7 +110,7 @@ func TestListServices(t *testing.T) {
 func TestLoadProviderServices(t *testing.T) {
 	t.Parallel()
 
-	factories, err := loadProviderServices()
+	factories, err := loadProviderServices(providerServicesJSON)
 	if err != nil {
 		t.Fatalf("loadProviderServices() error = %v", err)
 	}
@@ -226,6 +226,60 @@ func TestRegisterAllWithFactories_StopsOnError(t *testing.T) {
 	err := registerAllWithFactories(registrar, factories)
 	if err == nil {
 		t.Error("registerAllWithFactories() should return error when registration fails")
+	}
+}
+
+func TestRegisterAll_NilRegistrar(t *testing.T) {
+	t.Parallel()
+
+	err := RegisterAll(nil)
+	if err == nil {
+		t.Error("RegisterAll(nil) should return error")
+	}
+}
+
+func TestRegisterAllWithFactories_NilRegistrar(t *testing.T) {
+	t.Parallel()
+
+	err := registerAllWithFactories(nil, nil)
+	if err == nil {
+		t.Error("registerAllWithFactories(nil, ...) should return error")
+	}
+}
+
+func TestLoadProviderServices_ValidatesEmptyName(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadProviderServices([]byte(`[{"name":"","description":"test","params":[]}]`))
+	if err == nil {
+		t.Error("loadProviderServices() should return error for empty provider name")
+	}
+}
+
+func TestLoadProviderServices_ValidatesParamKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadProviderServices([]byte(`[{"name":"test","params":[{"name":"p","kind":"invalid"}]}]`))
+	if err == nil {
+		t.Error("loadProviderServices() should return error for invalid param kind")
+	}
+}
+
+func TestLoadProviderServices_ValidatesSecretParamHasSecretType(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadProviderServices([]byte(`[{"name":"test","params":[{"name":"token","kind":"secret","secret_type":""}]}]`))
+	if err == nil {
+		t.Error("loadProviderServices() should return error when secret param has no secret_type")
+	}
+}
+
+func TestLoadProviderServices_ValidatesNonSecretParamHasNoSecretType(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadProviderServices([]byte(`[{"name":"test","params":[{"name":"url","kind":"url","secret_type":"something"}]}]`))
+	if err == nil {
+		t.Error("loadProviderServices() should return error when non-secret param has secret_type")
 	}
 }
 


### PR DESCRIPTION
Introduces kdn provider create/list/remove commands backed by a new provider store and providerservice abstraction. Providers are typed LLM connections (e.g. anthropic, vertexai) whose secret-kind params are stored in the shared secret store under a namespaced key ("<provider>/<param>"), so they appear in kdn secret list with the correct type and description. The provider create Long description is built dynamically from registered services, with types and params in alphabetical order. Shell completion is wired for provider names and credential file paths.

Supported providers supported in this PR:
- Anthropic (token + optional URL)
- VertexAI

Fixes #537 