### PR TITLE
fix: pin @onecli-sh/sdk to avoid breaking change

### DIFF
--- a/pkg/runtime/podman/pods/approval-handler-package.json
+++ b/pkg/runtime/podman/pods/approval-handler-package.json
@@ -2,7 +2,7 @@
   "name": "approval-handler",
   "private": true,
   "dependencies": {
-    "@onecli-sh/sdk": "latest",
+    "@onecli-sh/sdk": "1.0.0",
     "tsx": "latest"
   }
 }


### PR DESCRIPTION
onecli 1.28 and @onecli-sh 2.0.0 introduced a breaking change by changing the url prefix (/api -> /v1: https://github.com/onecli/onecli/commit/154d6b05e0354d49c625fbf153a4d5c06773e75a)

Using @onecli-sh 2.0.0 with onecli < 1.28 does not work due to this change.
